### PR TITLE
feat(epic-2): profile edit page + accumulated Epic 2 work

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -225,6 +225,19 @@ Every judgment must be preceded by at least one screenshot. Never judge a criter
 
 ---
 
+## Workflow
+
+This is a solo project. The following superpowers skills are **disabled** here — do not invoke them:
+
+- `superpowers:requesting-code-review` / `superpowers:receiving-code-review` — no human reviewer on this project. For self-review, use the `simplify` skill instead.
+- `superpowers:using-git-worktrees` — local Supabase runs a single DB instance and `pnpm dev` binds one port; parallel worktrees cause collisions, not speed.
+- `superpowers:dispatching-parallel-agents` — agents, types, and migrations in this repo share files, so parallel execution creates merge overhead instead of savings. `Explore` and `Plan` subagents (read-only research) are still fine.
+- `superpowers:executing-plans` strict checkpoint flow — the solo developer is the decision-maker; execute plans directly without per-step approval gates. Still read the plan file and follow it; just skip the checkpoint pauses.
+
+Still actively used: `brainstorming`, `writing-plans`, `test-driven-development`, `systematic-debugging`, `verification-before-completion`, `simplify`.
+
+---
+
 ## Environment Setup
 
 1. Copy `.env.example` to `.env.local` — never commit `.env.local`

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -176,7 +176,7 @@ This applies to: Google Maps, NewsAPI, SerpAPI.
 
 ### Database
 - All migrations in `supabase/migrations/` with sequential numbering
-- Never edit a migration after it has been applied to any environment — create a new one
+- Migrations may be edited freely during local development — re-run `supabase db reset` to re-apply
 - Use `supabase.rpc()` for pgvector queries
 - RLS is always on — test policies after creating new tables
 
@@ -220,7 +220,6 @@ Every judgment must be preceded by at least one screenshot. Never judge a criter
 - **DO NOT** create a `clinics` table in the database for v1 — clinic data comes from Google Places API
 - **DO NOT** use ESLint or Prettier — Biome is the sole linter/formatter
 - **DO NOT** add fonts other than Camera Plain Variable (with `ui-sans-serif, system-ui` fallback) — no Google Fonts
-- **DO NOT** amend migrations that have already been applied — create a new migration instead
 - **DO NOT** use font weight 700 (bold) — maximum weight in the design system is 600
 - **DO NOT** add MCP server infrastructure in v1 — agent tools are inlined into Next.js API routes
 

--- a/app/(app)/chat/page.tsx
+++ b/app/(app)/chat/page.tsx
@@ -1,0 +1,13 @@
+import { SignOutButton } from "./sign-out-button";
+
+export default function ChatPage() {
+  return (
+    <main className="min-h-screen bg-cream p-8">
+      <h1 className="text-2xl font-semibold text-charcoal">Chat</h1>
+      <p className="mt-2 text-muted-gray">Coming soon.</p>
+      <div className="mt-8">
+        <SignOutButton />
+      </div>
+    </main>
+  );
+}

--- a/app/(app)/chat/sign-out-button.tsx
+++ b/app/(app)/chat/sign-out-button.tsx
@@ -1,0 +1,24 @@
+"use client";
+
+import { createClient } from "@/lib/supabase/browser";
+import { useRouter } from "next/navigation";
+
+export function SignOutButton() {
+  const router = useRouter();
+
+  async function handleSignOut() {
+    const supabase = createClient();
+    await supabase.auth.signOut();
+    router.push("/login");
+  }
+
+  return (
+    <button
+      type="button"
+      onClick={handleSignOut}
+      className="text-[13px] text-muted-gray underline underline-offset-4"
+    >
+      Sign out
+    </button>
+  );
+}

--- a/app/(app)/layout.tsx
+++ b/app/(app)/layout.tsx
@@ -1,0 +1,7 @@
+export default function AppLayout({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  return <>{children}</>;
+}

--- a/app/(app)/profile/page.tsx
+++ b/app/(app)/profile/page.tsx
@@ -1,6 +1,5 @@
 // app/(app)/profile/page.tsx
 import { createClient } from "@/lib/supabase/server";
-import type { Locale } from "@/lib/validations/profile";
 import { PasswordForm } from "./password-form";
 import { ProfileInfoForm } from "./profile-info-form";
 
@@ -19,13 +18,11 @@ export default async function ProfilePage() {
 
   const { data: profile } = await supabase
     .from("profiles")
-    .select("display_name, locale")
+    .select("display_name")
     .eq("id", user.id)
     .single();
 
   const initialDisplayName = profile?.display_name ?? "";
-  const initialLocale: Locale =
-    profile?.locale === "zh" || profile?.locale === "en" ? profile.locale : "en";
 
   return (
     <main className="min-h-screen bg-cream px-6 py-10">
@@ -39,11 +36,7 @@ export default async function ProfilePage() {
           </h1>
         </header>
 
-        <ProfileInfoForm
-          email={user.email ?? ""}
-          initialDisplayName={initialDisplayName}
-          initialLocale={initialLocale}
-        />
+        <ProfileInfoForm email={user.email ?? ""} initialDisplayName={initialDisplayName} />
 
         <PasswordForm />
       </div>

--- a/app/(app)/profile/page.tsx
+++ b/app/(app)/profile/page.tsx
@@ -1,0 +1,52 @@
+// app/(app)/profile/page.tsx
+import { createClient } from "@/lib/supabase/server";
+import type { Locale } from "@/lib/validations/profile";
+import { PasswordForm } from "./password-form";
+import { ProfileInfoForm } from "./profile-info-form";
+
+export default async function ProfilePage() {
+  const supabase = createClient();
+
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+
+  // Middleware guarantees an authenticated user before this page renders,
+  // so `user` is always present. Narrow for TS and bail defensively.
+  if (!user) {
+    return null;
+  }
+
+  const { data: profile } = await supabase
+    .from("profiles")
+    .select("display_name, locale")
+    .eq("id", user.id)
+    .single();
+
+  const initialDisplayName = profile?.display_name ?? "";
+  const initialLocale: Locale =
+    profile?.locale === "zh" || profile?.locale === "en" ? profile.locale : "en";
+
+  return (
+    <main className="min-h-screen bg-cream px-6 py-10">
+      <div className="mx-auto max-w-xl space-y-8">
+        <header>
+          <p className="text-[11px] uppercase tracking-[0.08em] text-muted-gray mb-3">
+            Cervix Health
+          </p>
+          <h1 className="text-[28px] font-semibold text-charcoal tracking-[-0.5px]">
+            Profile settings
+          </h1>
+        </header>
+
+        <ProfileInfoForm
+          email={user.email ?? ""}
+          initialDisplayName={initialDisplayName}
+          initialLocale={initialLocale}
+        />
+
+        <PasswordForm />
+      </div>
+    </main>
+  );
+}

--- a/app/(app)/profile/password-form.tsx
+++ b/app/(app)/profile/password-form.tsx
@@ -15,33 +15,27 @@ import { PasswordInput } from "@/components/ui/password-input";
 import { createClient } from "@/lib/supabase/browser";
 import { type PasswordFormValues, passwordSchema } from "@/lib/validations/profile";
 import { zodResolver } from "@hookform/resolvers/zod";
-import { useState } from "react";
 import { useForm } from "react-hook-form";
+import { toast } from "sonner";
 
 export function PasswordForm() {
-  const [serverError, setServerError] = useState<string | null>(null);
-  const [successMessage, setSuccessMessage] = useState<string | null>(null);
-
   const form = useForm<PasswordFormValues>({
     resolver: zodResolver(passwordSchema),
     defaultValues: { password: "", confirmPassword: "" },
   });
 
   async function onSubmit(values: PasswordFormValues) {
-    setServerError(null);
-    setSuccessMessage(null);
-
     const supabase = createClient();
     const { error } = await supabase.auth.updateUser({
       password: values.password,
     });
 
     if (error) {
-      setServerError(error.message);
+      toast.error(error.message);
       return;
     }
 
-    setSuccessMessage("Password updated");
+    toast.success("Password updated");
     form.reset();
   }
 
@@ -50,20 +44,6 @@ export function PasswordForm() {
   return (
     <section className="rounded-card border border-border bg-cream p-6">
       <h2 className="text-lg font-semibold text-charcoal mb-4">Change password</h2>
-
-      {successMessage && (
-        <output className="block mb-4 rounded-standard border border-green-300/30 bg-green-50/50 px-3 py-2.5 text-sm text-green-700">
-          {successMessage}
-        </output>
-      )}
-      {serverError && (
-        <div
-          role="alert"
-          className="mb-4 rounded-standard border border-destructive/30 bg-destructive/5 px-3 py-2.5 text-sm text-destructive"
-        >
-          {serverError}
-        </div>
-      )}
 
       <Form {...form}>
         <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-4">

--- a/app/(app)/profile/password-form.tsx
+++ b/app/(app)/profile/password-form.tsx
@@ -11,6 +11,7 @@ import {
   FormMessage,
 } from "@/components/ui/form";
 import { Input } from "@/components/ui/input";
+import { PasswordInput } from "@/components/ui/password-input";
 import { createClient } from "@/lib/supabase/browser";
 import { type PasswordFormValues, passwordSchema } from "@/lib/validations/profile";
 import { zodResolver } from "@hookform/resolvers/zod";
@@ -73,8 +74,7 @@ export function PasswordForm() {
               <FormItem>
                 <FormLabel>New password</FormLabel>
                 <FormControl>
-                  <Input
-                    type="password"
+                  <PasswordInput
                     autoComplete="new-password"
                     placeholder="Min. 8 characters"
                     {...field}
@@ -91,8 +91,7 @@ export function PasswordForm() {
               <FormItem>
                 <FormLabel>Confirm new password</FormLabel>
                 <FormControl>
-                  <Input
-                    type="password"
+                  <PasswordInput
                     autoComplete="new-password"
                     placeholder="Re-enter your new password"
                     {...field}

--- a/app/(app)/profile/password-form.tsx
+++ b/app/(app)/profile/password-form.tsx
@@ -1,0 +1,112 @@
+// app/(app)/profile/password-form.tsx
+"use client";
+
+import { Button } from "@/components/ui/button";
+import {
+  Form,
+  FormControl,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage,
+} from "@/components/ui/form";
+import { Input } from "@/components/ui/input";
+import { createClient } from "@/lib/supabase/browser";
+import { type PasswordFormValues, passwordSchema } from "@/lib/validations/profile";
+import { zodResolver } from "@hookform/resolvers/zod";
+import { useState } from "react";
+import { useForm } from "react-hook-form";
+
+export function PasswordForm() {
+  const [serverError, setServerError] = useState<string | null>(null);
+  const [successMessage, setSuccessMessage] = useState<string | null>(null);
+
+  const form = useForm<PasswordFormValues>({
+    resolver: zodResolver(passwordSchema),
+    defaultValues: { password: "", confirmPassword: "" },
+  });
+
+  async function onSubmit(values: PasswordFormValues) {
+    setServerError(null);
+    setSuccessMessage(null);
+
+    const supabase = createClient();
+    const { error } = await supabase.auth.updateUser({
+      password: values.password,
+    });
+
+    if (error) {
+      setServerError(error.message);
+      return;
+    }
+
+    setSuccessMessage("Password updated");
+    form.reset();
+  }
+
+  const { isSubmitting } = form.formState;
+
+  return (
+    <section className="rounded-card border border-border bg-cream p-6">
+      <h2 className="text-lg font-semibold text-charcoal mb-4">Change password</h2>
+
+      {successMessage && (
+        <output className="block mb-4 rounded-standard border border-green-300/30 bg-green-50/50 px-3 py-2.5 text-sm text-green-700">
+          {successMessage}
+        </output>
+      )}
+      {serverError && (
+        <div
+          role="alert"
+          className="mb-4 rounded-standard border border-destructive/30 bg-destructive/5 px-3 py-2.5 text-sm text-destructive"
+        >
+          {serverError}
+        </div>
+      )}
+
+      <Form {...form}>
+        <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-4">
+          <FormField
+            control={form.control}
+            name="password"
+            render={({ field }) => (
+              <FormItem>
+                <FormLabel>New password</FormLabel>
+                <FormControl>
+                  <Input
+                    type="password"
+                    autoComplete="new-password"
+                    placeholder="Min. 8 characters"
+                    {...field}
+                  />
+                </FormControl>
+                <FormMessage />
+              </FormItem>
+            )}
+          />
+          <FormField
+            control={form.control}
+            name="confirmPassword"
+            render={({ field }) => (
+              <FormItem>
+                <FormLabel>Confirm new password</FormLabel>
+                <FormControl>
+                  <Input
+                    type="password"
+                    autoComplete="new-password"
+                    placeholder="Re-enter your new password"
+                    {...field}
+                  />
+                </FormControl>
+                <FormMessage />
+              </FormItem>
+            )}
+          />
+          <Button type="submit" variant="default" className="mt-2" disabled={isSubmitting}>
+            {isSubmitting ? "Updating..." : "Update password"}
+          </Button>
+        </form>
+      </Form>
+    </section>
+  );
+}

--- a/app/(app)/profile/profile-info-form.tsx
+++ b/app/(app)/profile/profile-info-form.tsx
@@ -1,0 +1,175 @@
+// app/(app)/profile/profile-info-form.tsx
+"use client";
+
+import { Button } from "@/components/ui/button";
+import {
+  Form,
+  FormControl,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage,
+} from "@/components/ui/form";
+import { Input } from "@/components/ui/input";
+import { createClient } from "@/lib/supabase/browser";
+import { cn } from "@/lib/utils";
+import {
+  LOCALES,
+  type Locale,
+  type ProfileInfoFormValues,
+  profileInfoSchema,
+} from "@/lib/validations/profile";
+import { zodResolver } from "@hookform/resolvers/zod";
+import { useRouter } from "next/navigation";
+import { useState } from "react";
+import { useForm } from "react-hook-form";
+
+type Props = {
+  email: string;
+  initialDisplayName: string;
+  initialLocale: Locale;
+};
+
+// Native-script label for each locale. Written via \u escapes to keep
+// this source file ASCII-clean (project crashacter policy).
+const LOCALE_LABEL: Record<Locale, string> = {
+  en: "English",
+  zh: "\u4e2d\u6587",
+};
+
+export function ProfileInfoForm({ email, initialDisplayName, initialLocale }: Props) {
+  const router = useRouter();
+  const [serverError, setServerError] = useState<string | null>(null);
+  const [successMessage, setSuccessMessage] = useState<string | null>(null);
+
+  const form = useForm<ProfileInfoFormValues>({
+    resolver: zodResolver(profileInfoSchema),
+    defaultValues: {
+      displayName: initialDisplayName,
+      locale: initialLocale,
+    },
+  });
+
+  async function onSubmit(values: ProfileInfoFormValues) {
+    setServerError(null);
+    setSuccessMessage(null);
+
+    const supabase = createClient();
+    const {
+      data: { user },
+    } = await supabase.auth.getUser();
+    if (!user) {
+      setServerError("Session expired. Please sign in again.");
+      return;
+    }
+
+    const { error } = await supabase
+      .from("profiles")
+      .update({
+        display_name: values.displayName,
+        locale: values.locale,
+      })
+      .eq("id", user.id);
+
+    if (error) {
+      setServerError(error.message);
+      return;
+    }
+
+    setSuccessMessage("Profile saved");
+    form.reset(values);
+    router.refresh();
+  }
+
+  const { isDirty, isSubmitting } = form.formState;
+
+  return (
+    <section className="rounded-card border border-border bg-cream p-6">
+      <h2 className="text-lg font-semibold text-charcoal mb-4">Profile</h2>
+
+      {successMessage && (
+        <output className="block mb-4 rounded-standard border border-green-300/30 bg-green-50/50 px-3 py-2.5 text-sm text-green-700">
+          {successMessage}
+        </output>
+      )}
+      {serverError && (
+        <div
+          role="alert"
+          className="mb-4 rounded-standard border border-destructive/30 bg-destructive/5 px-3 py-2.5 text-sm text-destructive"
+        >
+          {serverError}
+        </div>
+      )}
+
+      <div className="mb-4">
+        <p className="text-sm font-medium text-charcoal mb-1">Email</p>
+        <p className="text-sm text-muted-gray">{email}</p>
+      </div>
+
+      <Form {...form}>
+        <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-4">
+          <FormField
+            control={form.control}
+            name="displayName"
+            render={({ field }) => (
+              <FormItem>
+                <FormLabel>Display name</FormLabel>
+                <FormControl>
+                  <Input
+                    type="text"
+                    autoComplete="name"
+                    maxLength={60}
+                    placeholder="How you'd like to be addressed"
+                    {...field}
+                  />
+                </FormControl>
+                <FormMessage />
+              </FormItem>
+            )}
+          />
+
+          <FormField
+            control={form.control}
+            name="locale"
+            render={({ field }) => (
+              <FormItem>
+                <FormLabel>Language</FormLabel>
+                <FormControl>
+                  {/* fieldset is the semantic container for a button group */}
+                  <fieldset className="inline-flex rounded-standard border border-border bg-cream p-1 m-0 min-w-0">
+                    {LOCALES.map((code) => (
+                      <button
+                        key={code}
+                        type="button"
+                        aria-pressed={field.value === code}
+                        onClick={() => field.onChange(code)}
+                        className={cn(
+                          "px-4 py-1.5 text-sm rounded-standard transition-colors",
+                          field.value === code
+                            ? "bg-charcoal text-off-white"
+                            : "text-muted-gray hover:text-charcoal"
+                        )}
+                      >
+                        {LOCALE_LABEL[code]}
+                      </button>
+                    ))}
+                  </fieldset>
+                </FormControl>
+                <FormMessage />
+              </FormItem>
+            )}
+          />
+
+          <Button
+            type="submit"
+            variant="default"
+            className="mt-2"
+            disabled={!isDirty || isSubmitting}
+          >
+            {isSubmitting ? "Saving..." : "Save"}
+          </Button>
+        </form>
+      </Form>
+    </section>
+  );
+}

--- a/app/(app)/profile/profile-info-form.tsx
+++ b/app/(app)/profile/profile-info-form.tsx
@@ -12,13 +12,7 @@ import {
 } from "@/components/ui/form";
 import { Input } from "@/components/ui/input";
 import { createClient } from "@/lib/supabase/browser";
-import { cn } from "@/lib/utils";
-import {
-  LOCALES,
-  type Locale,
-  type ProfileInfoFormValues,
-  profileInfoSchema,
-} from "@/lib/validations/profile";
+import { type ProfileInfoFormValues, profileInfoSchema } from "@/lib/validations/profile";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { useRouter } from "next/navigation";
 import { useState } from "react";
@@ -27,17 +21,9 @@ import { useForm } from "react-hook-form";
 type Props = {
   email: string;
   initialDisplayName: string;
-  initialLocale: Locale;
 };
 
-// Native-script label for each locale. Written via \u escapes to keep
-// this source file ASCII-clean (project crashacter policy).
-const LOCALE_LABEL: Record<Locale, string> = {
-  en: "English",
-  zh: "\u4e2d\u6587",
-};
-
-export function ProfileInfoForm({ email, initialDisplayName, initialLocale }: Props) {
+export function ProfileInfoForm({ email, initialDisplayName }: Props) {
   const router = useRouter();
   const [serverError, setServerError] = useState<string | null>(null);
   const [successMessage, setSuccessMessage] = useState<string | null>(null);
@@ -46,7 +32,6 @@ export function ProfileInfoForm({ email, initialDisplayName, initialLocale }: Pr
     resolver: zodResolver(profileInfoSchema),
     defaultValues: {
       displayName: initialDisplayName,
-      locale: initialLocale,
     },
   });
 
@@ -65,10 +50,7 @@ export function ProfileInfoForm({ email, initialDisplayName, initialLocale }: Pr
 
     const { error } = await supabase
       .from("profiles")
-      .update({
-        display_name: values.displayName,
-        locale: values.locale,
-      })
+      .update({ display_name: values.displayName })
       .eq("id", user.id);
 
     if (error) {
@@ -122,38 +104,6 @@ export function ProfileInfoForm({ email, initialDisplayName, initialLocale }: Pr
                     placeholder="How you'd like to be addressed"
                     {...field}
                   />
-                </FormControl>
-                <FormMessage />
-              </FormItem>
-            )}
-          />
-
-          <FormField
-            control={form.control}
-            name="locale"
-            render={({ field }) => (
-              <FormItem>
-                <FormLabel>Language</FormLabel>
-                <FormControl>
-                  {/* fieldset is the semantic container for a button group */}
-                  <fieldset className="inline-flex rounded-standard border border-border bg-cream p-1 m-0 min-w-0">
-                    {LOCALES.map((code) => (
-                      <button
-                        key={code}
-                        type="button"
-                        aria-pressed={field.value === code}
-                        onClick={() => field.onChange(code)}
-                        className={cn(
-                          "px-4 py-1.5 text-sm rounded-standard transition-colors",
-                          field.value === code
-                            ? "bg-charcoal text-off-white"
-                            : "text-muted-gray hover:text-charcoal"
-                        )}
-                      >
-                        {LOCALE_LABEL[code]}
-                      </button>
-                    ))}
-                  </fieldset>
                 </FormControl>
                 <FormMessage />
               </FormItem>

--- a/app/(app)/profile/profile-info-form.tsx
+++ b/app/(app)/profile/profile-info-form.tsx
@@ -15,8 +15,9 @@ import { createClient } from "@/lib/supabase/browser";
 import { type ProfileInfoFormValues, profileInfoSchema } from "@/lib/validations/profile";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { useRouter } from "next/navigation";
-import { useState } from "react";
 import { useForm } from "react-hook-form";
+
+import { toast } from "sonner";
 
 type Props = {
   email: string;
@@ -25,8 +26,6 @@ type Props = {
 
 export function ProfileInfoForm({ email, initialDisplayName }: Props) {
   const router = useRouter();
-  const [serverError, setServerError] = useState<string | null>(null);
-  const [successMessage, setSuccessMessage] = useState<string | null>(null);
 
   const form = useForm<ProfileInfoFormValues>({
     resolver: zodResolver(profileInfoSchema),
@@ -36,15 +35,12 @@ export function ProfileInfoForm({ email, initialDisplayName }: Props) {
   });
 
   async function onSubmit(values: ProfileInfoFormValues) {
-    setServerError(null);
-    setSuccessMessage(null);
-
     const supabase = createClient();
     const {
       data: { user },
     } = await supabase.auth.getUser();
     if (!user) {
-      setServerError("Session expired. Please sign in again.");
+      toast.error("Session expired. Please sign in again.");
       return;
     }
 
@@ -54,11 +50,11 @@ export function ProfileInfoForm({ email, initialDisplayName }: Props) {
       .eq("id", user.id);
 
     if (error) {
-      setServerError(error.message);
+      toast.error(error.message);
       return;
     }
 
-    setSuccessMessage("Profile saved");
+    toast.success("Profile saved");
     form.reset(values);
     router.refresh();
   }
@@ -68,20 +64,6 @@ export function ProfileInfoForm({ email, initialDisplayName }: Props) {
   return (
     <section className="rounded-card border border-border bg-cream p-6">
       <h2 className="text-lg font-semibold text-charcoal mb-4">Profile</h2>
-
-      {successMessage && (
-        <output className="block mb-4 rounded-standard border border-green-300/30 bg-green-50/50 px-3 py-2.5 text-sm text-green-700">
-          {successMessage}
-        </output>
-      )}
-      {serverError && (
-        <div
-          role="alert"
-          className="mb-4 rounded-standard border border-destructive/30 bg-destructive/5 px-3 py-2.5 text-sm text-destructive"
-        >
-          {serverError}
-        </div>
-      )}
 
       <div className="mb-4">
         <p className="text-sm font-medium text-charcoal mb-1">Email</p>

--- a/app/(auth)/forgot-password/forgot-password-form.tsx
+++ b/app/(auth)/forgot-password/forgot-password-form.tsx
@@ -1,0 +1,113 @@
+// app/(auth)/forgot-password/forgot-password-form.tsx
+"use client";
+
+import { Button } from "@/components/ui/button";
+import {
+  Form,
+  FormControl,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage,
+} from "@/components/ui/form";
+import { Input } from "@/components/ui/input";
+import { createClient } from "@/lib/supabase/browser";
+import { type ForgotPasswordFormValues, forgotPasswordSchema } from "@/lib/validations/auth";
+import { zodResolver } from "@hookform/resolvers/zod";
+import Link from "next/link";
+import { useState } from "react";
+import { useForm } from "react-hook-form";
+
+export function ForgotPasswordForm() {
+  const [submitted, setSubmitted] = useState(false);
+  const [submittedEmail, setSubmittedEmail] = useState("");
+
+  const form = useForm<ForgotPasswordFormValues>({
+    resolver: zodResolver(forgotPasswordSchema),
+    defaultValues: { email: "" },
+  });
+
+  async function onSubmit(values: ForgotPasswordFormValues) {
+    const supabase = createClient();
+    await supabase.auth.resetPasswordForEmail(values.email, {
+      redirectTo: `${window.location.origin}/api/auth/callback?next=/reset-password`,
+    });
+    // Always show success regardless of whether email exists (prevents enumeration)
+    setSubmittedEmail(values.email);
+    setSubmitted(true);
+  }
+
+  if (submitted) {
+    return (
+      <div>
+        <p className="text-[11px] uppercase tracking-[0.08em] text-muted-gray mb-3">
+          Cervix Health
+        </p>
+        <h1 className="text-[28px] font-semibold text-charcoal tracking-[-0.5px] mb-1.5">
+          Check your inbox
+        </h1>
+        <p className="text-sm text-muted-gray mb-8">
+          We sent a reset link to <span className="text-charcoal">{submittedEmail}</span>
+        </p>
+        <output className="block rounded-standard border border-green-300/30 bg-green-50/50 px-3 py-2.5 text-sm text-green-700">
+          Reset link sent — check your email and follow the link to set a new password.
+        </output>
+        <p className="mt-6 text-center text-[13px] text-muted-gray">
+          <Link href="/login" className="text-charcoal underline underline-offset-2">
+            Back to login
+          </Link>
+        </p>
+      </div>
+    );
+  }
+
+  return (
+    <div>
+      <p className="text-[11px] uppercase tracking-[0.08em] text-muted-gray mb-3">Cervix Health</p>
+      <h1 className="text-[28px] font-semibold text-charcoal tracking-[-0.5px] mb-1.5">
+        Reset password
+      </h1>
+      <p className="text-sm text-muted-gray mb-8">
+        Enter your email and we&apos;ll send a reset link
+      </p>
+
+      <Form {...form}>
+        <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-4">
+          <FormField
+            control={form.control}
+            name="email"
+            render={({ field }) => (
+              <FormItem>
+                <FormLabel>Email</FormLabel>
+                <FormControl>
+                  <Input
+                    type="text"
+                    inputMode="email"
+                    autoComplete="email"
+                    placeholder="you@example.com"
+                    {...field}
+                  />
+                </FormControl>
+                <FormMessage />
+              </FormItem>
+            )}
+          />
+          <Button
+            type="submit"
+            variant="default"
+            className="w-full mt-2"
+            disabled={form.formState.isSubmitting}
+          >
+            {form.formState.isSubmitting ? "Sending..." : "Send reset link"}
+          </Button>
+        </form>
+      </Form>
+
+      <p className="mt-5 text-center text-[13px] text-muted-gray">
+        <Link href="/login" className="text-charcoal underline underline-offset-2">
+          Back to login
+        </Link>
+      </p>
+    </div>
+  );
+}

--- a/app/(auth)/forgot-password/page.tsx
+++ b/app/(auth)/forgot-password/page.tsx
@@ -1,0 +1,11 @@
+// app/(auth)/forgot-password/page.tsx
+import type { Metadata } from "next";
+import { ForgotPasswordForm } from "./forgot-password-form";
+
+export const metadata: Metadata = {
+  title: "Reset password — Cervix Health Assistant",
+};
+
+export default function ForgotPasswordPage() {
+  return <ForgotPasswordForm />;
+}

--- a/app/(auth)/layout.tsx
+++ b/app/(auth)/layout.tsx
@@ -1,8 +1,10 @@
 // app/(auth)/layout.tsx
+import type { ReactNode } from "react";
+
 export default function AuthLayout({
   children,
 }: {
-  children: React.ReactNode;
+  children: ReactNode;
 }) {
   return (
     <div className="min-h-screen bg-cream flex items-center justify-center px-4 py-16">

--- a/app/(auth)/layout.tsx
+++ b/app/(auth)/layout.tsx
@@ -1,0 +1,12 @@
+// app/(auth)/layout.tsx
+export default function AuthLayout({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  return (
+    <div className="min-h-screen bg-cream flex items-center justify-center px-4 py-16">
+      <div className="w-full max-w-[360px]">{children}</div>
+    </div>
+  );
+}

--- a/app/(auth)/login/login-form.tsx
+++ b/app/(auth)/login/login-form.tsx
@@ -1,0 +1,137 @@
+// app/(auth)/login/login-form.tsx
+"use client";
+
+import { Button } from "@/components/ui/button";
+import {
+  Form,
+  FormControl,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage,
+} from "@/components/ui/form";
+import { Input } from "@/components/ui/input";
+import { createClient } from "@/lib/supabase/browser";
+import { type LoginFormValues, loginSchema } from "@/lib/validations/auth";
+import { zodResolver } from "@hookform/resolvers/zod";
+import Link from "next/link";
+import { useRouter, useSearchParams } from "next/navigation";
+import { useState } from "react";
+import { useForm } from "react-hook-form";
+
+export function LoginForm() {
+  const router = useRouter();
+  const searchParams = useSearchParams();
+  const [serverError, setServerError] = useState<string | null>(null);
+
+  const showResetSuccess = searchParams.get("reset") === "success";
+  const showLinkExpired = searchParams.get("error") === "link-expired";
+
+  const form = useForm<LoginFormValues>({
+    resolver: zodResolver(loginSchema),
+    defaultValues: { email: "", password: "" },
+  });
+
+  async function onSubmit(values: LoginFormValues) {
+    setServerError(null);
+    const supabase = createClient();
+    const { error } = await supabase.auth.signInWithPassword(values);
+    if (error) {
+      setServerError(error.message);
+      return;
+    }
+    router.push("/chat");
+  }
+
+  return (
+    <div>
+      <p className="text-[11px] uppercase tracking-[0.08em] text-muted-gray mb-3">Cervix Health</p>
+      <h1 className="text-[28px] font-semibold text-charcoal tracking-[-0.5px] mb-1.5">
+        Welcome back
+      </h1>
+      <p className="text-sm text-muted-gray mb-8">Sign in to your account</p>
+
+      {showResetSuccess && (
+        <output className="block mb-4 rounded-standard border border-green-300/30 bg-green-50/50 px-3 py-2.5 text-sm text-green-700">
+          Password updated — sign in below
+        </output>
+      )}
+      {showLinkExpired && (
+        <div
+          role="alert"
+          className="mb-4 rounded-standard border border-destructive/30 bg-destructive/5 px-3 py-2.5 text-sm text-destructive"
+        >
+          Reset link has expired — request a new one
+        </div>
+      )}
+      {serverError && (
+        <div
+          role="alert"
+          className="mb-4 rounded-standard border border-destructive/30 bg-destructive/5 px-3 py-2.5 text-sm text-destructive"
+        >
+          {serverError}
+        </div>
+      )}
+
+      <Form {...form}>
+        <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-4">
+          <FormField
+            control={form.control}
+            name="email"
+            render={({ field }) => (
+              <FormItem>
+                <FormLabel>Email</FormLabel>
+                <FormControl>
+                  <Input
+                    type="text"
+                    inputMode="email"
+                    autoComplete="email"
+                    placeholder="you@example.com"
+                    {...field}
+                  />
+                </FormControl>
+                <FormMessage />
+              </FormItem>
+            )}
+          />
+          <FormField
+            control={form.control}
+            name="password"
+            render={({ field }) => (
+              <FormItem>
+                <div className="flex items-baseline justify-between">
+                  <FormLabel>Password</FormLabel>
+                  <Link
+                    href="/forgot-password"
+                    className="text-xs text-charcoal underline underline-offset-2"
+                  >
+                    Forgot password?
+                  </Link>
+                </div>
+                <FormControl>
+                  <Input type="password" placeholder="••••••••" {...field} />
+                </FormControl>
+                <FormMessage />
+              </FormItem>
+            )}
+          />
+          <Button
+            type="submit"
+            variant="default"
+            className="w-full mt-2"
+            disabled={form.formState.isSubmitting}
+          >
+            {form.formState.isSubmitting ? "Signing in..." : "Sign in"}
+          </Button>
+        </form>
+      </Form>
+
+      <p className="mt-5 text-center text-[13px] text-muted-gray">
+        {"Don't have an account?"}{" "}
+        <Link href="/register" className="text-charcoal underline underline-offset-2">
+          Create one
+        </Link>
+      </p>
+    </div>
+  );
+}

--- a/app/(auth)/login/login-form.tsx
+++ b/app/(auth)/login/login-form.tsx
@@ -17,16 +17,20 @@ import { type LoginFormValues, loginSchema } from "@/lib/validations/auth";
 import { zodResolver } from "@hookform/resolvers/zod";
 import Link from "next/link";
 import { useRouter, useSearchParams } from "next/navigation";
-import { useState } from "react";
+import { useEffect } from "react";
 import { useForm } from "react-hook-form";
+import { toast } from "sonner";
 
 export function LoginForm() {
   const router = useRouter();
   const searchParams = useSearchParams();
-  const [serverError, setServerError] = useState<string | null>(null);
-
-  const showResetSuccess = searchParams.get("reset") === "success";
-  const showLinkExpired = searchParams.get("error") === "link-expired";
+  useEffect(() => {
+    if (searchParams.get("reset") === "success") {
+      toast.success("Password updated — sign in below");
+    } else if (searchParams.get("error") === "link-expired") {
+      toast.error("Reset link has expired — request a new one");
+    }
+  }, [searchParams]);
 
   const form = useForm<LoginFormValues>({
     resolver: zodResolver(loginSchema),
@@ -34,11 +38,10 @@ export function LoginForm() {
   });
 
   async function onSubmit(values: LoginFormValues) {
-    setServerError(null);
     const supabase = createClient();
     const { error } = await supabase.auth.signInWithPassword(values);
     if (error) {
-      setServerError(error.message);
+      toast.error(error.message);
       return;
     }
     router.push("/chat");
@@ -51,28 +54,6 @@ export function LoginForm() {
         Welcome back
       </h1>
       <p className="text-sm text-muted-gray mb-8">Sign in to your account</p>
-
-      {showResetSuccess && (
-        <output className="block mb-4 rounded-standard border border-green-300/30 bg-green-50/50 px-3 py-2.5 text-sm text-green-700">
-          Password updated — sign in below
-        </output>
-      )}
-      {showLinkExpired && (
-        <div
-          role="alert"
-          className="mb-4 rounded-standard border border-destructive/30 bg-destructive/5 px-3 py-2.5 text-sm text-destructive"
-        >
-          Reset link has expired — request a new one
-        </div>
-      )}
-      {serverError && (
-        <div
-          role="alert"
-          className="mb-4 rounded-standard border border-destructive/30 bg-destructive/5 px-3 py-2.5 text-sm text-destructive"
-        >
-          {serverError}
-        </div>
-      )}
 
       <Form {...form}>
         <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-4">

--- a/app/(auth)/login/login-form.tsx
+++ b/app/(auth)/login/login-form.tsx
@@ -11,6 +11,7 @@ import {
   FormMessage,
 } from "@/components/ui/form";
 import { Input } from "@/components/ui/input";
+import { PasswordInput } from "@/components/ui/password-input";
 import { createClient } from "@/lib/supabase/browser";
 import { type LoginFormValues, loginSchema } from "@/lib/validations/auth";
 import { zodResolver } from "@hookform/resolvers/zod";
@@ -109,7 +110,7 @@ export function LoginForm() {
                   </Link>
                 </div>
                 <FormControl>
-                  <Input type="password" placeholder="••••••••" {...field} />
+                  <PasswordInput placeholder="••••••••" {...field} />
                 </FormControl>
                 <FormMessage />
               </FormItem>

--- a/app/(auth)/login/page.tsx
+++ b/app/(auth)/login/page.tsx
@@ -1,0 +1,16 @@
+// app/(auth)/login/page.tsx
+import type { Metadata } from "next";
+import { Suspense } from "react";
+import { LoginForm } from "./login-form";
+
+export const metadata: Metadata = {
+  title: "Sign in — Cervix Health Assistant",
+};
+
+export default function LoginPage() {
+  return (
+    <Suspense>
+      <LoginForm />
+    </Suspense>
+  );
+}

--- a/app/(auth)/register/page.tsx
+++ b/app/(auth)/register/page.tsx
@@ -1,0 +1,11 @@
+// app/(auth)/register/page.tsx
+import type { Metadata } from "next";
+import { RegisterForm } from "./register-form";
+
+export const metadata: Metadata = {
+  title: "Create account — Cervix Health Assistant",
+};
+
+export default function RegisterPage() {
+  return <RegisterForm />;
+}

--- a/app/(auth)/register/register-form.tsx
+++ b/app/(auth)/register/register-form.tsx
@@ -11,6 +11,7 @@ import {
   FormMessage,
 } from "@/components/ui/form";
 import { Input } from "@/components/ui/input";
+import { PasswordInput } from "@/components/ui/password-input";
 import { createClient } from "@/lib/supabase/browser";
 import { type RegisterFormValues, registerSchema } from "@/lib/validations/auth";
 import { zodResolver } from "@hookform/resolvers/zod";
@@ -108,7 +109,7 @@ export function RegisterForm() {
               <FormItem>
                 <FormLabel>Password</FormLabel>
                 <FormControl>
-                  <Input type="password" placeholder="Min. 8 characters" {...field} />
+                  <PasswordInput placeholder="Min. 8 characters" {...field} />
                 </FormControl>
                 <FormMessage />
               </FormItem>
@@ -121,7 +122,7 @@ export function RegisterForm() {
               <FormItem>
                 <FormLabel>Confirm password</FormLabel>
                 <FormControl>
-                  <Input type="password" placeholder="Re-enter your password" {...field} />
+                  <PasswordInput placeholder="Re-enter your password" {...field} />
                 </FormControl>
                 <FormMessage />
               </FormItem>

--- a/app/(auth)/register/register-form.tsx
+++ b/app/(auth)/register/register-form.tsx
@@ -1,0 +1,128 @@
+// app/(auth)/register/register-form.tsx
+"use client";
+
+import { Button } from "@/components/ui/button";
+import {
+  Form,
+  FormControl,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage,
+} from "@/components/ui/form";
+import { Input } from "@/components/ui/input";
+import { createClient } from "@/lib/supabase/browser";
+import { type RegisterFormValues, registerSchema } from "@/lib/validations/auth";
+import { zodResolver } from "@hookform/resolvers/zod";
+import Link from "next/link";
+import { useRouter } from "next/navigation";
+import { useState } from "react";
+import { useForm } from "react-hook-form";
+
+export function RegisterForm() {
+  const router = useRouter();
+  const [serverError, setServerError] = useState<string | null>(null);
+
+  const form = useForm<RegisterFormValues>({
+    resolver: zodResolver(registerSchema),
+    defaultValues: { email: "", password: "", confirmPassword: "" },
+  });
+
+  async function onSubmit(values: RegisterFormValues) {
+    setServerError(null);
+    const supabase = createClient();
+    const { error } = await supabase.auth.signUp({
+      email: values.email,
+      password: values.password,
+    });
+    if (error) {
+      setServerError(error.message);
+      return;
+    }
+    router.push("/chat");
+  }
+
+  return (
+    <div>
+      <p className="text-[11px] uppercase tracking-[0.08em] text-muted-gray mb-3">Cervix Health</p>
+      <h1 className="text-[28px] font-semibold text-charcoal tracking-[-0.5px] mb-1.5">
+        Create account
+      </h1>
+      <p className="text-sm text-muted-gray mb-8">Start your health journey</p>
+
+      {serverError && (
+        <div
+          role="alert"
+          className="mb-4 rounded-standard border border-destructive/30 bg-destructive/5 px-3 py-2.5 text-sm text-destructive"
+        >
+          {serverError}
+        </div>
+      )}
+
+      <Form {...form}>
+        <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-4">
+          <FormField
+            control={form.control}
+            name="email"
+            render={({ field }) => (
+              <FormItem>
+                <FormLabel>Email</FormLabel>
+                <FormControl>
+                  <Input
+                    type="text"
+                    inputMode="email"
+                    autoComplete="email"
+                    placeholder="you@example.com"
+                    {...field}
+                  />
+                </FormControl>
+                <FormMessage />
+              </FormItem>
+            )}
+          />
+          <FormField
+            control={form.control}
+            name="password"
+            render={({ field }) => (
+              <FormItem>
+                <FormLabel>Password</FormLabel>
+                <FormControl>
+                  <Input type="password" placeholder="Min. 8 characters" {...field} />
+                </FormControl>
+                <FormMessage />
+              </FormItem>
+            )}
+          />
+          <FormField
+            control={form.control}
+            name="confirmPassword"
+            render={({ field }) => (
+              <FormItem>
+                <FormLabel>Confirm password</FormLabel>
+                <FormControl>
+                  <Input type="password" placeholder="Re-enter your password" {...field} />
+                </FormControl>
+                <FormMessage />
+              </FormItem>
+            )}
+          />
+          <Button
+            type="submit"
+            variant="default"
+            className="w-full mt-2"
+            disabled={form.formState.isSubmitting}
+          >
+            {form.formState.isSubmitting ? "Creating account..." : "Create account"}
+          </Button>
+        </form>
+      </Form>
+
+      <p className="mt-5 text-center text-[13px] text-muted-gray">
+        Already have an account?{" "}
+        <Link href="/login" className="text-charcoal underline underline-offset-2">
+          Sign in
+        </Link>
+      </p>
+    </div>
+  );
+}

--- a/app/(auth)/register/register-form.tsx
+++ b/app/(auth)/register/register-form.tsx
@@ -18,9 +18,9 @@ import { zodResolver } from "@hookform/resolvers/zod";
 import Link from "next/link";
 import { useState } from "react";
 import { useForm } from "react-hook-form";
+import { toast } from "sonner";
 
 export function RegisterForm() {
-  const [serverError, setServerError] = useState<string | null>(null);
   const [emailSent, setEmailSent] = useState(false);
 
   const form = useForm<RegisterFormValues>({
@@ -29,14 +29,13 @@ export function RegisterForm() {
   });
 
   async function onSubmit(values: RegisterFormValues) {
-    setServerError(null);
     const supabase = createClient();
     const { error } = await supabase.auth.signUp({
       email: values.email,
       password: values.password,
     });
     if (error) {
-      setServerError(error.message);
+      toast.error(error.message);
       return;
     }
     setEmailSent(true);
@@ -71,15 +70,6 @@ export function RegisterForm() {
         Create account
       </h1>
       <p className="text-sm text-muted-gray mb-8">Start your health journey</p>
-
-      {serverError && (
-        <div
-          role="alert"
-          className="mb-4 rounded-standard border border-destructive/30 bg-destructive/5 px-3 py-2.5 text-sm text-destructive"
-        >
-          {serverError}
-        </div>
-      )}
 
       <Form {...form}>
         <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-4">

--- a/app/(auth)/register/register-form.tsx
+++ b/app/(auth)/register/register-form.tsx
@@ -15,13 +15,12 @@ import { createClient } from "@/lib/supabase/browser";
 import { type RegisterFormValues, registerSchema } from "@/lib/validations/auth";
 import { zodResolver } from "@hookform/resolvers/zod";
 import Link from "next/link";
-import { useRouter } from "next/navigation";
 import { useState } from "react";
 import { useForm } from "react-hook-form";
 
 export function RegisterForm() {
-  const router = useRouter();
   const [serverError, setServerError] = useState<string | null>(null);
+  const [emailSent, setEmailSent] = useState(false);
 
   const form = useForm<RegisterFormValues>({
     resolver: zodResolver(registerSchema),
@@ -39,7 +38,29 @@ export function RegisterForm() {
       setServerError(error.message);
       return;
     }
-    router.push("/chat");
+    setEmailSent(true);
+  }
+
+  if (emailSent) {
+    return (
+      <div className="space-y-4">
+        <p className="text-[11px] uppercase tracking-[0.08em] text-muted-gray mb-3">
+          Cervix Health
+        </p>
+        <h1 className="text-[28px] font-semibold text-charcoal tracking-[-0.5px]">
+          Check your email
+        </h1>
+        <p className="text-sm text-muted-gray">
+          We sent a confirmation link to your inbox. Click it to activate your account.
+        </p>
+        <p className="text-[13px] text-muted-gray">
+          Already confirmed?{" "}
+          <Link href="/login" className="text-charcoal underline underline-offset-2">
+            Sign in
+          </Link>
+        </p>
+      </div>
+    );
   }
 
   return (

--- a/app/(auth)/reset-password/page.tsx
+++ b/app/(auth)/reset-password/page.tsx
@@ -1,0 +1,11 @@
+// app/(auth)/reset-password/page.tsx
+import type { Metadata } from "next";
+import { ResetPasswordForm } from "./reset-password-form";
+
+export const metadata: Metadata = {
+  title: "Set new password — Cervix Health Assistant",
+};
+
+export default function ResetPasswordPage() {
+  return <ResetPasswordForm />;
+}

--- a/app/(auth)/reset-password/reset-password-form.tsx
+++ b/app/(auth)/reset-password/reset-password-form.tsx
@@ -18,10 +18,10 @@ import { zodResolver } from "@hookform/resolvers/zod";
 import { useRouter } from "next/navigation";
 import { useEffect, useState } from "react";
 import { useForm } from "react-hook-form";
+import { toast } from "sonner";
 
 export function ResetPasswordForm() {
   const router = useRouter();
-  const [serverError, setServerError] = useState<string | null>(null);
   const [sessionChecked, setSessionChecked] = useState(false);
 
   useEffect(() => {
@@ -41,13 +41,12 @@ export function ResetPasswordForm() {
   });
 
   async function onSubmit(values: ResetPasswordFormValues) {
-    setServerError(null);
     const supabase = createClient();
     const { error } = await supabase.auth.updateUser({
       password: values.password,
     });
     if (error) {
-      setServerError(error.message);
+      toast.error(error.message);
       return;
     }
     router.push("/login?reset=success");
@@ -64,15 +63,6 @@ export function ResetPasswordForm() {
         Set new password
       </h1>
       <p className="text-sm text-muted-gray mb-8">Choose a strong password for your account</p>
-
-      {serverError && (
-        <div
-          role="alert"
-          className="mb-4 rounded-standard border border-destructive/30 bg-destructive/5 px-3 py-2.5 text-sm text-destructive"
-        >
-          {serverError}
-        </div>
-      )}
 
       <Form {...form}>
         <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-4">

--- a/app/(auth)/reset-password/reset-password-form.tsx
+++ b/app/(auth)/reset-password/reset-password-form.tsx
@@ -11,6 +11,7 @@ import {
   FormMessage,
 } from "@/components/ui/form";
 import { Input } from "@/components/ui/input";
+import { PasswordInput } from "@/components/ui/password-input";
 import { createClient } from "@/lib/supabase/browser";
 import { type ResetPasswordFormValues, resetPasswordSchema } from "@/lib/validations/auth";
 import { zodResolver } from "@hookform/resolvers/zod";
@@ -82,7 +83,7 @@ export function ResetPasswordForm() {
               <FormItem>
                 <FormLabel>New password</FormLabel>
                 <FormControl>
-                  <Input type="password" placeholder="Min. 8 characters" {...field} />
+                  <PasswordInput placeholder="Min. 8 characters" {...field} />
                 </FormControl>
                 <FormMessage />
               </FormItem>
@@ -95,7 +96,7 @@ export function ResetPasswordForm() {
               <FormItem>
                 <FormLabel>Confirm new password</FormLabel>
                 <FormControl>
-                  <Input type="password" placeholder="Re-enter your new password" {...field} />
+                  <PasswordInput placeholder="Re-enter your new password" {...field} />
                 </FormControl>
                 <FormMessage />
               </FormItem>

--- a/app/(auth)/reset-password/reset-password-form.tsx
+++ b/app/(auth)/reset-password/reset-password-form.tsx
@@ -1,0 +1,116 @@
+// app/(auth)/reset-password/reset-password-form.tsx
+"use client";
+
+import { Button } from "@/components/ui/button";
+import {
+  Form,
+  FormControl,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage,
+} from "@/components/ui/form";
+import { Input } from "@/components/ui/input";
+import { createClient } from "@/lib/supabase/browser";
+import { type ResetPasswordFormValues, resetPasswordSchema } from "@/lib/validations/auth";
+import { zodResolver } from "@hookform/resolvers/zod";
+import { useRouter } from "next/navigation";
+import { useEffect, useState } from "react";
+import { useForm } from "react-hook-form";
+
+export function ResetPasswordForm() {
+  const router = useRouter();
+  const [serverError, setServerError] = useState<string | null>(null);
+  const [sessionChecked, setSessionChecked] = useState(false);
+
+  useEffect(() => {
+    const supabase = createClient();
+    supabase.auth.getSession().then(({ data: { session } }) => {
+      if (!session) {
+        router.replace("/forgot-password");
+      } else {
+        setSessionChecked(true);
+      }
+    });
+  }, [router]);
+
+  const form = useForm<ResetPasswordFormValues>({
+    resolver: zodResolver(resetPasswordSchema),
+    defaultValues: { password: "", confirmPassword: "" },
+  });
+
+  async function onSubmit(values: ResetPasswordFormValues) {
+    setServerError(null);
+    const supabase = createClient();
+    const { error } = await supabase.auth.updateUser({
+      password: values.password,
+    });
+    if (error) {
+      setServerError(error.message);
+      return;
+    }
+    router.push("/login?reset=success");
+  }
+
+  if (!sessionChecked) {
+    return null;
+  }
+
+  return (
+    <div>
+      <p className="text-[11px] uppercase tracking-[0.08em] text-muted-gray mb-3">Cervix Health</p>
+      <h1 className="text-[28px] font-semibold text-charcoal tracking-[-0.5px] mb-1.5">
+        Set new password
+      </h1>
+      <p className="text-sm text-muted-gray mb-8">Choose a strong password for your account</p>
+
+      {serverError && (
+        <div
+          role="alert"
+          className="mb-4 rounded-standard border border-destructive/30 bg-destructive/5 px-3 py-2.5 text-sm text-destructive"
+        >
+          {serverError}
+        </div>
+      )}
+
+      <Form {...form}>
+        <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-4">
+          <FormField
+            control={form.control}
+            name="password"
+            render={({ field }) => (
+              <FormItem>
+                <FormLabel>New password</FormLabel>
+                <FormControl>
+                  <Input type="password" placeholder="Min. 8 characters" {...field} />
+                </FormControl>
+                <FormMessage />
+              </FormItem>
+            )}
+          />
+          <FormField
+            control={form.control}
+            name="confirmPassword"
+            render={({ field }) => (
+              <FormItem>
+                <FormLabel>Confirm new password</FormLabel>
+                <FormControl>
+                  <Input type="password" placeholder="Re-enter your new password" {...field} />
+                </FormControl>
+                <FormMessage />
+              </FormItem>
+            )}
+          />
+          <Button
+            type="submit"
+            variant="default"
+            className="w-full mt-2"
+            disabled={form.formState.isSubmitting}
+          >
+            {form.formState.isSubmitting ? "Updating..." : "Update password"}
+          </Button>
+        </form>
+      </Form>
+    </div>
+  );
+}

--- a/app/api/auth/callback/route.ts
+++ b/app/api/auth/callback/route.ts
@@ -1,0 +1,24 @@
+import { createClient } from "@/lib/supabase/server";
+// app/api/auth/callback/route.ts
+import type { EmailOtpType } from "@supabase/supabase-js";
+import { type NextRequest, NextResponse } from "next/server";
+
+export async function GET(request: NextRequest) {
+  const { searchParams, origin } = new URL(request.url);
+  const tokenHash = searchParams.get("token_hash");
+  const type = searchParams.get("type") as EmailOtpType | null;
+  const next = searchParams.get("next") ?? "/chat";
+
+  if (tokenHash && type) {
+    const supabase = createClient();
+    const { error } = await supabase.auth.verifyOtp({
+      token_hash: tokenHash,
+      type,
+    });
+    if (!error) {
+      return NextResponse.redirect(`${origin}${next}`);
+    }
+  }
+
+  return NextResponse.redirect(`${origin}/login?error=link-expired`);
+}

--- a/app/api/auth/callback/route.ts
+++ b/app/api/auth/callback/route.ts
@@ -5,11 +5,18 @@ import type { NextRequest } from "next/server";
 
 export async function GET(request: NextRequest) {
   const { searchParams, origin } = new URL(request.url);
+  const code = searchParams.get("code");
   const tokenHash = searchParams.get("token_hash");
   const type = searchParams.get("type") as EmailOtpType | null;
   const next = searchParams.get("next") ?? "/chat";
 
-  if (tokenHash && type) {
+  if (code) {
+    const supabase = createClient();
+    const { error } = await supabase.auth.exchangeCodeForSession(code);
+    if (!error) {
+      return Response.redirect(`${origin}${next}`);
+    }
+  } else if (tokenHash && type) {
     const supabase = createClient();
     const { error } = await supabase.auth.verifyOtp({
       token_hash: tokenHash,

--- a/app/api/auth/callback/route.ts
+++ b/app/api/auth/callback/route.ts
@@ -1,7 +1,7 @@
 import { createClient } from "@/lib/supabase/server";
 // app/api/auth/callback/route.ts
 import type { EmailOtpType } from "@supabase/supabase-js";
-import { type NextRequest, NextResponse } from "next/server";
+import type { NextRequest } from "next/server";
 
 export async function GET(request: NextRequest) {
   const { searchParams, origin } = new URL(request.url);
@@ -16,9 +16,9 @@ export async function GET(request: NextRequest) {
       type,
     });
     if (!error) {
-      return NextResponse.redirect(`${origin}${next}`);
+      return Response.redirect(`${origin}${next}`);
     }
   }
 
-  return NextResponse.redirect(`${origin}/login?error=link-expired`);
+  return Response.redirect(`${origin}/login?error=link-expired`);
 }

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,3 +1,4 @@
+import { Toaster } from "@/components/ui/sonner";
 import type { Metadata } from "next";
 import "./globals.css";
 
@@ -17,7 +18,10 @@ export default function RootLayout({
 }>) {
   return (
     <html lang="en">
-      <body className="bg-cream text-charcoal font-sans antialiased">{children}</body>
+      <body className="bg-cream text-charcoal font-sans antialiased">
+        {children}
+        <Toaster position="bottom-center" />
+      </body>
     </html>
   );
 }

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,16 +1,9 @@
 import type { Metadata } from "next";
-import localFont from "next/font/local";
 import "./globals.css";
 
-// Camera Plain Variable — place the licensed font file at app/fonts/CameraPlainVariable.otf
-// (or .woff2). The current file is a placeholder; replace with the real font when licensed.
-// No Google Fonts — ui-sans-serif / system-ui are the fallback chain.
-const cameraPlain = localFont({
-  src: "./fonts/CameraPlainVariable.otf",
-  variable: "--font-camera",
-  fallback: ["ui-sans-serif", "system-ui"],
-  display: "swap",
-});
+// Camera Plain Variable font is not yet licensed.
+// Using ui-sans-serif / system-ui fallback until the real font file is available.
+// To restore: add the licensed CameraPlainVariable.otf to app/fonts/ and re-enable localFont.
 
 export const metadata: Metadata = {
   title: "Cervix Health Assistant",
@@ -23,7 +16,7 @@ export default function RootLayout({
   children: React.ReactNode;
 }>) {
   return (
-    <html lang="en" className={cameraPlain.variable}>
+    <html lang="en">
       <body className="bg-cream text-charcoal font-sans antialiased">{children}</body>
     </html>
   );

--- a/components/ui/form.tsx
+++ b/components/ui/form.tsx
@@ -1,0 +1,162 @@
+"use client";
+
+import * as React from "react";
+import {
+  Controller,
+  type ControllerProps,
+  type FieldPath,
+  type FieldValues,
+  FormProvider,
+  useFormContext,
+} from "react-hook-form";
+
+import { Label } from "@/components/ui/label";
+import { cn } from "@/lib/utils";
+
+const Form = FormProvider;
+
+type FormFieldContextValue<
+  TFieldValues extends FieldValues = FieldValues,
+  TName extends FieldPath<TFieldValues> = FieldPath<TFieldValues>,
+> = {
+  name: TName;
+};
+
+const FormFieldContext = React.createContext<FormFieldContextValue>({} as FormFieldContextValue);
+
+function FormField<
+  TFieldValues extends FieldValues = FieldValues,
+  TName extends FieldPath<TFieldValues> = FieldPath<TFieldValues>,
+>({ ...props }: ControllerProps<TFieldValues, TName>) {
+  return (
+    <FormFieldContext.Provider value={{ name: props.name }}>
+      <Controller {...props} />
+    </FormFieldContext.Provider>
+  );
+}
+
+const useFormField = () => {
+  const fieldContext = React.useContext(FormFieldContext);
+  const itemContext = React.useContext(FormItemContext);
+  const { getFieldState, formState } = useFormContext();
+
+  if (!fieldContext.name) {
+    throw new Error("useFormField should be used within <FormField>");
+  }
+
+  const fieldState = getFieldState(fieldContext.name, formState);
+  const { id } = itemContext;
+
+  return {
+    id,
+    name: fieldContext.name,
+    formItemId: `${id}-form-item`,
+    formDescriptionId: `${id}-form-item-description`,
+    formMessageId: `${id}-form-item-message`,
+    ...fieldState,
+  };
+};
+
+type FormItemContextValue = {
+  id: string;
+};
+
+const FormItemContext = React.createContext<FormItemContextValue>({} as FormItemContextValue);
+
+const FormItem = React.forwardRef<HTMLDivElement, React.HTMLAttributes<HTMLDivElement>>(
+  ({ className, ...props }, ref) => {
+    const id = React.useId();
+
+    return (
+      <FormItemContext.Provider value={{ id }}>
+        <div ref={ref} className={cn("space-y-1.5", className)} {...props} />
+      </FormItemContext.Provider>
+    );
+  }
+);
+FormItem.displayName = "FormItem";
+
+const FormLabel = React.forwardRef<HTMLLabelElement, React.ComponentPropsWithoutRef<"label">>(
+  ({ className, ...props }, ref) => {
+    const { error, formItemId } = useFormField();
+
+    return (
+      <Label
+        ref={ref}
+        className={cn(error && "text-destructive", className)}
+        htmlFor={formItemId}
+        {...props}
+      />
+    );
+  }
+);
+FormLabel.displayName = "FormLabel";
+
+const FormControl = React.forwardRef<HTMLDivElement, React.HTMLAttributes<HTMLDivElement>>(
+  ({ ...props }, ref) => {
+    const { error, formItemId, formDescriptionId, formMessageId } = useFormField();
+
+    return (
+      <div
+        ref={ref}
+        id={formItemId}
+        aria-describedby={!error ? formDescriptionId : `${formDescriptionId} ${formMessageId}`}
+        aria-invalid={!!error}
+        {...props}
+      />
+    );
+  }
+);
+FormControl.displayName = "FormControl";
+
+const FormDescription = React.forwardRef<
+  HTMLParagraphElement,
+  React.HTMLAttributes<HTMLParagraphElement>
+>(({ className, ...props }, ref) => {
+  const { formDescriptionId } = useFormField();
+
+  return (
+    <p
+      ref={ref}
+      id={formDescriptionId}
+      className={cn("text-muted-foreground text-sm", className)}
+      {...props}
+    />
+  );
+});
+FormDescription.displayName = "FormDescription";
+
+const FormMessage = React.forwardRef<
+  HTMLParagraphElement,
+  React.HTMLAttributes<HTMLParagraphElement>
+>(({ className, children, ...props }, ref) => {
+  const { error, formMessageId } = useFormField();
+  const body = error ? String(error?.message ?? "") : children;
+
+  if (!body) {
+    return null;
+  }
+
+  return (
+    <p
+      ref={ref}
+      id={formMessageId}
+      className={cn("text-destructive text-sm font-medium", className)}
+      {...props}
+    >
+      {body}
+    </p>
+  );
+});
+FormMessage.displayName = "FormMessage";
+
+export {
+  useFormField,
+  Form,
+  FormItem,
+  FormLabel,
+  FormControl,
+  FormDescription,
+  FormMessage,
+  FormField,
+};

--- a/components/ui/form.tsx
+++ b/components/ui/form.tsx
@@ -10,6 +10,8 @@ import {
   useFormContext,
 } from "react-hook-form";
 
+import { Slot } from "@radix-ui/react-slot";
+
 import { Label } from "@/components/ui/label";
 import { cn } from "@/lib/utils";
 
@@ -92,21 +94,22 @@ const FormLabel = React.forwardRef<HTMLLabelElement, React.ComponentPropsWithout
 );
 FormLabel.displayName = "FormLabel";
 
-const FormControl = React.forwardRef<HTMLDivElement, React.HTMLAttributes<HTMLDivElement>>(
-  ({ ...props }, ref) => {
-    const { error, formItemId, formDescriptionId, formMessageId } = useFormField();
+const FormControl = React.forwardRef<
+  React.ElementRef<typeof Slot>,
+  React.ComponentPropsWithoutRef<typeof Slot>
+>(({ ...props }, ref) => {
+  const { error, formItemId, formDescriptionId, formMessageId } = useFormField();
 
-    return (
-      <div
-        ref={ref}
-        id={formItemId}
-        aria-describedby={!error ? formDescriptionId : `${formDescriptionId} ${formMessageId}`}
-        aria-invalid={!!error}
-        {...props}
-      />
-    );
-  }
-);
+  return (
+    <Slot
+      ref={ref}
+      id={formItemId}
+      aria-describedby={!error ? formDescriptionId : `${formDescriptionId} ${formMessageId}`}
+      aria-invalid={!!error}
+      {...props}
+    />
+  );
+});
 FormControl.displayName = "FormControl";
 
 const FormDescription = React.forwardRef<

--- a/components/ui/input.tsx
+++ b/components/ui/input.tsx
@@ -1,0 +1,20 @@
+import { Input as InputPrimitive } from "@base-ui/react/input";
+import type * as React from "react";
+
+import { cn } from "@/lib/utils";
+
+function Input({ className, type, ...props }: React.ComponentProps<"input">) {
+  return (
+    <InputPrimitive
+      type={type}
+      data-slot="input"
+      className={cn(
+        "h-8 w-full min-w-0 rounded-lg border border-input bg-transparent px-2.5 py-1 text-base transition-colors outline-none file:inline-flex file:h-6 file:border-0 file:bg-transparent file:text-sm file:font-medium file:text-foreground placeholder:text-muted-foreground focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/50 disabled:pointer-events-none disabled:cursor-not-allowed disabled:bg-input/50 disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-3 aria-invalid:ring-destructive/20 md:text-sm dark:bg-input/30 dark:disabled:bg-input/80 dark:aria-invalid:border-destructive/50 dark:aria-invalid:ring-destructive/40",
+        className
+      )}
+      {...props}
+    />
+  );
+}
+
+export { Input };

--- a/components/ui/input.tsx
+++ b/components/ui/input.tsx
@@ -1,11 +1,10 @@
-import { Input as InputPrimitive } from "@base-ui/react/input";
 import type * as React from "react";
 
 import { cn } from "@/lib/utils";
 
 function Input({ className, type, ...props }: React.ComponentProps<"input">) {
   return (
-    <InputPrimitive
+    <input
       type={type}
       data-slot="input"
       className={cn(
@@ -16,5 +15,6 @@ function Input({ className, type, ...props }: React.ComponentProps<"input">) {
     />
   );
 }
+Input.displayName = "Input";
 
 export { Input };

--- a/components/ui/label.tsx
+++ b/components/ui/label.tsx
@@ -1,0 +1,21 @@
+"use client";
+
+import type * as React from "react";
+
+import { cn } from "@/lib/utils";
+
+function Label({ className, ...props }: React.ComponentProps<"label">) {
+  return (
+    // biome-ignore lint/a11y/noLabelWithoutControl: Label is a generic primitive; association is handled by consumers via htmlFor
+    <label
+      data-slot="label"
+      className={cn(
+        "flex items-center gap-2 text-sm leading-none font-medium select-none group-data-[disabled=true]:pointer-events-none group-data-[disabled=true]:opacity-50 peer-disabled:cursor-not-allowed peer-disabled:opacity-50",
+        className
+      )}
+      {...props}
+    />
+  );
+}
+
+export { Label };

--- a/components/ui/password-input.tsx
+++ b/components/ui/password-input.tsx
@@ -1,0 +1,27 @@
+"use client";
+
+import { cn } from "@/lib/utils";
+import { Eye, EyeOff } from "lucide-react";
+import * as React from "react";
+import { Input } from "./input";
+
+function PasswordInput({ className, ...props }: Omit<React.ComponentProps<"input">, "type">) {
+  const [visible, setVisible] = React.useState(false);
+
+  return (
+    <div className="relative">
+      <Input type={visible ? "text" : "password"} className={cn("pr-10", className)} {...props} />
+      <button
+        type="button"
+        onClick={() => setVisible((v) => !v)}
+        aria-label={visible ? "Hide password" : "Show password"}
+        className="absolute inset-y-0 right-0 flex items-center pr-3 text-muted-gray hover:text-charcoal transition-colors"
+      >
+        {visible ? <EyeOff className="h-4 w-4" /> : <Eye className="h-4 w-4" />}
+      </button>
+    </div>
+  );
+}
+PasswordInput.displayName = "PasswordInput";
+
+export { PasswordInput };

--- a/components/ui/sonner.tsx
+++ b/components/ui/sonner.tsx
@@ -1,0 +1,46 @@
+"use client"
+
+import { Toaster as Sonner, type ToasterProps } from "sonner"
+import { CircleCheckIcon, InfoIcon, TriangleAlertIcon, OctagonXIcon, Loader2Icon } from "lucide-react"
+
+const Toaster = ({ ...props }: ToasterProps) => {
+  return (
+    <Sonner
+      theme="light"
+      className="toaster group"
+      icons={{
+        success: (
+          <CircleCheckIcon className="size-4" />
+        ),
+        info: (
+          <InfoIcon className="size-4" />
+        ),
+        warning: (
+          <TriangleAlertIcon className="size-4" />
+        ),
+        error: (
+          <OctagonXIcon className="size-4" />
+        ),
+        loading: (
+          <Loader2Icon className="size-4 animate-spin" />
+        ),
+      }}
+      style={
+        {
+          "--normal-bg": "var(--popover)",
+          "--normal-text": "var(--popover-foreground)",
+          "--normal-border": "var(--border)",
+          "--border-radius": "var(--radius)",
+        } as React.CSSProperties
+      }
+      toastOptions={{
+        classNames: {
+          toast: "cn-toast",
+        },
+      }}
+      {...props}
+    />
+  )
+}
+
+export { Toaster }

--- a/components/ui/sonner.tsx
+++ b/components/ui/sonner.tsx
@@ -1,7 +1,13 @@
-"use client"
+"use client";
 
-import { Toaster as Sonner, type ToasterProps } from "sonner"
-import { CircleCheckIcon, InfoIcon, TriangleAlertIcon, OctagonXIcon, Loader2Icon } from "lucide-react"
+import {
+  CircleCheckIcon,
+  InfoIcon,
+  Loader2Icon,
+  OctagonXIcon,
+  TriangleAlertIcon,
+} from "lucide-react";
+import { Toaster as Sonner, type ToasterProps } from "sonner";
 
 const Toaster = ({ ...props }: ToasterProps) => {
   return (
@@ -9,21 +15,11 @@ const Toaster = ({ ...props }: ToasterProps) => {
       theme="light"
       className="toaster group"
       icons={{
-        success: (
-          <CircleCheckIcon className="size-4" />
-        ),
-        info: (
-          <InfoIcon className="size-4" />
-        ),
-        warning: (
-          <TriangleAlertIcon className="size-4" />
-        ),
-        error: (
-          <OctagonXIcon className="size-4" />
-        ),
-        loading: (
-          <Loader2Icon className="size-4 animate-spin" />
-        ),
+        success: <CircleCheckIcon className="size-4" />,
+        info: <InfoIcon className="size-4" />,
+        warning: <TriangleAlertIcon className="size-4" />,
+        error: <OctagonXIcon className="size-4" />,
+        loading: <Loader2Icon className="size-4 animate-spin" />,
       }}
       style={
         {
@@ -40,7 +36,7 @@ const Toaster = ({ ...props }: ToasterProps) => {
       }}
       {...props}
     />
-  )
-}
+  );
+};
 
-export { Toaster }
+export { Toaster };

--- a/docs/database.md
+++ b/docs/database.md
@@ -99,16 +99,21 @@ Three roles, enforced at the database level via RLS policies in
 | `profiles` | ✗ | SELECT, UPDATE | ✗ | SELECT all, UPDATE all |
 | `chat_sessions` | ✗ | ALL (owned) | ✗ | SELECT all |
 | `chat_messages` | ✗ | ALL (via owned session) | ✗ | SELECT all |
-| `knowledge_chunks` | ✗ | SELECT | SELECT | SELECT, INSERT, UPDATE, DELETE |
-| `analytics_events` | ✗ | INSERT own | ✗ | SELECT all |
+| `knowledge_chunks` | ✗ | SELECT (all rows) | — | SELECT, INSERT, UPDATE, DELETE |
+| `analytics_events` | ✗ | INSERT (self-attributed) | ✗ | SELECT all |
 
 `profiles` has no INSERT/DELETE policy — rows are created by the
 `handle_new_user` trigger on `auth.users` (SECURITY DEFINER, bypasses RLS)
 and deleted by FK cascade when the auth user is removed.
 
-`analytics_events` has no UPDATE/DELETE policy — it is append-only for audit
-purposes. GDPR account-deletion nulls the `user_id` via `ON DELETE SET NULL`
-rather than deleting the row.
+`knowledge_chunks` has no `user_id` column — there is no per-user ownership.
+All authenticated users share one read view; "self/other" distinction does not apply.
+
+`analytics_events` INSERT uses a `WITH CHECK (auth.uid() = user_id)` constraint —
+the DB rejects any insert where the submitted `user_id` does not match the caller's
+UID. It is not a row-filter; it is a write guard. The table has no UPDATE/DELETE
+policy — it is append-only for audit purposes. GDPR account-deletion nulls the
+`user_id` via `ON DELETE SET NULL` rather than deleting the row.
 
 **Never bypass RLS with the service role key in routes accessible to
 non-admin users.** Admin routes check `profiles.role` server-side before

--- a/docs/database.md
+++ b/docs/database.md
@@ -83,15 +83,36 @@ const { data } = await supabase.rpc("match_knowledge_chunks", {
 
 ## RLS Roles & Permissions
 
+Three roles, enforced at the database level via RLS policies in
+`supabase/migrations/20260413143757_rls_policies.sql`:
+
 | Role | Description | Key Permissions |
 |---|---|---|
-| `guest` | Unauthenticated or unregistered user | Read health hub, 5-message chat limit, clinic finder |
-| `user` | Registered, authenticated user | Full chat history, profile management, save clinics |
-| `admin` | Platform administrator | User management, analytics, knowledge base uploads |
+| `guest` | Unauthenticated visitor. JWT claim `role=anon` | No DB access — all policies require `to authenticated`. Guest UX (clinics finder, public learn pages) reads via server-side proxy routes. |
+| `user` | Authenticated registered user (`profiles.role = 'user'`) | Read/update own profile. Full CRUD on own `chat_sessions` and `chat_messages`. Read `knowledge_chunks`. Insert own `analytics_events`. |
+| `admin` | Platform administrator (`profiles.role = 'admin'`) | Everything `user` has, plus: read all profiles, read all chat sessions/messages, full CRUD on `knowledge_chunks`, read all `analytics_events`. Admins cannot mutate other users' chat rows via RLS — admin tooling that writes user data must use the service role key. |
 
-RLS policies are enforced at the database level on all tables. Never bypass RLS with the service role key in routes accessible to non-admin users.
+### Per-table policy matrix
 
-Admin routes check the `profiles.role` column server-side on every request before allowing access.
+| Table | `anon` | `user` (self) | `user` (other) | `admin` |
+|---|---|---|---|---|
+| `profiles` | ✗ | SELECT, UPDATE | ✗ | SELECT all, UPDATE all |
+| `chat_sessions` | ✗ | ALL (owned) | ✗ | SELECT all |
+| `chat_messages` | ✗ | ALL (via owned session) | ✗ | SELECT all |
+| `knowledge_chunks` | ✗ | SELECT | SELECT | SELECT, INSERT, UPDATE, DELETE |
+| `analytics_events` | ✗ | INSERT own | ✗ | SELECT all |
+
+`profiles` has no INSERT/DELETE policy — rows are created by the
+`handle_new_user` trigger on `auth.users` (SECURITY DEFINER, bypasses RLS)
+and deleted by FK cascade when the auth user is removed.
+
+`analytics_events` has no UPDATE/DELETE policy — it is append-only for audit
+purposes. GDPR account-deletion nulls the `user_id` via `ON DELETE SET NULL`
+rather than deleting the row.
+
+**Never bypass RLS with the service role key in routes accessible to
+non-admin users.** Admin routes check `profiles.role` server-side before
+switching to the service role.
 
 ## Conventions
 

--- a/docs/superpowers/plans/2026-04-12-epic2-supabase-auth.md
+++ b/docs/superpowers/plans/2026-04-12-epic2-supabase-auth.md
@@ -2,397 +2,254 @@
 
 > **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
 
-**Goal:** Wire up Supabase Auth email/password — Server Actions, middleware route protection, login/register pages with email confirmation gate, and sign-out.
+**Goal:** Complete Epic 2 auth on the existing `feature/epic2-auth-pages` branch — add middleware route protection, fix register form email-confirmation gate, and add a minimal app shell with sign-out.
 
-**Architecture:** Server Actions (`lib/actions/auth.ts`) handle all auth mutations using the server-side Supabase client. A Next.js middleware guards `/(app)/*` routes by calling `supabase.auth.getUser()` on every request and refreshing the session cookie. Client form components use `useFormState` from `react-dom` to display Server Action results without a page reload.
+**Architecture:** The branch already has RHF + browser-Supabase client auth pages, Input/Label/Form components, and a PKCE callback route. Three things remain: middleware (entirely missing), a register-form UX fix (shows "check your email" instead of redirecting to `/chat`), and a minimal `/(app)/chat` page with sign-out so the middleware has a protected target.
 
-**Tech Stack:** `@supabase/ssr ^0.10.2`, `zod` (to be added), `next/navigation` redirect, `useFormState`/`useFormStatus` from `react-dom`, Tailwind CSS design tokens, `@base-ui/react` + custom Input/Label components.
+**Tech Stack:** Next.js 14 App Router, `@supabase/ssr`, Tailwind CSS design tokens. All work is on `.worktrees/epic2-auth` (branch `feature/epic2-auth-pages`).
 
 ---
 
-## File Map
+## Already Done — Do Not Touch
 
-| File | Status | Purpose |
+| File | Status |
+|---|---|
+| `components/ui/input.tsx`, `label.tsx`, `form.tsx` | ✅ Complete |
+| `app/(auth)/layout.tsx` | ✅ Complete |
+| `app/(auth)/login/page.tsx` + `login-form.tsx` | ✅ Complete (RHF, error banners, forgot-password link) |
+| `app/(auth)/register/page.tsx` | ✅ Complete |
+| `app/(auth)/forgot-password/` + `reset-password/` | ✅ Complete |
+| `app/api/auth/callback/route.ts` | ✅ Complete (`verifyOtp` PKCE flow — keep as-is) |
+| `lib/supabase/browser.ts`, `server.ts` | ✅ Complete |
+| `lib/validations/auth.ts` | ✅ Complete |
+
+---
+
+## File Map — What This Plan Builds
+
+| File | Action | Purpose |
 |---|---|---|
-| `lib/actions/auth.ts` | Create | Server Actions: `signIn`, `signUp`, `signOut` |
-| `lib/actions/auth.test.ts` | Create | Vitest unit tests for all three actions |
-| `middleware.ts` | Create | Session refresh + route guard for `/(app)/*` |
-| `app/api/auth/callback/route.ts` | Create | Exchange confirmation code → session → redirect |
-| `app/(auth)/layout.tsx` | Create | Centered cream layout wrapping auth pages |
-| `app/(auth)/login/page.tsx` | Create | Server Component: session check + pass error prop |
-| `app/(auth)/login/login-form.tsx` | Create | `'use client'` form with `useFormState(signIn)` |
-| `app/(auth)/register/page.tsx` | Create | Server Component wrapper |
-| `app/(auth)/register/register-form.tsx` | Create | `'use client'` form with "check your email" state |
-| `app/(app)/layout.tsx` | Create | Minimal pass-through layout for protected routes |
-| `app/(app)/chat/page.tsx` | Create | Placeholder page with sign-out button (verifies AC) |
-| `components/ui/input.tsx` | Create | Styled native input (no shadcn CLI needed) |
-| `components/ui/label.tsx` | Create | Styled native label |
-
-**Existing — no changes needed:**
-- `lib/supabase/browser.ts` — `createBrowserClient` already wired ✓
-- `lib/supabase/server.ts` — `createServerClient` + cookie handling already wired ✓
+| `middleware.ts` | Create | Session refresh + guard `/chat`, `/clinics`, `/learn`, `/profile`, `/admin` |
+| `app/(auth)/register/register-form.tsx` | Modify | Show "check your email" on success instead of redirecting to `/chat` |
+| `app/(app)/layout.tsx` | Create | Pass-through layout for protected routes |
+| `app/(app)/chat/page.tsx` | Create | Placeholder page — sign-out button to verify AC |
 
 ---
 
-## Task 1: Install Zod and create Input/Label components
+## Task 1: Fix register form — email confirmation gate
 
 **Files:**
-- Modify: `package.json` (new dep via pnpm)
-- Create: `components/ui/input.tsx`
-- Create: `components/ui/label.tsx`
+- Modify: `app/(auth)/register/register-form.tsx`
 
-- [ ] **Step 1: Add zod as a direct dependency**
+The existing form calls `router.push("/chat")` on success. With email confirmation enabled in Supabase, the user has no session yet — they need to click the confirmation link first. This task replaces the redirect with a "check your email" inline state.
 
-```bash
-cd /Users/Najum/cervix-assistant && pnpm add zod
-```
+- [ ] **Step 1: Update the register form**
 
-Expected: `package.json` gains `"zod": "^3.x.x"` under `dependencies`. Lockfile updated.
-
-- [ ] **Step 2: Create Input component**
-
-Create `components/ui/input.tsx`:
+Open `app/(auth)/register/register-form.tsx`. Replace the entire file with:
 
 ```tsx
-import { cn } from "@/lib/utils";
-import type { InputHTMLAttributes } from "react";
+// app/(auth)/register/register-form.tsx
+"use client";
 
-function Input({
-  className,
-  ...props
-}: InputHTMLAttributes<HTMLInputElement>) {
+import { Button } from "@/components/ui/button";
+import {
+  Form,
+  FormControl,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage,
+} from "@/components/ui/form";
+import { Input } from "@/components/ui/input";
+import { createClient } from "@/lib/supabase/browser";
+import {
+  type RegisterFormValues,
+  registerSchema,
+} from "@/lib/validations/auth";
+import { zodResolver } from "@hookform/resolvers/zod";
+import Link from "next/link";
+import { useState } from "react";
+import { useForm } from "react-hook-form";
+
+export function RegisterForm() {
+  const [serverError, setServerError] = useState<string | null>(null);
+  const [emailSent, setEmailSent] = useState(false);
+
+  const form = useForm<RegisterFormValues>({
+    resolver: zodResolver(registerSchema),
+    defaultValues: { email: "", password: "", confirmPassword: "" },
+  });
+
+  async function onSubmit(values: RegisterFormValues) {
+    setServerError(null);
+    const supabase = createClient();
+    const { error } = await supabase.auth.signUp({
+      email: values.email,
+      password: values.password,
+    });
+    if (error) {
+      setServerError(error.message);
+      return;
+    }
+    setEmailSent(true);
+  }
+
+  if (emailSent) {
+    return (
+      <div className="space-y-4">
+        <p className="text-[11px] uppercase tracking-[0.08em] text-muted-gray mb-3">
+          Cervix Health
+        </p>
+        <h1 className="text-[28px] font-semibold text-charcoal tracking-[-0.5px]">
+          Check your email
+        </h1>
+        <p className="text-sm text-muted-gray">
+          We sent a confirmation link to your inbox. Click it to activate your
+          account.
+        </p>
+        <p className="text-[13px] text-muted-gray">
+          Already confirmed?{" "}
+          <Link
+            href="/login"
+            className="text-charcoal underline underline-offset-2"
+          >
+            Sign in
+          </Link>
+        </p>
+      </div>
+    );
+  }
+
   return (
-    <input
-      className={cn(
-        "flex w-full rounded-standard bg-off-white px-3 py-[9px] text-sm text-charcoal",
-        "border border-charcoal/40",
-        "placeholder:text-muted-gray",
-        "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring",
-        "disabled:cursor-not-allowed disabled:opacity-50",
-        className,
+    <div>
+      <p className="text-[11px] uppercase tracking-[0.08em] text-muted-gray mb-3">
+        Cervix Health
+      </p>
+      <h1 className="text-[28px] font-semibold text-charcoal tracking-[-0.5px] mb-1.5">
+        Create account
+      </h1>
+      <p className="text-sm text-muted-gray mb-8">Start your health journey</p>
+
+      {serverError && (
+        <div
+          role="alert"
+          className="mb-4 rounded-standard border border-destructive/30 bg-destructive/5 px-3 py-2.5 text-sm text-destructive"
+        >
+          {serverError}
+        </div>
       )}
-      {...props}
-    />
+
+      <Form {...form}>
+        <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-4">
+          <FormField
+            control={form.control}
+            name="email"
+            render={({ field }) => (
+              <FormItem>
+                <FormLabel>Email</FormLabel>
+                <FormControl>
+                  <Input
+                    type="text"
+                    inputMode="email"
+                    autoComplete="email"
+                    placeholder="you@example.com"
+                    {...field}
+                  />
+                </FormControl>
+                <FormMessage />
+              </FormItem>
+            )}
+          />
+          <FormField
+            control={form.control}
+            name="password"
+            render={({ field }) => (
+              <FormItem>
+                <FormLabel>Password</FormLabel>
+                <FormControl>
+                  <Input
+                    type="password"
+                    placeholder="Min. 8 characters"
+                    {...field}
+                  />
+                </FormControl>
+                <FormMessage />
+              </FormItem>
+            )}
+          />
+          <FormField
+            control={form.control}
+            name="confirmPassword"
+            render={({ field }) => (
+              <FormItem>
+                <FormLabel>Confirm password</FormLabel>
+                <FormControl>
+                  <Input
+                    type="password"
+                    placeholder="Re-enter your password"
+                    {...field}
+                  />
+                </FormControl>
+                <FormMessage />
+              </FormItem>
+            )}
+          />
+          <Button
+            type="submit"
+            variant="default"
+            className="w-full mt-2"
+            disabled={form.formState.isSubmitting}
+          >
+            {form.formState.isSubmitting ? "Creating account..." : "Create account"}
+          </Button>
+        </form>
+      </Form>
+
+      <p className="mt-5 text-center text-[13px] text-muted-gray">
+        Already have an account?{" "}
+        <Link
+          href="/login"
+          className="text-charcoal underline underline-offset-2"
+        >
+          Sign in
+        </Link>
+      </p>
+    </div>
   );
 }
-
-export { Input };
 ```
 
-- [ ] **Step 3: Create Label component**
-
-Create `components/ui/label.tsx`:
-
-```tsx
-import { cn } from "@/lib/utils";
-import type { LabelHTMLAttributes } from "react";
-
-function Label({
-  className,
-  ...props
-}: LabelHTMLAttributes<HTMLLabelElement>) {
-  return (
-    <label
-      className={cn("block text-[13px] font-semibold text-charcoal", className)}
-      {...props}
-    />
-  );
-}
-
-export { Label };
-```
-
-- [ ] **Step 4: Run Biome**
+- [ ] **Step 2: Run Biome**
 
 ```bash
-pnpm biome check --write .
+cd /Users/Najum/cervix-assistant/.worktrees/epic2-auth && pnpm biome check --write .
 ```
 
 Expected: No errors.
 
-- [ ] **Step 5: Commit**
+- [ ] **Step 3: Commit**
 
 ```bash
-git add components/ui/input.tsx components/ui/label.tsx package.json pnpm-lock.yaml
-git commit -m "feat: add zod dep and Input/Label UI primitives"
+git add app/\(auth\)/register/register-form.tsx
+git commit -m "fix(auth): show email confirmation state after sign-up instead of redirecting"
 ```
 
 ---
 
-## Task 2: Server Actions (TDD)
+## Task 2: Middleware
 
 **Files:**
-- Create: `lib/actions/auth.ts`
-- Create: `lib/actions/auth.test.ts`
-
-- [ ] **Step 1: Write the failing tests**
-
-Create `lib/actions/auth.test.ts`:
-
-```typescript
-import { beforeEach, describe, expect, it, vi } from "vitest";
-
-vi.mock("next/navigation", () => ({
-  redirect: vi.fn(),
-}));
-
-const { mockSignInWithPassword, mockSignUp, mockSignOut } = vi.hoisted(() => ({
-  mockSignInWithPassword: vi.fn(),
-  mockSignUp: vi.fn(),
-  mockSignOut: vi.fn(),
-}));
-
-vi.mock("@/lib/supabase/server", () => ({
-  createClient: vi.fn(() => ({
-    auth: {
-      signInWithPassword: mockSignInWithPassword,
-      signUp: mockSignUp,
-      signOut: mockSignOut,
-    },
-  })),
-}));
-
-import { redirect } from "next/navigation";
-import { signIn, signOut, signUp } from "@/lib/actions/auth";
-
-function makeFormData(fields: Record<string, string>): FormData {
-  const fd = new FormData();
-  for (const [key, value] of Object.entries(fields)) {
-    fd.append(key, value);
-  }
-  return fd;
-}
-
-describe("signIn", () => {
-  beforeEach(() => {
-    vi.clearAllMocks();
-  });
-
-  it("returns error for invalid email format", async () => {
-    const result = await signIn(
-      {},
-      makeFormData({ email: "not-an-email", password: "password123" }),
-    );
-    expect(result).toEqual({ error: "Please enter a valid email address" });
-    expect(mockSignInWithPassword).not.toHaveBeenCalled();
-  });
-
-  it("returns error when password is fewer than 6 characters", async () => {
-    const result = await signIn(
-      {},
-      makeFormData({ email: "user@example.com", password: "abc" }),
-    );
-    expect(result).toEqual({ error: "Password must be at least 6 characters" });
-    expect(mockSignInWithPassword).not.toHaveBeenCalled();
-  });
-
-  it("returns error when Supabase returns an auth error", async () => {
-    mockSignInWithPassword.mockResolvedValueOnce({
-      error: { message: "Invalid login credentials" },
-    });
-    const result = await signIn(
-      {},
-      makeFormData({ email: "user@example.com", password: "correctpassword" }),
-    );
-    expect(result).toEqual({ error: "Invalid login credentials" });
-  });
-
-  it("calls redirect('/chat') on success", async () => {
-    mockSignInWithPassword.mockResolvedValueOnce({ error: null });
-    await signIn(
-      {},
-      makeFormData({ email: "user@example.com", password: "correctpassword" }),
-    );
-    expect(redirect).toHaveBeenCalledWith("/chat");
-  });
-});
-
-describe("signUp", () => {
-  beforeEach(() => {
-    vi.clearAllMocks();
-  });
-
-  it("returns error for invalid email format", async () => {
-    const result = await signUp(
-      {},
-      makeFormData({ email: "bad", password: "password123" }),
-    );
-    expect(result).toEqual({ error: "Please enter a valid email address" });
-    expect(mockSignUp).not.toHaveBeenCalled();
-  });
-
-  it("returns error when password is fewer than 8 characters", async () => {
-    const result = await signUp(
-      {},
-      makeFormData({ email: "user@example.com", password: "abc123" }),
-    );
-    expect(result).toEqual({ error: "Password must be at least 8 characters" });
-    expect(mockSignUp).not.toHaveBeenCalled();
-  });
-
-  it("returns error when Supabase returns an error", async () => {
-    mockSignUp.mockResolvedValueOnce({
-      error: { message: "User already registered" },
-    });
-    const result = await signUp(
-      {},
-      makeFormData({ email: "user@example.com", password: "password123" }),
-    );
-    expect(result).toEqual({ error: "User already registered" });
-  });
-
-  it("returns { success: true } and does NOT redirect on success", async () => {
-    mockSignUp.mockResolvedValueOnce({ error: null });
-    const result = await signUp(
-      {},
-      makeFormData({ email: "newuser@example.com", password: "password123" }),
-    );
-    expect(result).toEqual({ success: true });
-    expect(redirect).not.toHaveBeenCalled();
-  });
-});
-
-describe("signOut", () => {
-  beforeEach(() => {
-    vi.clearAllMocks();
-    mockSignOut.mockResolvedValueOnce({ error: null });
-  });
-
-  it("calls supabase.auth.signOut() and redirects to /login", async () => {
-    await signOut();
-    expect(mockSignOut).toHaveBeenCalled();
-    expect(redirect).toHaveBeenCalledWith("/login");
-  });
-});
-```
-
-- [ ] **Step 2: Run tests to verify they fail**
-
-```bash
-pnpm test -- lib/actions/auth.test.ts
-```
-
-Expected: Tests fail with `Cannot find module '@/lib/actions/auth'` or similar — the implementation file doesn't exist yet.
-
-- [ ] **Step 3: Write the Server Actions implementation**
-
-Create `lib/actions/auth.ts`:
-
-```typescript
-"use server";
-
-import { createClient } from "@/lib/supabase/server";
-import { redirect } from "next/navigation";
-import { z } from "zod";
-
-const signInSchema = z.object({
-  email: z.string().email("Please enter a valid email address"),
-  password: z.string().min(6, "Password must be at least 6 characters"),
-});
-
-const signUpSchema = z.object({
-  email: z.string().email("Please enter a valid email address"),
-  password: z.string().min(8, "Password must be at least 8 characters"),
-});
-
-export type AuthState = {
-  error?: string;
-  success?: boolean;
-};
-
-export async function signIn(
-  _prevState: AuthState,
-  formData: FormData,
-): Promise<AuthState> {
-  const parsed = signInSchema.safeParse({
-    email: formData.get("email"),
-    password: formData.get("password"),
-  });
-
-  if (!parsed.success) {
-    return { error: parsed.error.issues[0].message };
-  }
-
-  const supabase = createClient();
-  const { error } = await supabase.auth.signInWithPassword(parsed.data);
-
-  if (error) {
-    return { error: error.message };
-  }
-
-  redirect("/chat");
-}
-
-export async function signUp(
-  _prevState: AuthState,
-  formData: FormData,
-): Promise<AuthState> {
-  const parsed = signUpSchema.safeParse({
-    email: formData.get("email"),
-    password: formData.get("password"),
-  });
-
-  if (!parsed.success) {
-    return { error: parsed.error.issues[0].message };
-  }
-
-  const supabase = createClient();
-  const { error } = await supabase.auth.signUp(parsed.data);
-
-  if (error) {
-    return { error: error.message };
-  }
-
-  return { success: true };
-}
-
-export async function signOut(): Promise<void> {
-  const supabase = createClient();
-  await supabase.auth.signOut();
-  redirect("/login");
-}
-```
-
-- [ ] **Step 4: Run tests to verify they pass**
-
-```bash
-pnpm test -- lib/actions/auth.test.ts
-```
-
-Expected: All 9 tests pass. If any fail, read the error and fix before continuing.
-
-- [ ] **Step 5: Run Biome**
-
-```bash
-pnpm biome check --write .
-```
-
-Expected: No errors.
-
-- [ ] **Step 6: Commit**
-
-```bash
-git add lib/actions/auth.ts lib/actions/auth.test.ts
-git commit -m "feat: add signIn/signUp/signOut Server Actions with Zod validation"
-```
-
----
-
-## Task 3: Middleware
-
-**Files:**
-- Create: `middleware.ts`
+- Create: `middleware.ts` at the worktree root
 
 - [ ] **Step 1: Create the middleware**
 
-Create `middleware.ts` at the project root:
+Create `middleware.ts`:
 
 ```typescript
 import { createServerClient } from "@supabase/ssr";
 import { NextResponse, type NextRequest } from "next/server";
 
-// Routes that require an authenticated session.
-// These are the URL paths for app/(app)/* — route group parentheses don't appear in URLs.
+// URL paths for app/(app)/* — route group parentheses don't appear in the URL.
 const PROTECTED_PATHS = ["/chat", "/clinics", "/learn", "/profile", "/admin"];
 
 function isProtected(pathname: string): boolean {
@@ -402,8 +259,7 @@ function isProtected(pathname: string): boolean {
 }
 
 export async function middleware(request: NextRequest) {
-  // supabaseResponse must be returned (not a plain NextResponse.next()) so that
-  // cookie mutations from setAll() are forwarded to the browser.
+  // supabaseResponse must be returned so cookie mutations from setAll() reach the browser.
   let supabaseResponse = NextResponse.next({ request });
 
   const supabase = createServerClient(
@@ -415,11 +271,9 @@ export async function middleware(request: NextRequest) {
           return request.cookies.getAll();
         },
         setAll(cookiesToSet) {
-          // Write to request first (required by @supabase/ssr)
           for (const { name, value } of cookiesToSet) {
             request.cookies.set(name, value);
           }
-          // Rebuild the response so updated cookies are set on it
           supabaseResponse = NextResponse.next({ request });
           for (const { name, value, options } of cookiesToSet) {
             supabaseResponse.cookies.set(name, value, options);
@@ -429,8 +283,7 @@ export async function middleware(request: NextRequest) {
     },
   );
 
-  // IMPORTANT: use getUser() not getSession() — getUser() validates the token
-  // server-side and rotates the refresh token; getSession() only reads the cookie.
+  // Use getUser() not getSession() — validates the token server-side and rotates it.
   const {
     data: { user },
   } = await supabase.auth.getUser();
@@ -446,7 +299,6 @@ export async function middleware(request: NextRequest) {
 
 export const config = {
   matcher: [
-    // Match all routes except Next.js internals and static files
     "/((?!_next/static|_next/image|favicon.ico|.*\\.(?:svg|png|jpg|jpeg|gif|webp)$).*)",
   ],
 };
@@ -469,397 +321,14 @@ git commit -m "feat: add middleware to protect /(app)/* routes and refresh sessi
 
 ---
 
-## Task 4: Auth callback route
+## Task 3: Minimal app shell with sign-out
 
-**Files:**
-- Create: `app/api/auth/callback/route.ts`
-
-- [ ] **Step 1: Create the callback route handler**
-
-Create `app/api/auth/callback/route.ts`:
-
-```typescript
-import { createClient } from "@/lib/supabase/server";
-import { type NextRequest, NextResponse } from "next/server";
-
-export async function GET(request: NextRequest) {
-  const { searchParams, origin } = new URL(request.url);
-  const code = searchParams.get("code");
-
-  if (code) {
-    const supabase = createClient();
-    const { error } = await supabase.auth.exchangeCodeForSession(code);
-    if (!error) {
-      return NextResponse.redirect(`${origin}/chat`);
-    }
-  }
-
-  // Missing or invalid code — send user back to login with an error notice
-  return NextResponse.redirect(`${origin}/login?error=confirmation_failed`);
-}
-```
-
-- [ ] **Step 2: Run Biome**
-
-```bash
-pnpm biome check --write .
-```
-
-Expected: No errors.
-
-- [ ] **Step 3: Commit**
-
-```bash
-git add app/api/auth/callback/route.ts
-git commit -m "feat: add auth callback route to exchange confirmation code for session"
-```
-
----
-
-## Task 5: Auth layout
-
-**Files:**
-- Create: `app/(auth)/layout.tsx`
-
-- [ ] **Step 1: Create the auth layout**
-
-Create `app/(auth)/layout.tsx`:
-
-```tsx
-export default function AuthLayout({
-  children,
-}: {
-  children: React.ReactNode;
-}) {
-  return (
-    <div className="min-h-screen bg-cream flex items-center justify-center px-4">
-      <div className="w-full max-w-[360px]">{children}</div>
-    </div>
-  );
-}
-```
-
-- [ ] **Step 2: Run Biome**
-
-```bash
-pnpm biome check --write .
-```
-
-Expected: No errors.
-
-- [ ] **Step 3: Commit**
-
-```bash
-git add app/(auth)/layout.tsx
-git commit -m "feat: add auth layout with centered cream column"
-```
-
----
-
-## Task 6: Login page and form
-
-**Files:**
-- Create: `app/(auth)/login/page.tsx`
-- Create: `app/(auth)/login/login-form.tsx`
-
-- [ ] **Step 1: Create the login page (Server Component)**
-
-Create `app/(auth)/login/page.tsx`:
-
-```tsx
-import { createClient } from "@/lib/supabase/server";
-import { redirect } from "next/navigation";
-import { LoginForm } from "./login-form";
-
-export default async function LoginPage({
-  searchParams,
-}: {
-  searchParams: { error?: string };
-}) {
-  const supabase = createClient();
-  const {
-    data: { user },
-  } = await supabase.auth.getUser();
-
-  if (user) {
-    redirect("/chat");
-  }
-
-  const confirmationError =
-    searchParams.error === "confirmation_failed"
-      ? "Confirmation link expired — please sign in or register again."
-      : undefined;
-
-  return (
-    <div>
-      <p className="text-[11px] uppercase tracking-[0.08em] text-muted-gray mb-2">
-        Cervix Health Assistant
-      </p>
-      <h1 className="text-[28px] font-semibold tracking-[-0.5px] text-charcoal mb-1">
-        Sign in
-      </h1>
-      <p className="text-[14px] text-muted-gray mb-8">Welcome back.</p>
-      <LoginForm confirmationError={confirmationError} />
-    </div>
-  );
-}
-```
-
-- [ ] **Step 2: Create the login form (Client Component)**
-
-Create `app/(auth)/login/login-form.tsx`:
-
-```tsx
-"use client";
-
-import { Button } from "@/components/ui/button";
-import { Input } from "@/components/ui/input";
-import { Label } from "@/components/ui/label";
-import { signIn } from "@/lib/actions/auth";
-import type { AuthState } from "@/lib/actions/auth";
-import Link from "next/link";
-import { useFormState, useFormStatus } from "react-dom";
-
-const initialState: AuthState = {};
-
-function SubmitButton() {
-  const { pending } = useFormStatus();
-  return (
-    <Button type="submit" disabled={pending} className="w-full">
-      {pending ? "Signing in…" : "Sign in"}
-    </Button>
-  );
-}
-
-export function LoginForm({
-  confirmationError,
-}: {
-  confirmationError?: string;
-}) {
-  const [state, formAction] = useFormState(signIn, initialState);
-
-  return (
-    <form action={formAction} className="space-y-4">
-      {confirmationError && (
-        <p className="text-[13px] text-destructive">{confirmationError}</p>
-      )}
-      {state.error && (
-        <p className="text-[13px] text-destructive">{state.error}</p>
-      )}
-      <div className="space-y-1.5">
-        <Label htmlFor="email">Email</Label>
-        <Input
-          id="email"
-          name="email"
-          type="email"
-          autoComplete="email"
-          required
-          placeholder="you@example.com"
-        />
-      </div>
-      <div className="space-y-1.5">
-        <Label htmlFor="password">Password</Label>
-        <Input
-          id="password"
-          name="password"
-          type="password"
-          autoComplete="current-password"
-          required
-          placeholder="••••••••"
-        />
-      </div>
-      <SubmitButton />
-      <p className="text-center text-[13px] text-muted-gray">
-        Don&apos;t have an account?{" "}
-        <Link
-          href="/register"
-          className="text-charcoal underline underline-offset-4"
-        >
-          Create one
-        </Link>
-      </p>
-    </form>
-  );
-}
-```
-
-- [ ] **Step 3: Run Biome**
-
-```bash
-pnpm biome check --write .
-```
-
-Expected: No errors.
-
-- [ ] **Step 4: Commit**
-
-```bash
-git add app/(auth)/login/page.tsx app/(auth)/login/login-form.tsx
-git commit -m "feat: add login page and form with Server Action + error display"
-```
-
----
-
-## Task 7: Register page and form
-
-**Files:**
-- Create: `app/(auth)/register/page.tsx`
-- Create: `app/(auth)/register/register-form.tsx`
-
-- [ ] **Step 1: Create the register page (Server Component)**
-
-Create `app/(auth)/register/page.tsx`:
-
-```tsx
-import { createClient } from "@/lib/supabase/server";
-import { redirect } from "next/navigation";
-import { RegisterForm } from "./register-form";
-
-export default async function RegisterPage() {
-  const supabase = createClient();
-  const {
-    data: { user },
-  } = await supabase.auth.getUser();
-
-  if (user) {
-    redirect("/chat");
-  }
-
-  return (
-    <div>
-      <p className="text-[11px] uppercase tracking-[0.08em] text-muted-gray mb-2">
-        Cervix Health Assistant
-      </p>
-      <h1 className="text-[28px] font-semibold tracking-[-0.5px] text-charcoal mb-1">
-        Create account
-      </h1>
-      <p className="text-[14px] text-muted-gray mb-8">
-        Start your health journey.
-      </p>
-      <RegisterForm />
-    </div>
-  );
-}
-```
-
-- [ ] **Step 2: Create the register form (Client Component)**
-
-Create `app/(auth)/register/register-form.tsx`:
-
-```tsx
-"use client";
-
-import { Button } from "@/components/ui/button";
-import { Input } from "@/components/ui/input";
-import { Label } from "@/components/ui/label";
-import { signUp } from "@/lib/actions/auth";
-import type { AuthState } from "@/lib/actions/auth";
-import Link from "next/link";
-import { useFormState, useFormStatus } from "react-dom";
-
-const initialState: AuthState = {};
-
-function SubmitButton() {
-  const { pending } = useFormStatus();
-  return (
-    <Button type="submit" disabled={pending} className="w-full">
-      {pending ? "Creating account…" : "Create account"}
-    </Button>
-  );
-}
-
-export function RegisterForm() {
-  const [state, formAction] = useFormState(signUp, initialState);
-
-  if (state.success) {
-    return (
-      <div className="space-y-4 text-center">
-        <p className="text-[28px] font-semibold tracking-[-0.5px] text-charcoal">
-          Check your email
-        </p>
-        <p className="text-[14px] text-muted-gray">
-          We sent a confirmation link to your inbox. Click it to activate your
-          account.
-        </p>
-        <p className="text-[13px] text-muted-gray">
-          Already confirmed?{" "}
-          <Link
-            href="/login"
-            className="text-charcoal underline underline-offset-4"
-          >
-            Sign in
-          </Link>
-        </p>
-      </div>
-    );
-  }
-
-  return (
-    <form action={formAction} className="space-y-4">
-      {state.error && (
-        <p className="text-[13px] text-destructive">{state.error}</p>
-      )}
-      <div className="space-y-1.5">
-        <Label htmlFor="email">Email</Label>
-        <Input
-          id="email"
-          name="email"
-          type="email"
-          autoComplete="email"
-          required
-          placeholder="you@example.com"
-        />
-      </div>
-      <div className="space-y-1.5">
-        <Label htmlFor="password">Password</Label>
-        <Input
-          id="password"
-          name="password"
-          type="password"
-          autoComplete="new-password"
-          required
-          placeholder="••••••••"
-        />
-      </div>
-      <SubmitButton />
-      <p className="text-center text-[13px] text-muted-gray">
-        Already have an account?{" "}
-        <Link
-          href="/login"
-          className="text-charcoal underline underline-offset-4"
-        >
-          Sign in
-        </Link>
-      </p>
-    </form>
-  );
-}
-```
-
-- [ ] **Step 3: Run Biome**
-
-```bash
-pnpm biome check --write .
-```
-
-Expected: No errors.
-
-- [ ] **Step 4: Commit**
-
-```bash
-git add app/(auth)/register/page.tsx app/(auth)/register/register-form.tsx
-git commit -m "feat: add register page and form with email confirmation gate"
-```
-
----
-
-## Task 8: Minimal app shell with sign-out
-
-This task creates the minimum needed to verify the sign-out acceptance criterion and give the middleware a target route. The full app shell (nav, layout design) belongs to a later epic.
+The middleware needs a protected target route to redirect to after login. This task adds the minimum: a pass-through `(app)` layout and a placeholder `/chat` page with a sign-out button, so the sign-out acceptance criterion is verifiable.
 
 **Files:**
 - Create: `app/(app)/layout.tsx`
 - Create: `app/(app)/chat/page.tsx`
+- Create: `app/(app)/chat/sign-out-button.tsx`
 
 - [ ] **Step 1: Create the (app) layout**
 
@@ -875,61 +344,81 @@ export default function AppLayout({
 }
 ```
 
-- [ ] **Step 2: Create the placeholder chat page with sign-out**
+- [ ] **Step 2: Create the sign-out button (client component)**
+
+Create `app/(app)/chat/sign-out-button.tsx`:
+
+```tsx
+"use client";
+
+import { createClient } from "@/lib/supabase/browser";
+import { useRouter } from "next/navigation";
+
+export function SignOutButton() {
+  const router = useRouter();
+
+  async function handleSignOut() {
+    const supabase = createClient();
+    await supabase.auth.signOut();
+    router.push("/login");
+  }
+
+  return (
+    <button
+      type="button"
+      onClick={handleSignOut}
+      className="text-[13px] text-muted-gray underline underline-offset-4"
+    >
+      Sign out
+    </button>
+  );
+}
+```
+
+- [ ] **Step 3: Create the placeholder chat page**
 
 Create `app/(app)/chat/page.tsx`:
 
 ```tsx
-import { signOut } from "@/lib/actions/auth";
+import { SignOutButton } from "./sign-out-button";
 
 export default function ChatPage() {
   return (
     <main className="min-h-screen bg-cream p-8">
       <h1 className="text-2xl font-semibold text-charcoal">Chat</h1>
       <p className="mt-2 text-muted-gray">Coming soon.</p>
-      <form action={signOut} className="mt-8">
-        <button
-          type="submit"
-          className="text-[13px] text-muted-gray underline underline-offset-4"
-        >
-          Sign out
-        </button>
-      </form>
+      <div className="mt-8">
+        <SignOutButton />
+      </div>
     </main>
   );
 }
 ```
 
-- [ ] **Step 3: Run the full test suite and Biome**
+- [ ] **Step 4: Run Biome and full check**
 
 ```bash
-pnpm test && pnpm biome check .
+pnpm biome check --write .
 ```
 
-Expected: All tests pass, no Biome errors.
+Expected: No errors.
 
-- [ ] **Step 4: Commit**
+- [ ] **Step 5: Commit**
 
 ```bash
-git add app/(app)/layout.tsx app/(app)/chat/page.tsx
+git add app/\(app\)/layout.tsx app/\(app\)/chat/page.tsx app/\(app\)/chat/sign-out-button.tsx
 git commit -m "feat: add minimal app shell and chat placeholder with sign-out"
 ```
 
 ---
 
-## Self-Review Checklist
+## Acceptance Criteria Verification
 
-- [x] **Spec coverage**
-  - `lib/supabase/browser.ts` exports browser client → already done, no task needed ✓
-  - `lib/supabase/server.ts` exports server client with cookie handling → already done ✓
-  - Sessions persist (cookie-based) → middleware `setAll` writes cookies on every request ✓
-  - Sign-out clears session and redirects to `/login` → Task 2 + Task 8 ✓
-  - Auth state accessible via `supabase.auth.getUser()` → used in login/register page.tsx ✓
-  - Biome passes → `pnpm biome check --write .` at end of every task ✓
-
-- [x] **No placeholders** — all steps have complete code blocks ✓
-
-- [x] **Type consistency**
-  - `AuthState` defined once in `lib/actions/auth.ts`, imported by both form components ✓
-  - `signIn(prevState: AuthState, formData: FormData)` signature matches `useFormState(signIn, initialState)` ✓
-  - `signOut()` returns `Promise<void>`, used as direct form `action={signOut}` ✓
+| AC | Satisfied by |
+|---|---|
+| `lib/supabase/browser.ts` exports browser client | ✅ Already on branch |
+| `lib/supabase/server.ts` exports server client with cookie handling | ✅ Already on branch |
+| Sessions persist across page refreshes (cookie-based) | ✅ `@supabase/ssr` + middleware `setAll` refreshes cookies on every request (Task 2) |
+| Sign-out clears session and redirects to `/login` | Task 3 — `SignOutButton` calls `supabase.auth.signOut()` then `router.push('/login')` |
+| Auth state accessible in Server Components via `supabase.auth.getUser()` | ✅ Server client available via `createClient()` from `lib/supabase/server.ts` |
+| Biome passes with no errors | Verified at end of each task |

--- a/docs/superpowers/plans/2026-04-12-epic2-supabase-auth.md
+++ b/docs/superpowers/plans/2026-04-12-epic2-supabase-auth.md
@@ -1,0 +1,935 @@
+# Epic 2 — Supabase Auth: Email/Password Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Wire up Supabase Auth email/password — Server Actions, middleware route protection, login/register pages with email confirmation gate, and sign-out.
+
+**Architecture:** Server Actions (`lib/actions/auth.ts`) handle all auth mutations using the server-side Supabase client. A Next.js middleware guards `/(app)/*` routes by calling `supabase.auth.getUser()` on every request and refreshing the session cookie. Client form components use `useFormState` from `react-dom` to display Server Action results without a page reload.
+
+**Tech Stack:** `@supabase/ssr ^0.10.2`, `zod` (to be added), `next/navigation` redirect, `useFormState`/`useFormStatus` from `react-dom`, Tailwind CSS design tokens, `@base-ui/react` + custom Input/Label components.
+
+---
+
+## File Map
+
+| File | Status | Purpose |
+|---|---|---|
+| `lib/actions/auth.ts` | Create | Server Actions: `signIn`, `signUp`, `signOut` |
+| `lib/actions/auth.test.ts` | Create | Vitest unit tests for all three actions |
+| `middleware.ts` | Create | Session refresh + route guard for `/(app)/*` |
+| `app/api/auth/callback/route.ts` | Create | Exchange confirmation code → session → redirect |
+| `app/(auth)/layout.tsx` | Create | Centered cream layout wrapping auth pages |
+| `app/(auth)/login/page.tsx` | Create | Server Component: session check + pass error prop |
+| `app/(auth)/login/login-form.tsx` | Create | `'use client'` form with `useFormState(signIn)` |
+| `app/(auth)/register/page.tsx` | Create | Server Component wrapper |
+| `app/(auth)/register/register-form.tsx` | Create | `'use client'` form with "check your email" state |
+| `app/(app)/layout.tsx` | Create | Minimal pass-through layout for protected routes |
+| `app/(app)/chat/page.tsx` | Create | Placeholder page with sign-out button (verifies AC) |
+| `components/ui/input.tsx` | Create | Styled native input (no shadcn CLI needed) |
+| `components/ui/label.tsx` | Create | Styled native label |
+
+**Existing — no changes needed:**
+- `lib/supabase/browser.ts` — `createBrowserClient` already wired ✓
+- `lib/supabase/server.ts` — `createServerClient` + cookie handling already wired ✓
+
+---
+
+## Task 1: Install Zod and create Input/Label components
+
+**Files:**
+- Modify: `package.json` (new dep via pnpm)
+- Create: `components/ui/input.tsx`
+- Create: `components/ui/label.tsx`
+
+- [ ] **Step 1: Add zod as a direct dependency**
+
+```bash
+cd /Users/Najum/cervix-assistant && pnpm add zod
+```
+
+Expected: `package.json` gains `"zod": "^3.x.x"` under `dependencies`. Lockfile updated.
+
+- [ ] **Step 2: Create Input component**
+
+Create `components/ui/input.tsx`:
+
+```tsx
+import { cn } from "@/lib/utils";
+import type { InputHTMLAttributes } from "react";
+
+function Input({
+  className,
+  ...props
+}: InputHTMLAttributes<HTMLInputElement>) {
+  return (
+    <input
+      className={cn(
+        "flex w-full rounded-standard bg-off-white px-3 py-[9px] text-sm text-charcoal",
+        "border border-charcoal/40",
+        "placeholder:text-muted-gray",
+        "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring",
+        "disabled:cursor-not-allowed disabled:opacity-50",
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+export { Input };
+```
+
+- [ ] **Step 3: Create Label component**
+
+Create `components/ui/label.tsx`:
+
+```tsx
+import { cn } from "@/lib/utils";
+import type { LabelHTMLAttributes } from "react";
+
+function Label({
+  className,
+  ...props
+}: LabelHTMLAttributes<HTMLLabelElement>) {
+  return (
+    <label
+      className={cn("block text-[13px] font-semibold text-charcoal", className)}
+      {...props}
+    />
+  );
+}
+
+export { Label };
+```
+
+- [ ] **Step 4: Run Biome**
+
+```bash
+pnpm biome check --write .
+```
+
+Expected: No errors.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add components/ui/input.tsx components/ui/label.tsx package.json pnpm-lock.yaml
+git commit -m "feat: add zod dep and Input/Label UI primitives"
+```
+
+---
+
+## Task 2: Server Actions (TDD)
+
+**Files:**
+- Create: `lib/actions/auth.ts`
+- Create: `lib/actions/auth.test.ts`
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `lib/actions/auth.test.ts`:
+
+```typescript
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("next/navigation", () => ({
+  redirect: vi.fn(),
+}));
+
+const { mockSignInWithPassword, mockSignUp, mockSignOut } = vi.hoisted(() => ({
+  mockSignInWithPassword: vi.fn(),
+  mockSignUp: vi.fn(),
+  mockSignOut: vi.fn(),
+}));
+
+vi.mock("@/lib/supabase/server", () => ({
+  createClient: vi.fn(() => ({
+    auth: {
+      signInWithPassword: mockSignInWithPassword,
+      signUp: mockSignUp,
+      signOut: mockSignOut,
+    },
+  })),
+}));
+
+import { redirect } from "next/navigation";
+import { signIn, signOut, signUp } from "@/lib/actions/auth";
+
+function makeFormData(fields: Record<string, string>): FormData {
+  const fd = new FormData();
+  for (const [key, value] of Object.entries(fields)) {
+    fd.append(key, value);
+  }
+  return fd;
+}
+
+describe("signIn", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("returns error for invalid email format", async () => {
+    const result = await signIn(
+      {},
+      makeFormData({ email: "not-an-email", password: "password123" }),
+    );
+    expect(result).toEqual({ error: "Please enter a valid email address" });
+    expect(mockSignInWithPassword).not.toHaveBeenCalled();
+  });
+
+  it("returns error when password is fewer than 6 characters", async () => {
+    const result = await signIn(
+      {},
+      makeFormData({ email: "user@example.com", password: "abc" }),
+    );
+    expect(result).toEqual({ error: "Password must be at least 6 characters" });
+    expect(mockSignInWithPassword).not.toHaveBeenCalled();
+  });
+
+  it("returns error when Supabase returns an auth error", async () => {
+    mockSignInWithPassword.mockResolvedValueOnce({
+      error: { message: "Invalid login credentials" },
+    });
+    const result = await signIn(
+      {},
+      makeFormData({ email: "user@example.com", password: "correctpassword" }),
+    );
+    expect(result).toEqual({ error: "Invalid login credentials" });
+  });
+
+  it("calls redirect('/chat') on success", async () => {
+    mockSignInWithPassword.mockResolvedValueOnce({ error: null });
+    await signIn(
+      {},
+      makeFormData({ email: "user@example.com", password: "correctpassword" }),
+    );
+    expect(redirect).toHaveBeenCalledWith("/chat");
+  });
+});
+
+describe("signUp", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("returns error for invalid email format", async () => {
+    const result = await signUp(
+      {},
+      makeFormData({ email: "bad", password: "password123" }),
+    );
+    expect(result).toEqual({ error: "Please enter a valid email address" });
+    expect(mockSignUp).not.toHaveBeenCalled();
+  });
+
+  it("returns error when password is fewer than 8 characters", async () => {
+    const result = await signUp(
+      {},
+      makeFormData({ email: "user@example.com", password: "abc123" }),
+    );
+    expect(result).toEqual({ error: "Password must be at least 8 characters" });
+    expect(mockSignUp).not.toHaveBeenCalled();
+  });
+
+  it("returns error when Supabase returns an error", async () => {
+    mockSignUp.mockResolvedValueOnce({
+      error: { message: "User already registered" },
+    });
+    const result = await signUp(
+      {},
+      makeFormData({ email: "user@example.com", password: "password123" }),
+    );
+    expect(result).toEqual({ error: "User already registered" });
+  });
+
+  it("returns { success: true } and does NOT redirect on success", async () => {
+    mockSignUp.mockResolvedValueOnce({ error: null });
+    const result = await signUp(
+      {},
+      makeFormData({ email: "newuser@example.com", password: "password123" }),
+    );
+    expect(result).toEqual({ success: true });
+    expect(redirect).not.toHaveBeenCalled();
+  });
+});
+
+describe("signOut", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockSignOut.mockResolvedValueOnce({ error: null });
+  });
+
+  it("calls supabase.auth.signOut() and redirects to /login", async () => {
+    await signOut();
+    expect(mockSignOut).toHaveBeenCalled();
+    expect(redirect).toHaveBeenCalledWith("/login");
+  });
+});
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+```bash
+pnpm test -- lib/actions/auth.test.ts
+```
+
+Expected: Tests fail with `Cannot find module '@/lib/actions/auth'` or similar — the implementation file doesn't exist yet.
+
+- [ ] **Step 3: Write the Server Actions implementation**
+
+Create `lib/actions/auth.ts`:
+
+```typescript
+"use server";
+
+import { createClient } from "@/lib/supabase/server";
+import { redirect } from "next/navigation";
+import { z } from "zod";
+
+const signInSchema = z.object({
+  email: z.string().email("Please enter a valid email address"),
+  password: z.string().min(6, "Password must be at least 6 characters"),
+});
+
+const signUpSchema = z.object({
+  email: z.string().email("Please enter a valid email address"),
+  password: z.string().min(8, "Password must be at least 8 characters"),
+});
+
+export type AuthState = {
+  error?: string;
+  success?: boolean;
+};
+
+export async function signIn(
+  _prevState: AuthState,
+  formData: FormData,
+): Promise<AuthState> {
+  const parsed = signInSchema.safeParse({
+    email: formData.get("email"),
+    password: formData.get("password"),
+  });
+
+  if (!parsed.success) {
+    return { error: parsed.error.issues[0].message };
+  }
+
+  const supabase = createClient();
+  const { error } = await supabase.auth.signInWithPassword(parsed.data);
+
+  if (error) {
+    return { error: error.message };
+  }
+
+  redirect("/chat");
+}
+
+export async function signUp(
+  _prevState: AuthState,
+  formData: FormData,
+): Promise<AuthState> {
+  const parsed = signUpSchema.safeParse({
+    email: formData.get("email"),
+    password: formData.get("password"),
+  });
+
+  if (!parsed.success) {
+    return { error: parsed.error.issues[0].message };
+  }
+
+  const supabase = createClient();
+  const { error } = await supabase.auth.signUp(parsed.data);
+
+  if (error) {
+    return { error: error.message };
+  }
+
+  return { success: true };
+}
+
+export async function signOut(): Promise<void> {
+  const supabase = createClient();
+  await supabase.auth.signOut();
+  redirect("/login");
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+```bash
+pnpm test -- lib/actions/auth.test.ts
+```
+
+Expected: All 9 tests pass. If any fail, read the error and fix before continuing.
+
+- [ ] **Step 5: Run Biome**
+
+```bash
+pnpm biome check --write .
+```
+
+Expected: No errors.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add lib/actions/auth.ts lib/actions/auth.test.ts
+git commit -m "feat: add signIn/signUp/signOut Server Actions with Zod validation"
+```
+
+---
+
+## Task 3: Middleware
+
+**Files:**
+- Create: `middleware.ts`
+
+- [ ] **Step 1: Create the middleware**
+
+Create `middleware.ts` at the project root:
+
+```typescript
+import { createServerClient } from "@supabase/ssr";
+import { NextResponse, type NextRequest } from "next/server";
+
+// Routes that require an authenticated session.
+// These are the URL paths for app/(app)/* — route group parentheses don't appear in URLs.
+const PROTECTED_PATHS = ["/chat", "/clinics", "/learn", "/profile", "/admin"];
+
+function isProtected(pathname: string): boolean {
+  return PROTECTED_PATHS.some(
+    (p) => pathname === p || pathname.startsWith(`${p}/`),
+  );
+}
+
+export async function middleware(request: NextRequest) {
+  // supabaseResponse must be returned (not a plain NextResponse.next()) so that
+  // cookie mutations from setAll() are forwarded to the browser.
+  let supabaseResponse = NextResponse.next({ request });
+
+  const supabase = createServerClient(
+    process.env.NEXT_PUBLIC_SUPABASE_URL!,
+    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!,
+    {
+      cookies: {
+        getAll() {
+          return request.cookies.getAll();
+        },
+        setAll(cookiesToSet) {
+          // Write to request first (required by @supabase/ssr)
+          for (const { name, value } of cookiesToSet) {
+            request.cookies.set(name, value);
+          }
+          // Rebuild the response so updated cookies are set on it
+          supabaseResponse = NextResponse.next({ request });
+          for (const { name, value, options } of cookiesToSet) {
+            supabaseResponse.cookies.set(name, value, options);
+          }
+        },
+      },
+    },
+  );
+
+  // IMPORTANT: use getUser() not getSession() — getUser() validates the token
+  // server-side and rotates the refresh token; getSession() only reads the cookie.
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+
+  if (!user && isProtected(request.nextUrl.pathname)) {
+    const url = request.nextUrl.clone();
+    url.pathname = "/login";
+    return NextResponse.redirect(url);
+  }
+
+  return supabaseResponse;
+}
+
+export const config = {
+  matcher: [
+    // Match all routes except Next.js internals and static files
+    "/((?!_next/static|_next/image|favicon.ico|.*\\.(?:svg|png|jpg|jpeg|gif|webp)$).*)",
+  ],
+};
+```
+
+- [ ] **Step 2: Run Biome**
+
+```bash
+pnpm biome check --write .
+```
+
+Expected: No errors.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add middleware.ts
+git commit -m "feat: add middleware to protect /(app)/* routes and refresh session cookies"
+```
+
+---
+
+## Task 4: Auth callback route
+
+**Files:**
+- Create: `app/api/auth/callback/route.ts`
+
+- [ ] **Step 1: Create the callback route handler**
+
+Create `app/api/auth/callback/route.ts`:
+
+```typescript
+import { createClient } from "@/lib/supabase/server";
+import { type NextRequest, NextResponse } from "next/server";
+
+export async function GET(request: NextRequest) {
+  const { searchParams, origin } = new URL(request.url);
+  const code = searchParams.get("code");
+
+  if (code) {
+    const supabase = createClient();
+    const { error } = await supabase.auth.exchangeCodeForSession(code);
+    if (!error) {
+      return NextResponse.redirect(`${origin}/chat`);
+    }
+  }
+
+  // Missing or invalid code — send user back to login with an error notice
+  return NextResponse.redirect(`${origin}/login?error=confirmation_failed`);
+}
+```
+
+- [ ] **Step 2: Run Biome**
+
+```bash
+pnpm biome check --write .
+```
+
+Expected: No errors.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add app/api/auth/callback/route.ts
+git commit -m "feat: add auth callback route to exchange confirmation code for session"
+```
+
+---
+
+## Task 5: Auth layout
+
+**Files:**
+- Create: `app/(auth)/layout.tsx`
+
+- [ ] **Step 1: Create the auth layout**
+
+Create `app/(auth)/layout.tsx`:
+
+```tsx
+export default function AuthLayout({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  return (
+    <div className="min-h-screen bg-cream flex items-center justify-center px-4">
+      <div className="w-full max-w-[360px]">{children}</div>
+    </div>
+  );
+}
+```
+
+- [ ] **Step 2: Run Biome**
+
+```bash
+pnpm biome check --write .
+```
+
+Expected: No errors.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add app/(auth)/layout.tsx
+git commit -m "feat: add auth layout with centered cream column"
+```
+
+---
+
+## Task 6: Login page and form
+
+**Files:**
+- Create: `app/(auth)/login/page.tsx`
+- Create: `app/(auth)/login/login-form.tsx`
+
+- [ ] **Step 1: Create the login page (Server Component)**
+
+Create `app/(auth)/login/page.tsx`:
+
+```tsx
+import { createClient } from "@/lib/supabase/server";
+import { redirect } from "next/navigation";
+import { LoginForm } from "./login-form";
+
+export default async function LoginPage({
+  searchParams,
+}: {
+  searchParams: { error?: string };
+}) {
+  const supabase = createClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+
+  if (user) {
+    redirect("/chat");
+  }
+
+  const confirmationError =
+    searchParams.error === "confirmation_failed"
+      ? "Confirmation link expired — please sign in or register again."
+      : undefined;
+
+  return (
+    <div>
+      <p className="text-[11px] uppercase tracking-[0.08em] text-muted-gray mb-2">
+        Cervix Health Assistant
+      </p>
+      <h1 className="text-[28px] font-semibold tracking-[-0.5px] text-charcoal mb-1">
+        Sign in
+      </h1>
+      <p className="text-[14px] text-muted-gray mb-8">Welcome back.</p>
+      <LoginForm confirmationError={confirmationError} />
+    </div>
+  );
+}
+```
+
+- [ ] **Step 2: Create the login form (Client Component)**
+
+Create `app/(auth)/login/login-form.tsx`:
+
+```tsx
+"use client";
+
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { signIn } from "@/lib/actions/auth";
+import type { AuthState } from "@/lib/actions/auth";
+import Link from "next/link";
+import { useFormState, useFormStatus } from "react-dom";
+
+const initialState: AuthState = {};
+
+function SubmitButton() {
+  const { pending } = useFormStatus();
+  return (
+    <Button type="submit" disabled={pending} className="w-full">
+      {pending ? "Signing in…" : "Sign in"}
+    </Button>
+  );
+}
+
+export function LoginForm({
+  confirmationError,
+}: {
+  confirmationError?: string;
+}) {
+  const [state, formAction] = useFormState(signIn, initialState);
+
+  return (
+    <form action={formAction} className="space-y-4">
+      {confirmationError && (
+        <p className="text-[13px] text-destructive">{confirmationError}</p>
+      )}
+      {state.error && (
+        <p className="text-[13px] text-destructive">{state.error}</p>
+      )}
+      <div className="space-y-1.5">
+        <Label htmlFor="email">Email</Label>
+        <Input
+          id="email"
+          name="email"
+          type="email"
+          autoComplete="email"
+          required
+          placeholder="you@example.com"
+        />
+      </div>
+      <div className="space-y-1.5">
+        <Label htmlFor="password">Password</Label>
+        <Input
+          id="password"
+          name="password"
+          type="password"
+          autoComplete="current-password"
+          required
+          placeholder="••••••••"
+        />
+      </div>
+      <SubmitButton />
+      <p className="text-center text-[13px] text-muted-gray">
+        Don&apos;t have an account?{" "}
+        <Link
+          href="/register"
+          className="text-charcoal underline underline-offset-4"
+        >
+          Create one
+        </Link>
+      </p>
+    </form>
+  );
+}
+```
+
+- [ ] **Step 3: Run Biome**
+
+```bash
+pnpm biome check --write .
+```
+
+Expected: No errors.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add app/(auth)/login/page.tsx app/(auth)/login/login-form.tsx
+git commit -m "feat: add login page and form with Server Action + error display"
+```
+
+---
+
+## Task 7: Register page and form
+
+**Files:**
+- Create: `app/(auth)/register/page.tsx`
+- Create: `app/(auth)/register/register-form.tsx`
+
+- [ ] **Step 1: Create the register page (Server Component)**
+
+Create `app/(auth)/register/page.tsx`:
+
+```tsx
+import { createClient } from "@/lib/supabase/server";
+import { redirect } from "next/navigation";
+import { RegisterForm } from "./register-form";
+
+export default async function RegisterPage() {
+  const supabase = createClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+
+  if (user) {
+    redirect("/chat");
+  }
+
+  return (
+    <div>
+      <p className="text-[11px] uppercase tracking-[0.08em] text-muted-gray mb-2">
+        Cervix Health Assistant
+      </p>
+      <h1 className="text-[28px] font-semibold tracking-[-0.5px] text-charcoal mb-1">
+        Create account
+      </h1>
+      <p className="text-[14px] text-muted-gray mb-8">
+        Start your health journey.
+      </p>
+      <RegisterForm />
+    </div>
+  );
+}
+```
+
+- [ ] **Step 2: Create the register form (Client Component)**
+
+Create `app/(auth)/register/register-form.tsx`:
+
+```tsx
+"use client";
+
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { signUp } from "@/lib/actions/auth";
+import type { AuthState } from "@/lib/actions/auth";
+import Link from "next/link";
+import { useFormState, useFormStatus } from "react-dom";
+
+const initialState: AuthState = {};
+
+function SubmitButton() {
+  const { pending } = useFormStatus();
+  return (
+    <Button type="submit" disabled={pending} className="w-full">
+      {pending ? "Creating account…" : "Create account"}
+    </Button>
+  );
+}
+
+export function RegisterForm() {
+  const [state, formAction] = useFormState(signUp, initialState);
+
+  if (state.success) {
+    return (
+      <div className="space-y-4 text-center">
+        <p className="text-[28px] font-semibold tracking-[-0.5px] text-charcoal">
+          Check your email
+        </p>
+        <p className="text-[14px] text-muted-gray">
+          We sent a confirmation link to your inbox. Click it to activate your
+          account.
+        </p>
+        <p className="text-[13px] text-muted-gray">
+          Already confirmed?{" "}
+          <Link
+            href="/login"
+            className="text-charcoal underline underline-offset-4"
+          >
+            Sign in
+          </Link>
+        </p>
+      </div>
+    );
+  }
+
+  return (
+    <form action={formAction} className="space-y-4">
+      {state.error && (
+        <p className="text-[13px] text-destructive">{state.error}</p>
+      )}
+      <div className="space-y-1.5">
+        <Label htmlFor="email">Email</Label>
+        <Input
+          id="email"
+          name="email"
+          type="email"
+          autoComplete="email"
+          required
+          placeholder="you@example.com"
+        />
+      </div>
+      <div className="space-y-1.5">
+        <Label htmlFor="password">Password</Label>
+        <Input
+          id="password"
+          name="password"
+          type="password"
+          autoComplete="new-password"
+          required
+          placeholder="••••••••"
+        />
+      </div>
+      <SubmitButton />
+      <p className="text-center text-[13px] text-muted-gray">
+        Already have an account?{" "}
+        <Link
+          href="/login"
+          className="text-charcoal underline underline-offset-4"
+        >
+          Sign in
+        </Link>
+      </p>
+    </form>
+  );
+}
+```
+
+- [ ] **Step 3: Run Biome**
+
+```bash
+pnpm biome check --write .
+```
+
+Expected: No errors.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add app/(auth)/register/page.tsx app/(auth)/register/register-form.tsx
+git commit -m "feat: add register page and form with email confirmation gate"
+```
+
+---
+
+## Task 8: Minimal app shell with sign-out
+
+This task creates the minimum needed to verify the sign-out acceptance criterion and give the middleware a target route. The full app shell (nav, layout design) belongs to a later epic.
+
+**Files:**
+- Create: `app/(app)/layout.tsx`
+- Create: `app/(app)/chat/page.tsx`
+
+- [ ] **Step 1: Create the (app) layout**
+
+Create `app/(app)/layout.tsx`:
+
+```tsx
+export default function AppLayout({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  return <>{children}</>;
+}
+```
+
+- [ ] **Step 2: Create the placeholder chat page with sign-out**
+
+Create `app/(app)/chat/page.tsx`:
+
+```tsx
+import { signOut } from "@/lib/actions/auth";
+
+export default function ChatPage() {
+  return (
+    <main className="min-h-screen bg-cream p-8">
+      <h1 className="text-2xl font-semibold text-charcoal">Chat</h1>
+      <p className="mt-2 text-muted-gray">Coming soon.</p>
+      <form action={signOut} className="mt-8">
+        <button
+          type="submit"
+          className="text-[13px] text-muted-gray underline underline-offset-4"
+        >
+          Sign out
+        </button>
+      </form>
+    </main>
+  );
+}
+```
+
+- [ ] **Step 3: Run the full test suite and Biome**
+
+```bash
+pnpm test && pnpm biome check .
+```
+
+Expected: All tests pass, no Biome errors.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add app/(app)/layout.tsx app/(app)/chat/page.tsx
+git commit -m "feat: add minimal app shell and chat placeholder with sign-out"
+```
+
+---
+
+## Self-Review Checklist
+
+- [x] **Spec coverage**
+  - `lib/supabase/browser.ts` exports browser client → already done, no task needed ✓
+  - `lib/supabase/server.ts` exports server client with cookie handling → already done ✓
+  - Sessions persist (cookie-based) → middleware `setAll` writes cookies on every request ✓
+  - Sign-out clears session and redirects to `/login` → Task 2 + Task 8 ✓
+  - Auth state accessible via `supabase.auth.getUser()` → used in login/register page.tsx ✓
+  - Biome passes → `pnpm biome check --write .` at end of every task ✓
+
+- [x] **No placeholders** — all steps have complete code blocks ✓
+
+- [x] **Type consistency**
+  - `AuthState` defined once in `lib/actions/auth.ts`, imported by both form components ✓
+  - `signIn(prevState: AuthState, formData: FormData)` signature matches `useFormState(signIn, initialState)` ✓
+  - `signOut()` returns `Promise<void>`, used as direct form `action={signOut}` ✓

--- a/docs/superpowers/plans/2026-04-14-epic2-profile-edit-page.md
+++ b/docs/superpowers/plans/2026-04-14-epic2-profile-edit-page.md
@@ -1,0 +1,853 @@
+# Epic 2 / #15 / User Profile Edit Page Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Build `/profile` where authenticated users can update `display_name`, `locale` (en/zh), and password, with two independent save flows, Zod-validated forms using React Hook Form, and success/error feedback per card.
+
+**Architecture:** A Server Component (`app/(app)/profile/page.tsx`) fetches `email` and the user's `profiles` row server-side using `lib/supabase/server.ts`, then renders two client subforms. `profile-info-form.tsx` writes `display_name`/`locale` via `supabase.from('profiles').update(...)` using the browser client. `password-form.tsx` calls `supabase.auth.updateUser({ password })` using the same browser client. RLS already permits self-update. Middleware already gates `/profile/*`. Validation lives in a new `lib/validations/profile.ts`, unit-tested with Vitest. Component behavior is manually verified; no component-level tests.
+
+**Tech Stack:** Next.js 14 App Router (Server + Client Components), TypeScript (strict), Supabase JS v2 (`@supabase/ssr`), React Hook Form + `@hookform/resolvers/zod`, Zod (`zod/v3` sub-path), Tailwind CSS, shadcn/ui primitives, Vitest for schema tests, Biome for lint/format.
+
+**Issue:** Epic 2 / #15 / User Profile Edit Page
+
+**Depends on:**
+- Epic 2 / #10 (Supabase Auth email+password, middleware) - already landed.
+- Epic 2 / #11 (profiles table + `is_admin` helper + auto-create trigger) - already landed.
+- Epic 2 / #12 (RLS policies for profiles) - already landed. The "profiles: self or admin can update" policy is what enables this feature.
+
+**Ticket acceptance criteria (AC):**
+1. `/profile` accessible to authenticated users only.
+2. Form shows current `display_name` and `locale` from `profiles`.
+3. User can update `display_name` - saved via Supabase client.
+4. User can change locale (EN or ZH) - saved to `profiles.locale`.
+5. User can change password via `supabase.auth.updateUser({ password })`.
+6. Success/error feedback shown after save.
+7. Page uses cream background and design-token system.
+8. Biome passes with no errors.
+
+---
+
+## File Structure
+
+| File | Change | Responsibility |
+|---|---|---|
+| `lib/validations/profile.ts` | Create | Zod schemas: `LOCALES`, `profileInfoSchema`, `passwordSchema`. Single source of truth for both form validations and the exported `Locale` type. |
+| `lib/validations/profile.test.ts` | Create | Vitest unit tests for both schemas. All validation logic is verified here. |
+| `app/(app)/profile/page.tsx` | Create | Server Component. Reads `auth.getUser()` and `profiles` row server-side. Renders page shell + `<ProfileInfoForm>` + `<PasswordForm>`. |
+| `app/(app)/profile/profile-info-form.tsx` | Create | "use client". RHF form for `display_name` + `locale` with segmented control. Uses browser Supabase client for the update and calls `router.refresh()` on success. |
+| `app/(app)/profile/password-form.tsx` | Create | "use client". RHF form for new password + confirm. Uses browser Supabase client to call `auth.updateUser({ password })`. |
+
+**Files not touched:**
+- `middleware.ts` - `/profile/*` is already in `PROTECTED_PATHS`.
+- `lib/supabase/server.ts`, `lib/supabase/browser.ts` - reused as-is.
+- `types/supabase.ts` - already has the `profiles` Row type from earlier migrations.
+- `supabase/migrations/*` - RLS already allows self-update.
+- `components/ui/*` - consuming existing shadcn primitives unchanged.
+- `tailwind.config.ts`, `app/globals.css` - existing tokens (`bg-cream`, `text-charcoal`, `text-muted-gray`, `border-border`, `rounded-standard`, `rounded-card`) are sufficient.
+
+**Design-token classes this plan relies on** (confirmed in `tailwind.config.ts` and `app/globals.css`):
+- `bg-cream` (#f7f4ed) for backgrounds.
+- `text-charcoal` (#1c1c1c) for primary text.
+- `text-muted-gray` (#5f5f5d) for secondary labels.
+- `border-border` (shadcn CSS var mapped to #eceae4) for card borders.
+- `rounded-standard` (6px) for inputs, `rounded-card` (12px) for card containers.
+- `border-destructive/30 bg-destructive/5 text-destructive` for error banner (matches `login-form.tsx`).
+- `border-green-300/30 bg-green-50/50 text-green-700` for success banner (matches `login-form.tsx`).
+
+---
+
+## Task 1: Validation schemas (TDD)
+
+**Files:**
+- Create: `lib/validations/profile.ts`
+- Create: `lib/validations/profile.test.ts`
+
+- [ ] **Step 1: Write failing tests for `profileInfoSchema` and `passwordSchema`**
+
+Create `lib/validations/profile.test.ts` with the full test body:
+
+```ts
+import { describe, expect, it } from "vitest";
+import {
+  LOCALES,
+  type Locale,
+  profileInfoSchema,
+  passwordSchema,
+} from "./profile";
+
+describe("LOCALES", () => {
+  it("contains exactly en and zh", () => {
+    expect(LOCALES).toEqual(["en", "zh"]);
+  });
+});
+
+describe("profileInfoSchema", () => {
+  it("accepts a valid English profile", () => {
+    const result = profileInfoSchema.safeParse({
+      displayName: "Alice",
+      locale: "en",
+    });
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.displayName).toBe("Alice");
+      expect(result.data.locale).toBe("en");
+    }
+  });
+
+  it("accepts a valid Chinese profile", () => {
+    const result = profileInfoSchema.safeParse({
+      displayName: "B",
+      locale: "zh",
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it("trims surrounding whitespace on displayName", () => {
+    const result = profileInfoSchema.safeParse({
+      displayName: "  Alice  ",
+      locale: "en",
+    });
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.displayName).toBe("Alice");
+    }
+  });
+
+  it("rejects an empty displayName", () => {
+    const result = profileInfoSchema.safeParse({
+      displayName: "",
+      locale: "en",
+    });
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.error.issues[0].message).toBe("Display name is required");
+      expect(result.error.issues[0].path).toEqual(["displayName"]);
+    }
+  });
+
+  it("rejects a whitespace-only displayName after trim", () => {
+    const result = profileInfoSchema.safeParse({
+      displayName: "     ",
+      locale: "en",
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects a displayName longer than 60 characters", () => {
+    const result = profileInfoSchema.safeParse({
+      displayName: "a".repeat(61),
+      locale: "en",
+    });
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.error.issues[0].message).toBe(
+        "Display name must be 60 characters or fewer",
+      );
+    }
+  });
+
+  it("accepts a displayName of exactly 60 characters", () => {
+    const result = profileInfoSchema.safeParse({
+      displayName: "a".repeat(60),
+      locale: "en",
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it("rejects an unknown locale", () => {
+    const result = profileInfoSchema.safeParse({
+      displayName: "Alice",
+      locale: "fr" as unknown as Locale,
+    });
+    expect(result.success).toBe(false);
+  });
+});
+
+describe("passwordSchema", () => {
+  it("accepts matching 8-character passwords", () => {
+    const result = passwordSchema.safeParse({
+      password: "abcd1234",
+      confirmPassword: "abcd1234",
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it("rejects a 7-character password", () => {
+    const result = passwordSchema.safeParse({
+      password: "abcd123",
+      confirmPassword: "abcd123",
+    });
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.error.issues[0].message).toBe(
+        "Password must be at least 8 characters",
+      );
+      expect(result.error.issues[0].path).toEqual(["password"]);
+    }
+  });
+
+  it("rejects mismatched confirmation with path confirmPassword", () => {
+    const result = passwordSchema.safeParse({
+      password: "abcd1234",
+      confirmPassword: "abcd1235",
+    });
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      const issue = result.error.issues.find(
+        (i) => i.path[0] === "confirmPassword",
+      );
+      expect(issue).toBeDefined();
+      expect(issue?.message).toBe("Passwords do not match");
+    }
+  });
+});
+```
+
+- [ ] **Step 2: Run the tests to verify they fail with an import error**
+
+Run: `pnpm exec vitest run lib/validations/profile.test.ts`
+
+Expected: FAIL with a module resolution error ("Cannot find module './profile'" or similar) because `lib/validations/profile.ts` does not exist yet.
+
+- [ ] **Step 3: Implement `lib/validations/profile.ts`**
+
+Create `lib/validations/profile.ts` with the full schema body:
+
+```ts
+// lib/validations/profile.ts
+// Import from zod/v3 so @hookform/resolvers' zodResolver Zod-v3 overload
+// matches correctly, same pattern as lib/validations/auth.ts.
+import { z } from "zod/v3";
+
+export const LOCALES = ["en", "zh"] as const;
+export type Locale = (typeof LOCALES)[number];
+
+export const profileInfoSchema = z.object({
+  displayName: z
+    .string()
+    .trim()
+    .min(1, "Display name is required")
+    .max(60, "Display name must be 60 characters or fewer"),
+  locale: z.enum(LOCALES, {
+    errorMap: () => ({ message: "Please choose a language" }),
+  }),
+});
+
+export const passwordSchema = z
+  .object({
+    password: z.string().min(8, "Password must be at least 8 characters"),
+    confirmPassword: z.string(),
+  })
+  .refine((data) => data.password === data.confirmPassword, {
+    message: "Passwords do not match",
+    path: ["confirmPassword"],
+  });
+
+export type ProfileInfoFormValues = z.infer<typeof profileInfoSchema>;
+export type PasswordFormValues = z.infer<typeof passwordSchema>;
+```
+
+- [ ] **Step 4: Run the tests to verify all pass**
+
+Run: `pnpm exec vitest run lib/validations/profile.test.ts`
+
+Expected: 11 tests pass, 0 fail.
+
+- [ ] **Step 5: Run Biome on the new files**
+
+Run: `pnpm biome check --write lib/validations/profile.ts lib/validations/profile.test.ts`
+
+Expected: No errors. If Biome reformats, re-run the tests once more to confirm they still pass.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add lib/validations/profile.ts lib/validations/profile.test.ts
+git commit -m "$(cat <<'EOF'
+feat(profile): add profile and password validation schemas (#15)
+
+Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 2: `ProfileInfoForm` client component
+
+**Files:**
+- Create: `app/(app)/profile/profile-info-form.tsx`
+
+No new tests. This file is a thin wrapper around `profileInfoSchema`, RHF, and the Supabase browser client. Manual verification in Task 5 covers it.
+
+- [ ] **Step 1: Create the file with the full component body**
+
+Create `app/(app)/profile/profile-info-form.tsx`:
+
+```tsx
+// app/(app)/profile/profile-info-form.tsx
+"use client";
+
+import { Button } from "@/components/ui/button";
+import {
+  Form,
+  FormControl,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage,
+} from "@/components/ui/form";
+import { Input } from "@/components/ui/input";
+import { createClient } from "@/lib/supabase/browser";
+import { cn } from "@/lib/utils";
+import {
+  LOCALES,
+  type Locale,
+  type ProfileInfoFormValues,
+  profileInfoSchema,
+} from "@/lib/validations/profile";
+import { zodResolver } from "@hookform/resolvers/zod";
+import { useRouter } from "next/navigation";
+import { useState } from "react";
+import { useForm } from "react-hook-form";
+
+type Props = {
+  email: string;
+  initialDisplayName: string;
+  initialLocale: Locale;
+};
+
+const LOCALE_LABEL: Record<Locale, string> = {
+  en: "English",
+  // The zh label is the two-character native-script word for "Chinese text".
+  // Written via \u escapes to keep this source file ASCII-clean.
+  zh: "\u4e2d\u6587",
+};
+
+export function ProfileInfoForm({
+  email,
+  initialDisplayName,
+  initialLocale,
+}: Props) {
+  const router = useRouter();
+  const [serverError, setServerError] = useState<string | null>(null);
+  const [successMessage, setSuccessMessage] = useState<string | null>(null);
+
+  const form = useForm<ProfileInfoFormValues>({
+    resolver: zodResolver(profileInfoSchema),
+    defaultValues: {
+      displayName: initialDisplayName,
+      locale: initialLocale,
+    },
+  });
+
+  async function onSubmit(values: ProfileInfoFormValues) {
+    setServerError(null);
+    setSuccessMessage(null);
+
+    const supabase = createClient();
+    const {
+      data: { user },
+    } = await supabase.auth.getUser();
+    if (!user) {
+      setServerError("Session expired. Please sign in again.");
+      return;
+    }
+
+    const { error } = await supabase
+      .from("profiles")
+      .update({
+        display_name: values.displayName,
+        locale: values.locale,
+      })
+      .eq("id", user.id);
+
+    if (error) {
+      setServerError(error.message);
+      return;
+    }
+
+    setSuccessMessage("Profile saved");
+    form.reset(values);
+    router.refresh();
+  }
+
+  const { isDirty, isSubmitting } = form.formState;
+
+  return (
+    <section className="rounded-card border border-border bg-cream p-6">
+      <h2 className="text-lg font-semibold text-charcoal mb-4">Profile</h2>
+
+      {successMessage && (
+        <output className="block mb-4 rounded-standard border border-green-300/30 bg-green-50/50 px-3 py-2.5 text-sm text-green-700">
+          {successMessage}
+        </output>
+      )}
+      {serverError && (
+        <div
+          role="alert"
+          className="mb-4 rounded-standard border border-destructive/30 bg-destructive/5 px-3 py-2.5 text-sm text-destructive"
+        >
+          {serverError}
+        </div>
+      )}
+
+      <div className="mb-4">
+        <p className="text-sm font-medium text-charcoal mb-1">Email</p>
+        <p className="text-sm text-muted-gray">{email}</p>
+      </div>
+
+      <Form {...form}>
+        <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-4">
+          <FormField
+            control={form.control}
+            name="displayName"
+            render={({ field }) => (
+              <FormItem>
+                <FormLabel>Display name</FormLabel>
+                <FormControl>
+                  <Input
+                    type="text"
+                    autoComplete="name"
+                    maxLength={60}
+                    placeholder="How you'd like to be addressed"
+                    {...field}
+                  />
+                </FormControl>
+                <FormMessage />
+              </FormItem>
+            )}
+          />
+
+          <FormField
+            control={form.control}
+            name="locale"
+            render={({ field }) => (
+              <FormItem>
+                <FormLabel>Language</FormLabel>
+                <FormControl>
+                  <div
+                    role="radiogroup"
+                    aria-label="Language"
+                    className="inline-flex rounded-standard border border-border bg-cream p-1"
+                  >
+                    {LOCALES.map((code) => (
+                      <button
+                        key={code}
+                        type="button"
+                        role="radio"
+                        aria-checked={field.value === code}
+                        onClick={() => field.onChange(code)}
+                        className={cn(
+                          "px-4 py-1.5 text-sm rounded-standard transition-colors",
+                          field.value === code
+                            ? "bg-charcoal text-off-white"
+                            : "text-muted-gray hover:text-charcoal",
+                        )}
+                      >
+                        {LOCALE_LABEL[code]}
+                      </button>
+                    ))}
+                  </div>
+                </FormControl>
+                <FormMessage />
+              </FormItem>
+            )}
+          />
+
+          <Button
+            type="submit"
+            variant="default"
+            className="mt-2"
+            disabled={!isDirty || isSubmitting}
+          >
+            {isSubmitting ? "Saving..." : "Save"}
+          </Button>
+        </form>
+      </Form>
+    </section>
+  );
+}
+```
+
+- [ ] **Step 2: Run Biome on the new file**
+
+Run: `pnpm biome check --write "app/(app)/profile/profile-info-form.tsx"`
+
+Expected: No errors.
+
+- [ ] **Step 3: TypeScript smoke check by running the existing tests**
+
+Run: `pnpm exec vitest run lib/validations/profile.test.ts`
+
+Expected: Still 11 passing. This catches any accidental type break in `profile.ts` while adding the component.
+
+(Note: there is no component-level test. The file is still unreachable from the app until Task 4 wires it in - that is fine. This step only confirms the schema import chain still type-checks.)
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add "app/(app)/profile/profile-info-form.tsx"
+git commit -m "$(cat <<'EOF'
+feat(profile): add ProfileInfoForm client component (#15)
+
+Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 3: `PasswordForm` client component
+
+**Files:**
+- Create: `app/(app)/profile/password-form.tsx`
+
+- [ ] **Step 1: Create the file with the full component body**
+
+Create `app/(app)/profile/password-form.tsx`:
+
+```tsx
+// app/(app)/profile/password-form.tsx
+"use client";
+
+import { Button } from "@/components/ui/button";
+import {
+  Form,
+  FormControl,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage,
+} from "@/components/ui/form";
+import { Input } from "@/components/ui/input";
+import { createClient } from "@/lib/supabase/browser";
+import {
+  type PasswordFormValues,
+  passwordSchema,
+} from "@/lib/validations/profile";
+import { zodResolver } from "@hookform/resolvers/zod";
+import { useState } from "react";
+import { useForm } from "react-hook-form";
+
+export function PasswordForm() {
+  const [serverError, setServerError] = useState<string | null>(null);
+  const [successMessage, setSuccessMessage] = useState<string | null>(null);
+
+  const form = useForm<PasswordFormValues>({
+    resolver: zodResolver(passwordSchema),
+    defaultValues: { password: "", confirmPassword: "" },
+  });
+
+  async function onSubmit(values: PasswordFormValues) {
+    setServerError(null);
+    setSuccessMessage(null);
+
+    const supabase = createClient();
+    const { error } = await supabase.auth.updateUser({
+      password: values.password,
+    });
+
+    if (error) {
+      setServerError(error.message);
+      return;
+    }
+
+    setSuccessMessage("Password updated");
+    form.reset();
+  }
+
+  const { isSubmitting } = form.formState;
+
+  return (
+    <section className="rounded-card border border-border bg-cream p-6">
+      <h2 className="text-lg font-semibold text-charcoal mb-4">
+        Change password
+      </h2>
+
+      {successMessage && (
+        <output className="block mb-4 rounded-standard border border-green-300/30 bg-green-50/50 px-3 py-2.5 text-sm text-green-700">
+          {successMessage}
+        </output>
+      )}
+      {serverError && (
+        <div
+          role="alert"
+          className="mb-4 rounded-standard border border-destructive/30 bg-destructive/5 px-3 py-2.5 text-sm text-destructive"
+        >
+          {serverError}
+        </div>
+      )}
+
+      <Form {...form}>
+        <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-4">
+          <FormField
+            control={form.control}
+            name="password"
+            render={({ field }) => (
+              <FormItem>
+                <FormLabel>New password</FormLabel>
+                <FormControl>
+                  <Input
+                    type="password"
+                    autoComplete="new-password"
+                    placeholder="Min. 8 characters"
+                    {...field}
+                  />
+                </FormControl>
+                <FormMessage />
+              </FormItem>
+            )}
+          />
+          <FormField
+            control={form.control}
+            name="confirmPassword"
+            render={({ field }) => (
+              <FormItem>
+                <FormLabel>Confirm new password</FormLabel>
+                <FormControl>
+                  <Input
+                    type="password"
+                    autoComplete="new-password"
+                    placeholder="Re-enter your new password"
+                    {...field}
+                  />
+                </FormControl>
+                <FormMessage />
+              </FormItem>
+            )}
+          />
+          <Button
+            type="submit"
+            variant="default"
+            className="mt-2"
+            disabled={isSubmitting}
+          >
+            {isSubmitting ? "Updating..." : "Update password"}
+          </Button>
+        </form>
+      </Form>
+    </section>
+  );
+}
+```
+
+- [ ] **Step 2: Run Biome on the new file**
+
+Run: `pnpm biome check --write "app/(app)/profile/password-form.tsx"`
+
+Expected: No errors.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add "app/(app)/profile/password-form.tsx"
+git commit -m "$(cat <<'EOF'
+feat(profile): add PasswordForm client component (#15)
+
+Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 4: `ProfilePage` server component
+
+**Files:**
+- Create: `app/(app)/profile/page.tsx`
+
+- [ ] **Step 1: Create the file with the full Server Component body**
+
+Create `app/(app)/profile/page.tsx`:
+
+```tsx
+// app/(app)/profile/page.tsx
+import { createClient } from "@/lib/supabase/server";
+import type { Locale } from "@/lib/validations/profile";
+import { PasswordForm } from "./password-form";
+import { ProfileInfoForm } from "./profile-info-form";
+
+export default async function ProfilePage() {
+  const supabase = createClient();
+
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+
+  // Middleware guarantees an authenticated user before this page renders,
+  // so `user` is always present. Narrow for TS and bail defensively.
+  if (!user) {
+    return null;
+  }
+
+  const { data: profile } = await supabase
+    .from("profiles")
+    .select("display_name, locale")
+    .eq("id", user.id)
+    .single();
+
+  const initialDisplayName = profile?.display_name ?? "";
+  const initialLocale: Locale =
+    profile?.locale === "zh" || profile?.locale === "en"
+      ? profile.locale
+      : "en";
+
+  return (
+    <main className="min-h-screen bg-cream px-6 py-10">
+      <div className="mx-auto max-w-xl space-y-8">
+        <header>
+          <p className="text-[11px] uppercase tracking-[0.08em] text-muted-gray mb-3">
+            Cervix Health
+          </p>
+          <h1 className="text-[28px] font-semibold text-charcoal tracking-[-0.5px]">
+            Profile settings
+          </h1>
+        </header>
+
+        <ProfileInfoForm
+          email={user.email ?? ""}
+          initialDisplayName={initialDisplayName}
+          initialLocale={initialLocale}
+        />
+
+        <PasswordForm />
+      </div>
+    </main>
+  );
+}
+```
+
+- [ ] **Step 2: Run Biome on the new file**
+
+Run: `pnpm biome check --write "app/(app)/profile/page.tsx"`
+
+Expected: No errors.
+
+- [ ] **Step 3: Type-check the whole project**
+
+Run: `pnpm exec tsc --noEmit`
+
+Expected: No errors. If `@/lib/validations/profile` type imports fail, fix the import path in `profile-info-form.tsx` or `page.tsx`.
+
+(If the project does not have `tsc` installed directly, run `pnpm exec next build` instead and confirm it type-checks during build. Either one is acceptable for this step.)
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add "app/(app)/profile/page.tsx"
+git commit -m "$(cat <<'EOF'
+feat(profile): add profile page server component wiring (#15)
+
+Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 5: Manual verification
+
+**Files:** None modified. This task is a verification gate.
+
+- [ ] **Step 1: Run the full Vitest suite**
+
+Run: `pnpm test`
+
+Expected: All existing tests pass, including the new `lib/validations/profile.test.ts`.
+
+- [ ] **Step 2: Run Biome across the whole repo**
+
+Run: `pnpm biome check .`
+
+Expected: No errors.
+
+- [ ] **Step 3: Start the local Supabase stack (if not already running)**
+
+Run: `supabase start`
+
+Expected: All containers healthy. If Docker is not running, start Docker Desktop first.
+
+- [ ] **Step 4: Start the dev server**
+
+Run: `pnpm dev`
+
+Expected: Next.js starts on `http://localhost:3000`. Leave it running for the next steps.
+
+- [ ] **Step 5: Smoke test in the browser**
+
+Navigate to `http://localhost:3000/login` and sign in as an existing test user (or register a new one if the local DB is fresh).
+
+After login, navigate to `http://localhost:3000/profile`.
+
+Verify each of the following:
+1. The page renders with a cream background, `Profile settings` header, and two cards stacked vertically.
+2. The Profile card shows the user's `email` as a read-only row.
+3. The Profile card's `display_name` field is pre-filled with the current value.
+4. The Language segmented control shows the current locale selected (EN or ZH).
+5. The Save button is disabled until any field is modified.
+6. Change `display_name` to a new non-empty value, click Save. Success banner appears, button returns to disabled.
+7. Hard-reload the page. The new `display_name` is still there (persisted + refreshed).
+8. Toggle the Language segmented control to the other locale, click Save. Success banner appears.
+9. Hard-reload. The new locale is still selected.
+10. Clear `display_name`, tab out. The form shows `Display name is required` and Save remains disabled.
+11. In the Password card, enter `abc12345` / `abc12345`. Click Update password. Success banner `Password updated` appears and both password fields clear.
+12. Sign out (use any existing sign-out path, or clear cookies), navigate to `/login`, sign back in with the new password. Login succeeds.
+13. In the Password card, enter `abc12345` / `differnt1`. Submit. Inline field error `Passwords do not match` appears under `Confirm new password`.
+14. In the Password card, enter a 7-character password. Submit. Inline field error `Password must be at least 8 characters` appears.
+15. Open a second browser profile (or an incognito window). Sign in as a different test user. Navigate to `/profile`. The display_name and locale shown are the second user's, not the first (confirms RLS self-scoping).
+
+- [ ] **Step 6: Confirm nothing about the `profiles` table was accidentally exposed**
+
+In the first browser tab, open DevTools -> Network. Reload `/profile`. Verify no network request to the Supabase REST endpoint returns a row for anyone other than the signed-in user. (The only request to `/rest/v1/profiles` should be the single-user `select` with a `id=eq.<uuid>` filter.)
+
+- [ ] **Step 7: Stop the dev server**
+
+Stop `pnpm dev` (Ctrl-C in its terminal).
+
+- [ ] **Step 8: No-code commit to mark verification complete (optional)**
+
+This step is only to create a recorded checkpoint if the reviewer wants it. If the manual verification produced no code changes, skip this step.
+
+If the reviewer asked for a "done" marker, add one to the PR description instead of an empty commit.
+
+---
+
+## Post-implementation: PR
+
+Once all five tasks are green and committed, open a pull request targeting `main`:
+
+```bash
+gh pr create --title "feat(profile): user profile edit page (#15)" --body "$(cat <<'EOF'
+## Summary
+- Add `/profile` with read-only email, editable display name, EN/ZH segmented locale, and password change.
+- Add Zod schemas in `lib/validations/profile.ts` with Vitest coverage.
+- Two independent save flows via the browser Supabase client; RLS already enforces self-scope.
+
+Closes #15.
+
+## Test plan
+- [ ] Vitest: `pnpm test` passes
+- [ ] Biome: `pnpm biome check .` passes
+- [ ] Smoke test: manual verification in Task 5 of the plan completed
+
+Plan: `docs/superpowers/plans/2026-04-14-epic2-profile-edit-page.md`
+Spec: `docs/superpowers/specs/2026-04-14-epic2-profile-edit-design.md`
+EOF
+)"
+```
+
+---
+
+## AC Mapping (self-review)
+
+| AC | Task covering it |
+|---|---|
+| 1. `/profile` gated to authenticated | Already covered by `middleware.ts`. Task 4 puts the page under `app/(app)/profile/`, which matches `PROTECTED_PATHS`. |
+| 2. Form shows current `display_name` and locale | Task 4 server-side fetch; Task 2 `defaultValues` from props. |
+| 3. Update `display_name` via Supabase client | Task 2 `onSubmit` calls `.from('profiles').update(...)`. |
+| 4. Change locale (EN/ZH) | Task 2 segmented control writes to `locale`. |
+| 5. Change password via `auth.updateUser` | Task 3 `onSubmit` calls `supabase.auth.updateUser({ password })`. |
+| 6. Success/error feedback | Tasks 2 and 3 render `<output>` success and `<div role="alert">` error banners. |
+| 7. Cream background + design tokens | Task 4 `bg-cream` shell; Tasks 2 and 3 card styling. |
+| 8. Biome passes | Every task ends with `pnpm biome check --write` on the touched files; Task 5 runs `pnpm biome check .` across the repo. |

--- a/docs/superpowers/specs/2026-04-12-epic2-supabase-auth-design.md
+++ b/docs/superpowers/specs/2026-04-12-epic2-supabase-auth-design.md
@@ -1,0 +1,195 @@
+# Epic 2 — Supabase Auth: Email/Password
+
+**Date:** 2026-04-12
+**Issue:** [Epic 2 · Supabase Auth — Email/Password #10](https://github.com)
+**Supersedes:** `docs/superpowers/specs/2026-04-11-auth-pages-design.md` (see Decision Changes below)
+
+---
+
+## Scope
+
+Wire up Supabase Auth email/password for the App Router: session management, middleware route protection, auth pages (login + register), sign-out, and email confirmation callback.
+
+**Out of scope for this ticket:**
+- Google OAuth
+- Forgot password / reset password flow
+- App shell nav (sign-out button placement in nav comes in a later epic)
+
+---
+
+## Decision Changes vs Prior Spec (2026-04-11)
+
+| Decision | Old spec | This spec | Reason |
+|---|---|---|---|
+| Post-register UX | Redirect to `/chat` (no confirmation gate) | Show "check your email" state on register page | Supabase sends confirmation email — must click before session exists |
+| Auth mutations | Client-side browser Supabase calls | Server Actions (`lib/actions/auth.ts`) | Keeps auth logic server-side; no client token exposure |
+| Callback exchange | `supabase.auth.verifyOtp()` (PKCE) | `supabase.auth.exchangeCodeForSession()` | Current `@supabase/ssr` pattern for email confirmation links |
+| Forgot / reset password | Included | Deferred | Not in Epic 2 ticket scope |
+| React Hook Form | Required dependency | Not added | Server Actions validate via Zod server-side; RHF adds client complexity without benefit here |
+
+---
+
+## File Structure
+
+```
+middleware.ts                          # Route guard for /(app)/* routes
+
+app/(auth)/
+├── layout.tsx                         # Minimal centered layout (cream bg, max-w-sm column)
+├── login/
+│   ├── page.tsx                       # Server Component — reads ?error searchParam, renders LoginForm
+│   └── login-form.tsx                 # 'use client' — useActionState(signIn), error display
+└── register/
+    ├── page.tsx                       # Server Component wrapper
+    └── register-form.tsx              # 'use client' — useActionState(signUp), "check your email" state
+
+app/api/auth/
+└── callback/
+    └── route.ts                       # exchangeCodeForSession() → redirect to /chat
+
+lib/actions/
+└── auth.ts                            # Server Actions: signIn, signUp, signOut
+```
+
+**Existing files (already satisfy AC, no changes needed):**
+- `lib/supabase/browser.ts` — `createClient()` via `createBrowserClient`
+- `lib/supabase/server.ts` — `createClient()` via `createServerClient` with cookie handling
+
+---
+
+## Architecture
+
+### Middleware (`middleware.ts`)
+
+Uses the `@supabase/ssr` recommended pattern: create a server client inside middleware, call `supabase.auth.getUser()` to validate the session token server-side (not `getSession()`, which only reads the cookie without verifying). Refreshes the session cookie on every request so tokens rotate automatically.
+
+**Protected:** all routes matching `/(app)/*` (i.e. `/chat`, `/clinics`, `/learn`, `/profile`, `/admin`).
+**Unprotected:** `/`, `/login`, `/register`, `/api/auth/callback`, and all static assets.
+
+Unauthenticated request to a protected route → redirect to `/login`. No `?redirectTo` param.
+
+### Server Actions (`lib/actions/auth.ts`)
+
+All three actions are `'use server'` functions. They use `createClient()` from `lib/supabase/server.ts` and call `redirect()` from `next/navigation` on success.
+
+**`signIn(formData: FormData)`**
+1. Parse + validate email/password with Zod
+2. `supabase.auth.signInWithPassword({ email, password })`
+3. Success → `redirect('/chat')`
+4. Error → return `{ error: string }` to the form
+
+**`signUp(formData: FormData)`**
+1. Parse + validate email/password with Zod
+2. `supabase.auth.signUp({ email, password })`
+3. Success → return `{ success: true }` (form shows "check your email" state)
+4. Error → return `{ error: string }` to the form
+
+**`signOut()`**
+1. `supabase.auth.signOut()`
+2. `redirect('/login')`
+
+### Auth Callback (`app/api/auth/callback/route.ts`)
+
+GET handler. Reads `code` from search params. Calls `supabase.auth.exchangeCodeForSession(code)`. On success, redirects to `/chat`. On failure (missing/invalid/expired code), redirects to `/login?error=confirmation_failed`.
+
+### Auth Pages
+
+Both pages are Server Components that check for an existing session at the top via `supabase.auth.getUser()` — authenticated users are redirected to `/chat` immediately.
+
+**Login (`/login`):**
+- `page.tsx` is a Server Component — reads `?error=confirmation_failed` searchParam and passes it to a `LoginForm` client component
+- `login-form.tsx` (`'use client'`) — uses `useActionState(signIn)` to handle pending/error state; shows inline error on failure
+- Form: email + password + "Sign in" button; link to `/register`
+
+**Register (`/register`):**
+- `page.tsx` is a Server Component wrapper
+- `register-form.tsx` (`'use client'`) — uses `useActionState(signUp)`; on success state replaces form with "Check your email" confirmation message
+- Form: email + password + "Create account" button; link to `/login`
+- On Server Action error: inline error message below form
+
+---
+
+## Data Flow
+
+```
+Login:
+  form submit → signIn() → supabase.auth.signInWithPassword() → redirect /chat
+                                                               ↘ return error → display inline
+
+Register:
+  form submit → signUp() → supabase.auth.signUp() → return { success } → show "check your email"
+                                                  ↘ return error → display inline
+
+Email confirmation:
+  user clicks link → /api/auth/callback?code=xxx → exchangeCodeForSession() → redirect /chat
+                                                                             ↘ redirect /login?error=confirmation_failed
+
+Sign-out:
+  button → signOut() → supabase.auth.signOut() → redirect /login
+
+Route guard:
+  request to /(app)/* → middleware → getUser() → authenticated → pass through
+                                                ↘ unauthenticated → redirect /login
+```
+
+---
+
+## Visual Design
+
+Matches design tokens from `docs/design-tokens.md` and the prior auth pages spec:
+
+- **Background:** `#f7f4ed` (cream) — no white card, form floats on page
+- **Layout:** vertically + horizontally centered, `max-w-[360px]` content column
+- **Heading:** 28px / weight 600 / letter-spacing -0.5px / charcoal
+- **Subheading / nav links:** 13px / muted-gray
+- **Inputs:** `background #fcfbf8`, `border 1px solid rgba(28,28,28,0.4)`, `border-radius 6px`, `padding 9px 12px`
+- **Submit button:** charcoal bg, off-white text
+- **Max font weight:** 600 (never 700)
+- **UI primitives:** shadcn/ui `Input`, `Button`, `Label`
+
+---
+
+## Error Handling
+
+| Scenario | Behavior |
+|---|---|
+| Wrong credentials | Inline error below form (Server Action returns `{ error }`) |
+| Email already registered | Inline error (Supabase message surfaced as-is — no leaking) |
+| Unconfirmed email on login | Inline error |
+| Expired confirmation link | Redirect to `/login?error=confirmation_failed` → login page shows notice |
+| Invalid code in callback | Redirect to `/login?error=confirmation_failed` |
+| Already authenticated visiting `/login` or `/register` | Redirect to `/chat` |
+| Cookie mutation in Server Component | Silently ignored (already handled in `server.ts`) |
+
+---
+
+## Validation (`lib/actions/auth.ts`)
+
+Zod schemas defined inside `auth.ts` (no separate `lib/validations/` file — one-off, not shared).
+
+**`signInSchema`:** `email` (valid email), `password` (non-empty, min 6 chars)
+
+**`signUpSchema`:** `email` (valid email), `password` (min 8 chars)
+
+---
+
+## Acceptance Criteria Mapping
+
+| AC | Implementation |
+|---|---|
+| `lib/supabase/browser.ts` exports browser client | Already done — `createClient()` via `createBrowserClient` |
+| `lib/supabase/server.ts` exports server client with cookie handling | Already done — `createClient()` via `createServerClient` |
+| Sessions persist across page refreshes (cookie-based) | `@supabase/ssr` writes session to cookies; middleware refreshes on every request |
+| Sign-out clears session and redirects to `/login` | `signOut()` Server Action: `supabase.auth.signOut()` → `redirect('/login')` |
+| Auth state accessible in Server Components via `supabase.auth.getUser()` | Server client available anywhere via `createClient()` from `lib/supabase/server.ts` |
+| Biome passes with no errors | Run `pnpm biome check --write .` after implementation |
+
+---
+
+## Constraints
+
+- No pure white (`#ffffff`) backgrounds
+- Max font weight 600
+- No ESLint/Prettier — Biome only
+- Server client used in Server Actions + middleware; browser client NOT used for auth mutations
+- `getUser()` (server-validated) not `getSession()` (cookie-only) in middleware

--- a/docs/superpowers/specs/2026-04-13-epic2-profiles-table-design.md
+++ b/docs/superpowers/specs/2026-04-13-epic2-profiles-table-design.md
@@ -1,0 +1,146 @@
+# Epic 2 — Profiles Table + Auto-Create Trigger on Signup
+
+**Issue:** [#11](https://github.com/Zoeyyhc/cervix-assistant/issues/11)
+**Date:** 2026-04-13
+**Status:** Design approved, pending implementation plan
+
+---
+
+## Summary
+
+Bring the `public.profiles` table and `handle_new_user` trigger up to the Epic 2 spec by adding two columns — `display_name` and `updated_at` — and wiring `handle_new_user` to populate `display_name` from `auth.users.raw_user_meta_data` when present. Add a `BEFORE UPDATE` trigger so `updated_at` advances automatically.
+
+This is a DB-only ticket. No app code (including `register-form.tsx`) changes.
+
+## Context
+
+The `profiles` table and a basic `handle_new_user` trigger already exist in `supabase/migrations/20260409165311_enable_pgvector_and_create_profiles.sql` from Epic 1. Current columns: `id`, `email`, `role`, `full_name`, `avatar_url`, `locale`, `created_at`. Missing per issue #11: `display_name`, `updated_at`.
+
+Per the updated `CLAUDE.md` convention (2026-04-13), migrations may be edited freely during local development. This design edits the existing Epic 1 migration file in place rather than adding a new numbered migration. Re-application happens via `supabase db reset`.
+
+## Decisions
+
+| # | Decision | Rationale |
+|---|---|---|
+| 1 | Edit the existing Epic 1 migration file rather than creating a new one | Solo dev, local-only DB. Keeps history clean. Matches updated CLAUDE.md rule. |
+| 2 | Additive: keep `full_name` and `avatar_url`, add `display_name` and `updated_at` | Non-destructive. Epic 1 columns stay available for future use. |
+| 3 | `display_name` is nullable, no default | No meaningful default exists. User sets it later via profile UI. |
+| 4 | `handle_new_user` reads `raw_user_meta_data->>'display_name'` (via `nullif` to coerce empty strings to null) | Forward-compatible with a future register-form change that sends metadata. Costs nothing today — resolves to null since no caller sends it yet. |
+| 5 | `updated_at` driven by a `BEFORE UPDATE` trigger, not app code | Automatic, uniform across every write path (SQL, RPC, client SDK). |
+| 6 | `handle_profile_updated_at` is NOT `SECURITY DEFINER` | Row-local mutation; no cross-role writes needed. Least privilege. |
+| 7 | No changes to `register-form.tsx` | Ticket is explicitly DB-only. A follow-up ticket will own the form change because it has its own UX decisions (required? min length? shown on login page?). |
+| 8 | No backfill for existing rows | Dev DB only; `supabase db reset` wipes and re-applies. |
+| 9 | No RLS policy changes | Existing row-level policies (`profiles: self or admin can select/update`) cover the new columns automatically. |
+
+## Schema — final state of `public.profiles`
+
+```sql
+id           uuid primary key references auth.users(id) on delete cascade
+email        text
+role         text check (role in ('guest','user','admin')) default 'user'
+full_name    text                          -- kept from Epic 1
+avatar_url   text                          -- kept from Epic 1
+display_name text                          -- NEW, nullable
+locale       text default 'en'
+created_at   timestamptz default now()
+updated_at   timestamptz default now()     -- NEW
+```
+
+## Migration changes
+
+All changes live in `supabase/migrations/20260409165311_enable_pgvector_and_create_profiles.sql`.
+
+### 1. Add `display_name` and `updated_at` columns
+
+```sql
+alter table public.profiles
+  add column if not exists display_name text;
+
+alter table public.profiles
+  add column if not exists updated_at timestamptz default now();
+```
+
+Using `if not exists` keeps the migration idempotent on partial re-runs.
+
+### 2. Update `handle_new_user` function body
+
+```sql
+create or replace function public.handle_new_user()
+returns trigger as $$
+begin
+  insert into public.profiles (id, email, display_name)
+  values (
+    new.id,
+    new.email,
+    nullif(new.raw_user_meta_data->>'display_name', '')
+  )
+  on conflict (id) do nothing;
+  return new;
+end;
+$$ language plpgsql security definer
+   set search_path = '';
+```
+
+Stays `SECURITY DEFINER` + `search_path = ''`. The existing `on_auth_user_created` trigger on `auth.users` does not need to be re-created — `create or replace function` swaps the body in place.
+
+### 3. Add `updated_at` trigger
+
+```sql
+create or replace function public.handle_profile_updated_at()
+returns trigger as $$
+begin
+  new.updated_at = now();
+  return new;
+end;
+$$ language plpgsql;
+
+drop trigger if exists profiles_set_updated_at on public.profiles;
+create trigger profiles_set_updated_at
+  before update on public.profiles
+  for each row execute function public.handle_profile_updated_at();
+```
+
+`drop trigger if exists` + `create trigger` makes this safely re-runnable.
+
+## RLS
+
+Unchanged. The existing policies are row-level, not column-level, so they cover the new columns automatically.
+
+## Verification plan
+
+These steps run after applying the migration and belong in the implementation plan's verification step.
+
+1. **Migration applies cleanly**
+   `supabase db reset` — exits 0, no warnings about the profiles migration.
+
+2. **Schema matches**
+   `psql ... -c "\d public.profiles"` shows `display_name text` and `updated_at timestamptz default now()` columns.
+
+3. **Auto-create on signup (basic path)**
+   Sign up a new user via the dev server register form.
+   `select id, email, display_name, created_at, updated_at from public.profiles where email = '<new>';`
+   Expect: row exists, `display_name` is null, `created_at` and `updated_at` are both set and equal (within a few ms).
+
+4. **`updated_at` advances on update**
+   `update public.profiles set locale = 'zh' where id = '<new>';`
+   Re-select → `updated_at` is now later than `created_at`.
+
+5. **`display_name` populates from metadata when present**
+   Insert a second user directly in SQL:
+   ```sql
+   -- run as service role via `supabase` CLI or SQL editor
+   insert into auth.users (id, email, raw_user_meta_data)
+   values (gen_random_uuid(), 'test@example.com', '{"display_name":"Test User"}'::jsonb);
+   ```
+   Re-select from `profiles` → `display_name = 'Test User'`.
+
+6. **Biome clean**
+   `pnpm biome check .` → no errors. (No app code changes, but run it anyway per house rules.)
+
+## Out of scope
+
+- Changes to `register-form.tsx`, `registerSchema`, or the signup flow — a future ticket will own collecting `display_name` on signup.
+- Changes to `full_name`, `avatar_url`, or any other existing column.
+- Any RLS policy changes.
+- Updates to `docs/database.md` — optional cleanup, tracked separately. The schema as shipped will diverge slightly from the doc (which currently lists `full_name` and no `display_name`).
+- Creating a profile-edit UI so a user can set their own `display_name`.

--- a/docs/superpowers/specs/2026-04-14-epic2-profile-edit-design.md
+++ b/docs/superpowers/specs/2026-04-14-epic2-profile-edit-design.md
@@ -1,0 +1,311 @@
+# Epic 2 — User Profile Edit Page
+
+**Date:** 2026-04-14
+**Issue:** Epic 2 · #15 · User Profile Edit Page
+
+---
+
+## Scope
+
+Build a profile settings page at `/profile` where authenticated users can update their `display_name`, `locale` preference, and password.
+
+**In scope:**
+- Display the signed-in user's email (read-only).
+- Edit `display_name` and `locale` via a Profile card with its own Save button.
+- Change password via a separate Password card with its own Save button.
+- Success and error feedback on each card independently.
+- Zod-validated forms, RHF submission, browser Supabase client for mutations.
+- Design-token-compliant layout (cream background, charcoal text, existing card/border styles).
+- Vitest unit tests for the new validation schemas.
+
+**Out of scope:**
+- Avatar upload / profile picture.
+- Email change (requires a confirmation flow).
+- Account deletion.
+- Immediate UI language switch on locale change — Epic 8 owns the i18n wiring; this ticket only stores the preference.
+- Requiring the user's current password before setting a new one (matches the existing `reset-password-form.tsx` flow).
+- Playwright E2E specs — manual verification only, consistent with the testing strategy in memory.
+
+---
+
+## File Structure
+
+```
+app/(app)/profile/
+├── page.tsx                  # Server Component — loads profile, renders both forms
+├── profile-info-form.tsx     # "use client" — display_name + locale (EN/ZH segmented)
+└── password-form.tsx         # "use client" — new password + confirm
+
+lib/validations/
+└── profile.ts                # Zod: profileInfoSchema, passwordSchema (+ inferred types)
+
+lib/validations/
+└── profile.test.ts           # Vitest unit tests for the schemas
+```
+
+**Existing files that already satisfy requirements (untouched):**
+- `middleware.ts` — already protects `/profile/*` via `PROTECTED_PATHS`.
+- `lib/supabase/server.ts` — used for the server-side profile read.
+- `lib/supabase/browser.ts` — used for all client-side mutations.
+- `types/supabase.ts` — already contains the `profiles` Row type.
+- `supabase/migrations/20260413143757_rls_policies.sql` — RLS already allows self-update on `profiles`.
+- `components/ui/{form,input,button,label}.tsx` — existing shadcn primitives, no new ones needed.
+
+---
+
+## Architecture
+
+### Component tree
+
+```
+ProfilePage (Server Component)
+├── Page shell (<main> with cream bg, centered max-w-xl column, <h1>)
+├── <ProfileInfoForm email={...} initialDisplayName={...} initialLocale={...} />
+│   └── Card
+│       ├── <h2>Profile</h2>
+│       ├── Success / error banner slot
+│       ├── Read-only email row
+│       ├── RHF <FormField name="displayName"> → <Input>
+│       ├── RHF <FormField name="locale"> → Segmented control (button radiogroup)
+│       └── <Button type="submit">Save</Button>
+└── <PasswordForm />
+    └── Card
+        ├── <h2>Change password</h2>
+        ├── Success / error banner slot
+        ├── RHF <FormField name="password"> → <Input type="password">
+        ├── RHF <FormField name="confirmPassword"> → <Input type="password">
+        └── <Button type="submit">Update password</Button>
+```
+
+### Data flow — initial load
+
+1. `page.tsx` calls `createClient()` from `lib/supabase/server.ts`.
+2. `const { data: { user } } = await supabase.auth.getUser()`. Middleware has already redirected unauthenticated requests, but we still read `user` to get `id` and `email`. TypeScript narrowing guards an unreachable `null` branch.
+3. `const { data: profile } = await supabase.from('profiles').select('display_name, locale').eq('id', user.id).single()`.
+4. If `profile` is null (network blip or RLS misconfiguration), render the forms with defaults `displayName: ""` and `locale: "en"`. The Profile form submit stays blocked by the Zod `min(1)` rule until the user types a name. No error banner on server load — graceful degradation.
+5. Pass `email`, `initialDisplayName`, `initialLocale` as props to `<ProfileInfoForm>`. Render `<PasswordForm>` with no props.
+
+### Data flow — profile save
+
+1. Client `ProfileInfoForm` uses RHF + `zodResolver(profileInfoSchema)` with `defaultValues` from props.
+2. Submit button is disabled when `!form.formState.isDirty || form.formState.isSubmitting`.
+3. On submit, handler:
+   - Clears `serverError` state.
+   - Creates a browser Supabase client via `createClient()` from `lib/supabase/browser.ts`.
+   - Reads `user.id` via `await supabase.auth.getUser()` (cheap — cookie read).
+   - Calls `supabase.from('profiles').update({ display_name: values.displayName, locale: values.locale }).eq('id', user.id)`. `displayName` is already trimmed by Zod.
+   - On error: `setServerError(error.message)` and return.
+   - On success: set `successMessage("Profile saved")`, call `router.refresh()` so the Server Component re-pulls the row and `defaultValues` stay in sync, then `form.reset(values)` so `isDirty` flips back to false.
+
+### Data flow — password save
+
+1. Client `PasswordForm` uses RHF + `zodResolver(passwordSchema)` with `defaultValues: { password: "", confirmPassword: "" }`.
+2. On submit, handler:
+   - Clears `serverError` state.
+   - Calls `supabase.auth.updateUser({ password: values.password })` from the browser client.
+   - On error: `setServerError(error.message)` and return. Password fields stay populated so the user can retry without re-typing.
+   - On success: set `successMessage("Password updated")` and call `form.reset()` to clear both fields so no stale password sits in the DOM.
+
+---
+
+## Validation Schemas (`lib/validations/profile.ts`)
+
+```ts
+import { z } from "zod/v3";
+
+export const LOCALES = ["en", "zh"] as const;
+export type Locale = (typeof LOCALES)[number];
+
+export const profileInfoSchema = z.object({
+  displayName: z
+    .string()
+    .trim()
+    .min(1, "Display name is required")
+    .max(60, "Display name must be 60 characters or fewer"),
+  locale: z.enum(LOCALES, {
+    errorMap: () => ({ message: "Please choose a language" }),
+  }),
+});
+
+export const passwordSchema = z
+  .object({
+    password: z.string().min(8, "Password must be at least 8 characters"),
+    confirmPassword: z.string(),
+  })
+  .refine((data) => data.password === data.confirmPassword, {
+    message: "Passwords do not match",
+    path: ["confirmPassword"],
+  });
+
+export type ProfileInfoFormValues = z.infer<typeof profileInfoSchema>;
+export type PasswordFormValues = z.infer<typeof passwordSchema>;
+```
+
+**Notes:**
+- `zod/v3` sub-path matches the existing `lib/validations/auth.ts` convention so `@hookform/resolvers`' v3 overload resolves.
+- `LOCALES` is exported as a single source of truth. The segmented control iterates over it to render the two pills; no hardcoded locale list in the component.
+- `passwordSchema` is a near-duplicate of `resetPasswordSchema` in `lib/validations/auth.ts`. Kept separate so a future policy divergence in one flow doesn't accidentally break the other.
+- `.trim()` on `displayName` runs in Zod, so the value handed to Supabase is already trimmed.
+
+---
+
+## Component Details
+
+### `app/(app)/profile/page.tsx` (Server Component)
+
+- Async default export.
+- Calls `createClient()` from `lib/supabase/server.ts`.
+- Reads `user` and `profile` as described in the data flow.
+- Renders a `<main>` with cream background, `max-w-xl` centered column, vertical spacing between header and the two cards.
+- Header: small uppercase eyebrow ("Cervix Health") + `<h1>` "Profile settings", matching the typography in `login-form.tsx`.
+- Passes props and renders both client forms.
+
+### `profile-info-form.tsx`
+
+- `"use client"`.
+- Props: `email: string`, `initialDisplayName: string`, `initialLocale: "en" | "zh"`.
+- RHF form, `zodResolver(profileInfoSchema)`.
+- Card container styled as `rounded-standard border border-warm bg-cream p-6` (exact tokens confirmed via `docs/design-tokens.md` during implementation — if the token names differ, use the values from that file).
+- Inside the card:
+  1. `<h2 className="text-lg font-semibold text-charcoal mb-4">Profile</h2>`
+  2. Success `<output>` slot (shown only when `successMessage` is set).
+  3. Error `<div role="alert">` slot (shown only when `serverError` is set).
+  4. Read-only email row: `<FormLabel>Email</FormLabel>` above a `<p className="text-sm text-charcoal">{email}</p>`. No input, no edit affordance.
+  5. `<FormField name="displayName">` → `<Input type="text" autoComplete="name" maxLength={60}>`.
+  6. `<FormField name="locale">` → segmented control, rendered via RHF's field `value` / `onChange`:
+     ```tsx
+     <div role="radiogroup" aria-label="Language" className="inline-flex rounded-standard border border-warm bg-cream p-1">
+       {LOCALES.map((code) => (
+         <button
+           key={code}
+           type="button"
+           role="radio"
+           aria-checked={field.value === code}
+           onClick={() => field.onChange(code)}
+           className={cn(
+             "px-4 py-1.5 text-sm rounded-[calc(var(--radius-standard)-4px)] transition-colors",
+             field.value === code
+               ? "bg-charcoal text-cream"
+               : "text-charcoal/70 hover:text-charcoal",
+           )}
+         >
+           {code === "en" ? "English" : "中文"}
+         </button>
+       ))}
+     </div>
+     ```
+  7. `<Button type="submit" disabled={!isDirty || isSubmitting}>` with label "Save" / "Saving…".
+
+### `password-form.tsx`
+
+- `"use client"`, no props.
+- Same card container style as `ProfileInfoForm`.
+- `<h2>Change password</h2>`.
+- Success / error banner slots identical to the profile card.
+- Two `<Input type="password" autoComplete="new-password">` for `password` and `confirmPassword`, each wrapped in a `<FormField>`.
+- `<Button type="submit" disabled={isSubmitting}>` with label "Update password" / "Updating…".
+
+---
+
+## Error Handling
+
+**Profile load (`page.tsx`):**
+- Middleware guarantees authentication, so `getUser()` returning `null` is unreachable. A `return null` guard is present for TS narrowing only.
+- If `profile` query fails or returns `null`, render forms with empty / default values. The submit button stays disabled until the user fills in a valid display name. No server-rendered error banner.
+
+**Profile save (`profile-info-form.tsx`):**
+- Zod-level rejections are blocked by RHF before the submit handler runs; only Supabase errors reach the handler.
+- Supabase errors (network, RLS reject) surface as `<div role="alert">` with `error.message`.
+- `setServerError(null)` at the top of every submit so a stale error clears on retry.
+- No optimistic update — the handler `await`s the mutation before flipping UI state.
+- On success, `router.refresh()` re-pulls the server component so the form's `defaultValues` no longer lie.
+
+**Password save (`password-form.tsx`):**
+- Supabase errors (weak password, expired session, rate limit) surface in the same banner pattern.
+- On error, password fields stay populated so the user can retry without re-typing.
+- On success, `form.reset()` clears both fields so no stale password lingers in the DOM.
+
+**Shared patterns (matching `login-form.tsx` and `reset-password-form.tsx`):**
+- `<output>` for success messages (avoids `role="alert"` noise).
+- `<div role="alert">` for errors.
+- Submit button disabled during `isSubmitting` to prevent double-submit.
+
+---
+
+## Testing
+
+### Unit tests — `lib/validations/profile.test.ts` (Vitest)
+
+**`profileInfoSchema`:**
+- Accepts `{ displayName: "Alice", locale: "en" }`.
+- Accepts `{ displayName: "B", locale: "zh" }` (min 1 boundary).
+- Rejects empty `displayName`.
+- Rejects whitespace-only `displayName` (trim → "").
+- Rejects `displayName` of length 61.
+- Rejects `locale: "fr"` (not in enum).
+- Trims `"  Alice  "` to `"Alice"` in the parsed output.
+
+**`passwordSchema`:**
+- Accepts matching 8-character passwords.
+- Rejects 7-character password with the "at least 8 characters" message.
+- Rejects mismatched confirmation; the error path must be `["confirmPassword"]` so RHF wires it to the right field.
+
+### No component-level Vitest
+
+The two form components are thin RHF wrappers around the schemas above and the Supabase browser client. Testing them would require mocking Supabase, which is brittle and doesn't verify real behavior. The schemas carry the logic worth isolating; the forms are covered by manual verification.
+
+### Manual verification (before marking the ticket complete)
+
+1. `pnpm dev`, sign in, navigate to `/profile`.
+2. Verify read-only email displays correctly; `display_name` and locale match the DB.
+3. Change `display_name` → Save → success banner → reload → value persisted.
+4. Toggle locale EN ↔ ZH → Save → reload → value persisted.
+5. Clear `display_name` → submit is disabled (or shows validation error).
+6. Change password to matching 8+ char values → success banner → fields clear → sign out → sign in with the new password.
+7. Mismatched passwords → inline error on `confirmPassword`.
+8. Sign in as a second user in a different browser, confirm they see their own profile, not user 1's (RLS sanity check).
+9. `pnpm biome check .` — passes with zero errors.
+10. `pnpm exec vitest run lib/validations/profile.test.ts` — passes.
+
+---
+
+## Design Tokens and Styling
+
+- Background: cream (existing `bg-cream` token). Never pure white.
+- Text: charcoal (`text-charcoal`).
+- Borders: warm (`border-warm`).
+- Border radius: `rounded-standard` (matches auth forms).
+- Typography: Camera Plain Variable via existing `<h1>` / `<h2>` classes; max weight 600 (no `font-bold`).
+- Segmented-control active state uses `bg-charcoal text-cream`; inactive uses `text-charcoal/70`.
+- Success banner: soft green background (`border-green-300/30 bg-green-50/50 text-green-700`), matching `login-form.tsx`.
+- Error banner: `border-destructive/30 bg-destructive/5 text-destructive`, matching `login-form.tsx`.
+
+Exact token class names will be verified against `docs/design-tokens.md` during implementation. If any token name differs, the implementation will use whatever the tokens doc defines — this spec names them for illustrative consistency with existing auth forms.
+
+---
+
+## Acceptance Criteria Mapping
+
+| Ticket AC | Covered by |
+|---|---|
+| `/profile` accessible to authenticated users only | `middleware.ts` already gates `PROTECTED_PATHS` including `/profile` |
+| Form displays current `display_name` and locale | `page.tsx` server-side read → props → RHF `defaultValues` |
+| User can update `display_name` via Supabase client | `profile-info-form.tsx` submit handler calls `.from('profiles').update(...)` |
+| User can change locale (EN / ZH) | Same submit handler writes `locale` column |
+| User can change password via `supabase.auth.updateUser` | `password-form.tsx` submit handler |
+| Success/error feedback after save | `<output>` success and `<div role="alert">` error banners on each card |
+| Cream background + design tokens | Server component shell + card containers |
+| Biome passes | Verified via `pnpm biome check .` as the last step |
+
+---
+
+## Risks and Open Questions
+
+**None blocking.** All ticket ambiguities were resolved during brainstorming:
+- Two cards, not one form.
+- No current-password requirement on password change.
+- Segmented control for locale, not a `<select>`.
+- `display_name` required, min 1, max 60, trimmed.
+- Email shown read-only at the top of the Profile card.
+- No immediate UI language switch on locale change.
+- Vitest for validation only; manual verification for UI.

--- a/docs/superpowers/specs/2026-04-14-epic2-profile-edit-design.md
+++ b/docs/superpowers/specs/2026-04-14-epic2-profile-edit-design.md
@@ -1,7 +1,7 @@
-# Epic 2 — User Profile Edit Page
+# Epic 2 - User Profile Edit Page
 
 **Date:** 2026-04-14
-**Issue:** Epic 2 · #15 · User Profile Edit Page
+**Issue:** Epic 2 / #15 / User Profile Edit Page
 
 ---
 
@@ -22,9 +22,9 @@ Build a profile settings page at `/profile` where authenticated users can update
 - Avatar upload / profile picture.
 - Email change (requires a confirmation flow).
 - Account deletion.
-- Immediate UI language switch on locale change — Epic 8 owns the i18n wiring; this ticket only stores the preference.
+- Immediate UI language switch on locale change. Epic 8 owns the i18n wiring; this ticket only stores the preference.
 - Requiring the user's current password before setting a new one (matches the existing `reset-password-form.tsx` flow).
-- Playwright E2E specs — manual verification only, consistent with the testing strategy in memory.
+- Playwright E2E specs. Manual verification only, consistent with the testing strategy in memory.
 
 ---
 
@@ -32,24 +32,22 @@ Build a profile settings page at `/profile` where authenticated users can update
 
 ```
 app/(app)/profile/
-├── page.tsx                  # Server Component — loads profile, renders both forms
-├── profile-info-form.tsx     # "use client" — display_name + locale (EN/ZH segmented)
-└── password-form.tsx         # "use client" — new password + confirm
+    page.tsx                  Server Component: loads profile, renders both forms
+    profile-info-form.tsx     "use client": display_name + locale (EN/ZH segmented)
+    password-form.tsx         "use client": new password + confirm
 
 lib/validations/
-└── profile.ts                # Zod: profileInfoSchema, passwordSchema (+ inferred types)
-
-lib/validations/
-└── profile.test.ts           # Vitest unit tests for the schemas
+    profile.ts                Zod: profileInfoSchema, passwordSchema (+ inferred types)
+    profile.test.ts           Vitest unit tests for the schemas
 ```
 
 **Existing files that already satisfy requirements (untouched):**
-- `middleware.ts` — already protects `/profile/*` via `PROTECTED_PATHS`.
-- `lib/supabase/server.ts` — used for the server-side profile read.
-- `lib/supabase/browser.ts` — used for all client-side mutations.
-- `types/supabase.ts` — already contains the `profiles` Row type.
-- `supabase/migrations/20260413143757_rls_policies.sql` — RLS already allows self-update on `profiles`.
-- `components/ui/{form,input,button,label}.tsx` — existing shadcn primitives, no new ones needed.
+- `middleware.ts` already protects `/profile/*` via `PROTECTED_PATHS`.
+- `lib/supabase/server.ts` used for the server-side profile read.
+- `lib/supabase/browser.ts` used for all client-side mutations.
+- `types/supabase.ts` already contains the `profiles` Row type.
+- `supabase/migrations/20260413143757_rls_policies.sql` RLS already allows self-update on `profiles`.
+- `components/ui/{form,input,button,label}.tsx` existing shadcn primitives, no new ones needed.
 
 ---
 
@@ -59,45 +57,45 @@ lib/validations/
 
 ```
 ProfilePage (Server Component)
-├── Page shell (<main> with cream bg, centered max-w-xl column, <h1>)
-├── <ProfileInfoForm email={...} initialDisplayName={...} initialLocale={...} />
-│   └── Card
-│       ├── <h2>Profile</h2>
-│       ├── Success / error banner slot
-│       ├── Read-only email row
-│       ├── RHF <FormField name="displayName"> → <Input>
-│       ├── RHF <FormField name="locale"> → Segmented control (button radiogroup)
-│       └── <Button type="submit">Save</Button>
-└── <PasswordForm />
-    └── Card
-        ├── <h2>Change password</h2>
-        ├── Success / error banner slot
-        ├── RHF <FormField name="password"> → <Input type="password">
-        ├── RHF <FormField name="confirmPassword"> → <Input type="password">
-        └── <Button type="submit">Update password</Button>
+  Page shell (<main> with cream bg, centered max-w-xl column, <h1>)
+  <ProfileInfoForm email={...} initialDisplayName={...} initialLocale={...} />
+    Card
+      <h2>Profile</h2>
+      Success / error banner slot
+      Read-only email row
+      RHF <FormField name="displayName"> -> <Input>
+      RHF <FormField name="locale"> -> Segmented control (button radiogroup)
+      <Button type="submit">Save</Button>
+  <PasswordForm />
+    Card
+      <h2>Change password</h2>
+      Success / error banner slot
+      RHF <FormField name="password"> -> <Input type="password">
+      RHF <FormField name="confirmPassword"> -> <Input type="password">
+      <Button type="submit">Update password</Button>
 ```
 
-### Data flow — initial load
+### Data flow: initial load
 
 1. `page.tsx` calls `createClient()` from `lib/supabase/server.ts`.
 2. `const { data: { user } } = await supabase.auth.getUser()`. Middleware has already redirected unauthenticated requests, but we still read `user` to get `id` and `email`. TypeScript narrowing guards an unreachable `null` branch.
 3. `const { data: profile } = await supabase.from('profiles').select('display_name, locale').eq('id', user.id).single()`.
-4. If `profile` is null (network blip or RLS misconfiguration), render the forms with defaults `displayName: ""` and `locale: "en"`. The Profile form submit stays blocked by the Zod `min(1)` rule until the user types a name. No error banner on server load — graceful degradation.
+4. If `profile` is null (network blip or RLS misconfiguration), render the forms with defaults `displayName: ""` and `locale: "en"`. The Profile form submit stays blocked by the Zod `min(1)` rule until the user types a name. No error banner on server load. Graceful degradation.
 5. Pass `email`, `initialDisplayName`, `initialLocale` as props to `<ProfileInfoForm>`. Render `<PasswordForm>` with no props.
 
-### Data flow — profile save
+### Data flow: profile save
 
 1. Client `ProfileInfoForm` uses RHF + `zodResolver(profileInfoSchema)` with `defaultValues` from props.
 2. Submit button is disabled when `!form.formState.isDirty || form.formState.isSubmitting`.
 3. On submit, handler:
    - Clears `serverError` state.
    - Creates a browser Supabase client via `createClient()` from `lib/supabase/browser.ts`.
-   - Reads `user.id` via `await supabase.auth.getUser()` (cheap — cookie read).
+   - Reads `user.id` via `await supabase.auth.getUser()` (cheap cookie read).
    - Calls `supabase.from('profiles').update({ display_name: values.displayName, locale: values.locale }).eq('id', user.id)`. `displayName` is already trimmed by Zod.
    - On error: `setServerError(error.message)` and return.
    - On success: set `successMessage("Profile saved")`, call `router.refresh()` so the Server Component re-pulls the row and `defaultValues` stay in sync, then `form.reset(values)` so `isDirty` flips back to false.
 
-### Data flow — password save
+### Data flow: password save
 
 1. Client `PasswordForm` uses RHF + `zodResolver(passwordSchema)` with `defaultValues: { password: "", confirmPassword: "" }`.
 2. On submit, handler:
@@ -144,7 +142,7 @@ export type PasswordFormValues = z.infer<typeof passwordSchema>;
 **Notes:**
 - `zod/v3` sub-path matches the existing `lib/validations/auth.ts` convention so `@hookform/resolvers`' v3 overload resolves.
 - `LOCALES` is exported as a single source of truth. The segmented control iterates over it to render the two pills; no hardcoded locale list in the component.
-- `passwordSchema` is a near-duplicate of `resetPasswordSchema` in `lib/validations/auth.ts`. Kept separate so a future policy divergence in one flow doesn't accidentally break the other.
+- `passwordSchema` is a near-duplicate of `resetPasswordSchema` in `lib/validations/auth.ts`. Kept separate so a future policy divergence in one flow does not accidentally break the other.
 - `.trim()` on `displayName` runs in Zod, so the value handed to Supabase is already trimmed.
 
 ---
@@ -165,14 +163,14 @@ export type PasswordFormValues = z.infer<typeof passwordSchema>;
 - `"use client"`.
 - Props: `email: string`, `initialDisplayName: string`, `initialLocale: "en" | "zh"`.
 - RHF form, `zodResolver(profileInfoSchema)`.
-- Card container styled as `rounded-standard border border-warm bg-cream p-6` (exact tokens confirmed via `docs/design-tokens.md` during implementation — if the token names differ, use the values from that file).
+- Card container styled as `rounded-standard border border-warm bg-cream p-6` (exact tokens confirmed via `docs/design-tokens.md` during implementation. If the token names differ, use the values from that file).
 - Inside the card:
   1. `<h2 className="text-lg font-semibold text-charcoal mb-4">Profile</h2>`
   2. Success `<output>` slot (shown only when `successMessage` is set).
   3. Error `<div role="alert">` slot (shown only when `serverError` is set).
   4. Read-only email row: `<FormLabel>Email</FormLabel>` above a `<p className="text-sm text-charcoal">{email}</p>`. No input, no edit affordance.
-  5. `<FormField name="displayName">` → `<Input type="text" autoComplete="name" maxLength={60}>`.
-  6. `<FormField name="locale">` → segmented control, rendered via RHF's field `value` / `onChange`:
+  5. `<FormField name="displayName">` -> `<Input type="text" autoComplete="name" maxLength={60}>`.
+  6. `<FormField name="locale">` -> segmented control, rendered via RHF's field `value` / `onChange`:
      ```tsx
      <div role="radiogroup" aria-label="Language" className="inline-flex rounded-standard border border-warm bg-cream p-1">
        {LOCALES.map((code) => (
@@ -189,12 +187,13 @@ export type PasswordFormValues = z.infer<typeof passwordSchema>;
                : "text-charcoal/70 hover:text-charcoal",
            )}
          >
-           {code === "en" ? "English" : "中文"}
+           {code === "en" ? "English" : "Chinese"}
          </button>
        ))}
      </div>
      ```
-  7. `<Button type="submit" disabled={!isDirty || isSubmitting}>` with label "Save" / "Saving…".
+     Note: the Chinese button label in the spec shows "Chinese" to stay ASCII-only. In the actual JSX, the label for `zh` should display the native-script word for Chinese (two Han characters meaning "Chinese text"). Store that literal string in the component when implementing.
+  7. `<Button type="submit" disabled={!isDirty || isSubmitting}>` with label "Save" / "Saving".
 
 ### `password-form.tsx`
 
@@ -203,7 +202,7 @@ export type PasswordFormValues = z.infer<typeof passwordSchema>;
 - `<h2>Change password</h2>`.
 - Success / error banner slots identical to the profile card.
 - Two `<Input type="password" autoComplete="new-password">` for `password` and `confirmPassword`, each wrapped in a `<FormField>`.
-- `<Button type="submit" disabled={isSubmitting}>` with label "Update password" / "Updating…".
+- `<Button type="submit" disabled={isSubmitting}>` with label "Update password" / "Updating".
 
 ---
 
@@ -217,7 +216,7 @@ export type PasswordFormValues = z.infer<typeof passwordSchema>;
 - Zod-level rejections are blocked by RHF before the submit handler runs; only Supabase errors reach the handler.
 - Supabase errors (network, RLS reject) surface as `<div role="alert">` with `error.message`.
 - `setServerError(null)` at the top of every submit so a stale error clears on retry.
-- No optimistic update — the handler `await`s the mutation before flipping UI state.
+- No optimistic update. The handler `await`s the mutation before flipping UI state.
 - On success, `router.refresh()` re-pulls the server component so the form's `defaultValues` no longer lie.
 
 **Password save (`password-form.tsx`):**
@@ -234,13 +233,13 @@ export type PasswordFormValues = z.infer<typeof passwordSchema>;
 
 ## Testing
 
-### Unit tests — `lib/validations/profile.test.ts` (Vitest)
+### Unit tests: `lib/validations/profile.test.ts` (Vitest)
 
 **`profileInfoSchema`:**
 - Accepts `{ displayName: "Alice", locale: "en" }`.
 - Accepts `{ displayName: "B", locale: "zh" }` (min 1 boundary).
 - Rejects empty `displayName`.
-- Rejects whitespace-only `displayName` (trim → "").
+- Rejects whitespace-only `displayName` (trim produces "").
 - Rejects `displayName` of length 61.
 - Rejects `locale: "fr"` (not in enum).
 - Trims `"  Alice  "` to `"Alice"` in the parsed output.
@@ -252,20 +251,20 @@ export type PasswordFormValues = z.infer<typeof passwordSchema>;
 
 ### No component-level Vitest
 
-The two form components are thin RHF wrappers around the schemas above and the Supabase browser client. Testing them would require mocking Supabase, which is brittle and doesn't verify real behavior. The schemas carry the logic worth isolating; the forms are covered by manual verification.
+The two form components are thin RHF wrappers around the schemas above and the Supabase browser client. Testing them would require mocking Supabase, which is brittle and does not verify real behavior. The schemas carry the logic worth isolating; the forms are covered by manual verification.
 
 ### Manual verification (before marking the ticket complete)
 
 1. `pnpm dev`, sign in, navigate to `/profile`.
 2. Verify read-only email displays correctly; `display_name` and locale match the DB.
-3. Change `display_name` → Save → success banner → reload → value persisted.
-4. Toggle locale EN ↔ ZH → Save → reload → value persisted.
-5. Clear `display_name` → submit is disabled (or shows validation error).
-6. Change password to matching 8+ char values → success banner → fields clear → sign out → sign in with the new password.
-7. Mismatched passwords → inline error on `confirmPassword`.
+3. Change `display_name`, click Save, success banner, reload, value persisted.
+4. Toggle locale EN vs ZH, Save, reload, value persisted.
+5. Clear `display_name`, submit is disabled (or shows validation error).
+6. Change password to matching 8+ char values, success banner, fields clear, sign out, sign in with the new password.
+7. Mismatched passwords show inline error on `confirmPassword`.
 8. Sign in as a second user in a different browser, confirm they see their own profile, not user 1's (RLS sanity check).
-9. `pnpm biome check .` — passes with zero errors.
-10. `pnpm exec vitest run lib/validations/profile.test.ts` — passes.
+9. `pnpm biome check .` passes with zero errors.
+10. `pnpm exec vitest run lib/validations/profile.test.ts` passes.
 
 ---
 
@@ -280,7 +279,7 @@ The two form components are thin RHF wrappers around the schemas above and the S
 - Success banner: soft green background (`border-green-300/30 bg-green-50/50 text-green-700`), matching `login-form.tsx`.
 - Error banner: `border-destructive/30 bg-destructive/5 text-destructive`, matching `login-form.tsx`.
 
-Exact token class names will be verified against `docs/design-tokens.md` during implementation. If any token name differs, the implementation will use whatever the tokens doc defines — this spec names them for illustrative consistency with existing auth forms.
+Exact token class names will be verified against `docs/design-tokens.md` during implementation. If any token name differs, the implementation will use whatever the tokens doc defines. This spec names them for illustrative consistency with existing auth forms.
 
 ---
 
@@ -289,7 +288,7 @@ Exact token class names will be verified against `docs/design-tokens.md` during 
 | Ticket AC | Covered by |
 |---|---|
 | `/profile` accessible to authenticated users only | `middleware.ts` already gates `PROTECTED_PATHS` including `/profile` |
-| Form displays current `display_name` and locale | `page.tsx` server-side read → props → RHF `defaultValues` |
+| Form displays current `display_name` and locale | `page.tsx` server-side read, props, RHF `defaultValues` |
 | User can update `display_name` via Supabase client | `profile-info-form.tsx` submit handler calls `.from('profiles').update(...)` |
 | User can change locale (EN / ZH) | Same submit handler writes `locale` column |
 | User can change password via `supabase.auth.updateUser` | `password-form.tsx` submit handler |

--- a/e2e/auth/forgot-password.spec.ts
+++ b/e2e/auth/forgot-password.spec.ts
@@ -1,0 +1,35 @@
+// e2e/auth/forgot-password.spec.ts
+import { expect, test } from "@playwright/test";
+
+test.describe("Forgot password page", () => {
+  test("renders email field and submit button", async ({ page }) => {
+    await page.goto("/forgot-password");
+    await expect(page.getByLabel("Email")).toBeVisible();
+    await expect(
+      page.getByRole("button", { name: "Send reset link" }),
+    ).toBeVisible();
+  });
+
+  test("shows field error for invalid email format", async ({ page }) => {
+    await page.goto("/forgot-password");
+    await page.fill('[name="email"]', "not-an-email");
+    await page.click('[type="submit"]');
+    await expect(
+      page.getByText("Please enter a valid email address"),
+    ).toBeVisible();
+  });
+
+  test("shows success confirmation after submitting valid email", async ({
+    page,
+  }) => {
+    await page.goto("/forgot-password");
+    await page.fill('[name="email"]', "anyone@example.com");
+    await page.click('[type="submit"]');
+    // Supabase returns success even for non-existent emails (prevents enumeration)
+    await expect(page.getByRole("status")).toBeVisible();
+    // Form is replaced by confirmation — submit button no longer visible
+    await expect(
+      page.getByRole("button", { name: "Send reset link" }),
+    ).not.toBeVisible();
+  });
+});

--- a/e2e/auth/forgot-password.spec.ts
+++ b/e2e/auth/forgot-password.spec.ts
@@ -5,31 +5,23 @@ test.describe("Forgot password page", () => {
   test("renders email field and submit button", async ({ page }) => {
     await page.goto("/forgot-password");
     await expect(page.getByLabel("Email")).toBeVisible();
-    await expect(
-      page.getByRole("button", { name: "Send reset link" }),
-    ).toBeVisible();
+    await expect(page.getByRole("button", { name: "Send reset link" })).toBeVisible();
   });
 
   test("shows field error for invalid email format", async ({ page }) => {
     await page.goto("/forgot-password");
     await page.fill('[name="email"]', "not-an-email");
     await page.click('[type="submit"]');
-    await expect(
-      page.getByText("Please enter a valid email address"),
-    ).toBeVisible();
+    await expect(page.getByText("Please enter a valid email address")).toBeVisible();
   });
 
-  test("shows success confirmation after submitting valid email", async ({
-    page,
-  }) => {
+  test("shows success confirmation after submitting valid email", async ({ page }) => {
     await page.goto("/forgot-password");
     await page.fill('[name="email"]', "anyone@example.com");
     await page.click('[type="submit"]');
     // Supabase returns success even for non-existent emails (prevents enumeration)
     await expect(page.getByRole("status")).toBeVisible();
     // Form is replaced by confirmation — submit button no longer visible
-    await expect(
-      page.getByRole("button", { name: "Send reset link" }),
-    ).not.toBeVisible();
+    await expect(page.getByRole("button", { name: "Send reset link" })).not.toBeVisible();
   });
 });

--- a/e2e/auth/login.spec.ts
+++ b/e2e/auth/login.spec.ts
@@ -1,0 +1,48 @@
+// e2e/auth/login.spec.ts
+import { expect, test } from "@playwright/test";
+import { createTestUser, deleteTestUser } from "../helpers/supabase";
+
+const TEST_EMAIL = "e2e-login@test.local";
+const TEST_PASSWORD = "TestPass123!";
+
+test.describe("Login page", () => {
+  let userId: string;
+
+  test.beforeAll(async () => {
+    userId = await createTestUser(TEST_EMAIL, TEST_PASSWORD);
+  });
+
+  test.afterAll(async () => {
+    await deleteTestUser(userId);
+  });
+
+  test("renders email and password fields", async ({ page }) => {
+    await page.goto("/login");
+    await expect(page.getByLabel("Email")).toBeVisible();
+    await expect(page.getByLabel("Password")).toBeVisible();
+  });
+
+  test("shows field error for invalid email format", async ({ page }) => {
+    await page.goto("/login");
+    await page.fill('[name="email"]', "not-an-email");
+    await page.fill('[name="password"]', "anything");
+    await page.click('[type="submit"]');
+    await expect(page.getByText("Please enter a valid email address")).toBeVisible();
+  });
+
+  test("shows server error banner for wrong credentials", async ({ page }) => {
+    await page.goto("/login");
+    await page.fill('[name="email"]', TEST_EMAIL);
+    await page.fill('[name="password"]', "wrongpassword");
+    await page.click('[type="submit"]');
+    await expect(page.getByRole("alert")).toBeVisible();
+  });
+
+  test("valid credentials redirect to /chat", async ({ page }) => {
+    await page.goto("/login");
+    await page.fill('[name="email"]', TEST_EMAIL);
+    await page.fill('[name="password"]', TEST_PASSWORD);
+    await page.click('[type="submit"]');
+    await expect(page).toHaveURL("/chat");
+  });
+});

--- a/e2e/auth/register.spec.ts
+++ b/e2e/auth/register.spec.ts
@@ -4,9 +4,7 @@ import { expect, test } from "@playwright/test";
 test.describe("Register page", () => {
   const uniqueEmail = () => `e2e-register-${Date.now()}@test.local`;
 
-  test("renders email, password, and confirm password fields", async ({
-    page,
-  }) => {
+  test("renders email, password, and confirm password fields", async ({ page }) => {
     await page.goto("/register");
     await expect(page.getByLabel("Email")).toBeVisible();
     await expect(page.getByLabel("Password", { exact: true })).toBeVisible();
@@ -28,9 +26,7 @@ test.describe("Register page", () => {
     await page.fill('[name="password"]', "Password123!");
     await page.fill('[name="confirmPassword"]', "Password123!");
     await page.click('[type="submit"]');
-    await expect(
-      page.getByText("Please enter a valid email address"),
-    ).toBeVisible();
+    await expect(page.getByText("Please enter a valid email address")).toBeVisible();
   });
 
   test("valid registration redirects to /chat", async ({ page }) => {

--- a/e2e/auth/register.spec.ts
+++ b/e2e/auth/register.spec.ts
@@ -29,14 +29,14 @@ test.describe("Register page", () => {
     await expect(page.getByText("Please enter a valid email address")).toBeVisible();
   });
 
-  test("valid registration redirects to /chat", async ({ page }) => {
+  test("valid registration shows email confirmation screen", async ({ page }) => {
     const email = uniqueEmail();
     await page.goto("/register");
     await page.fill('[name="email"]', email);
     await page.fill('[name="password"]', "Password123!");
     await page.fill('[name="confirmPassword"]', "Password123!");
     await page.click('[type="submit"]');
-    await expect(page).toHaveURL("/chat");
+    await expect(page.getByRole("heading", { name: "Check your email" })).toBeVisible();
   });
 
   test("already-registered email shows server error", async ({ page }) => {
@@ -47,7 +47,7 @@ test.describe("Register page", () => {
     await page.fill('[name="password"]', "Password123!");
     await page.fill('[name="confirmPassword"]', "Password123!");
     await page.click('[type="submit"]');
-    await expect(page).toHaveURL("/chat");
+    await expect(page.getByRole("heading", { name: "Check your email" })).toBeVisible();
 
     // Second registration with same email
     await page.goto("/register");

--- a/e2e/auth/register.spec.ts
+++ b/e2e/auth/register.spec.ts
@@ -1,0 +1,64 @@
+// e2e/auth/register.spec.ts
+import { expect, test } from "@playwright/test";
+
+test.describe("Register page", () => {
+  const uniqueEmail = () => `e2e-register-${Date.now()}@test.local`;
+
+  test("renders email, password, and confirm password fields", async ({
+    page,
+  }) => {
+    await page.goto("/register");
+    await expect(page.getByLabel("Email")).toBeVisible();
+    await expect(page.getByLabel("Password", { exact: true })).toBeVisible();
+    await expect(page.getByLabel("Confirm password")).toBeVisible();
+  });
+
+  test("shows field error when passwords do not match", async ({ page }) => {
+    await page.goto("/register");
+    await page.fill('[name="email"]', "test@example.com");
+    await page.fill('[name="password"]', "Password123!");
+    await page.fill('[name="confirmPassword"]', "DifferentPass123!");
+    await page.click('[type="submit"]');
+    await expect(page.getByText("Passwords do not match")).toBeVisible();
+  });
+
+  test("shows field error for invalid email format", async ({ page }) => {
+    await page.goto("/register");
+    await page.fill('[name="email"]', "bad-email");
+    await page.fill('[name="password"]', "Password123!");
+    await page.fill('[name="confirmPassword"]', "Password123!");
+    await page.click('[type="submit"]');
+    await expect(
+      page.getByText("Please enter a valid email address"),
+    ).toBeVisible();
+  });
+
+  test("valid registration redirects to /chat", async ({ page }) => {
+    const email = uniqueEmail();
+    await page.goto("/register");
+    await page.fill('[name="email"]', email);
+    await page.fill('[name="password"]', "Password123!");
+    await page.fill('[name="confirmPassword"]', "Password123!");
+    await page.click('[type="submit"]');
+    await expect(page).toHaveURL("/chat");
+  });
+
+  test("already-registered email shows server error", async ({ page }) => {
+    const email = uniqueEmail();
+    // First registration
+    await page.goto("/register");
+    await page.fill('[name="email"]', email);
+    await page.fill('[name="password"]', "Password123!");
+    await page.fill('[name="confirmPassword"]', "Password123!");
+    await page.click('[type="submit"]');
+    await expect(page).toHaveURL("/chat");
+
+    // Second registration with same email
+    await page.goto("/register");
+    await page.fill('[name="email"]', email);
+    await page.fill('[name="password"]', "Password123!");
+    await page.fill('[name="confirmPassword"]', "Password123!");
+    await page.click('[type="submit"]');
+    await expect(page.getByRole("alert")).toBeVisible();
+  });
+});

--- a/e2e/auth/reset-password.spec.ts
+++ b/e2e/auth/reset-password.spec.ts
@@ -2,9 +2,7 @@
 import { expect, test } from "@playwright/test";
 
 test.describe("Reset password page", () => {
-  test("redirects to /forgot-password when there is no active session", async ({
-    page,
-  }) => {
+  test("redirects to /forgot-password when there is no active session", async ({ page }) => {
     // Navigate directly without going through the email link
     await page.goto("/reset-password");
     await expect(page).toHaveURL("/forgot-password");

--- a/e2e/auth/reset-password.spec.ts
+++ b/e2e/auth/reset-password.spec.ts
@@ -1,0 +1,46 @@
+// e2e/auth/reset-password.spec.ts
+import { expect, test } from "@playwright/test";
+
+test.describe("Reset password page", () => {
+  test("redirects to /forgot-password when there is no active session", async ({
+    page,
+  }) => {
+    // Navigate directly without going through the email link
+    await page.goto("/reset-password");
+    await expect(page).toHaveURL("/forgot-password");
+  });
+
+  test("shows password fields when session is present", async ({ page }) => {
+    // Register a temp user to establish a session
+    const email = `e2e-reset-${Date.now()}@test.local`;
+    const password = "Password123!";
+
+    await page.goto("/register");
+    await page.fill('[name="email"]', email);
+    await page.fill('[name="password"]', password);
+    await page.fill('[name="confirmPassword"]', password);
+    await page.click('[type="submit"]');
+    await expect(page).toHaveURL("/chat");
+
+    // Now navigate to reset-password — session is active
+    await page.goto("/reset-password");
+    await expect(page.getByLabel("New password", { exact: true })).toBeVisible();
+    await expect(page.getByLabel("Confirm new password", { exact: true })).toBeVisible();
+  });
+
+  test("shows error when passwords do not match", async ({ page }) => {
+    const email = `e2e-reset-mismatch-${Date.now()}@test.local`;
+    await page.goto("/register");
+    await page.fill('[name="email"]', email);
+    await page.fill('[name="password"]', "Password123!");
+    await page.fill('[name="confirmPassword"]', "Password123!");
+    await page.click('[type="submit"]');
+    await expect(page).toHaveURL("/chat");
+
+    await page.goto("/reset-password");
+    await page.fill('[name="password"]', "NewPass123!");
+    await page.fill('[name="confirmPassword"]', "DifferentPass!");
+    await page.click('[type="submit"]');
+    await expect(page.getByText("Passwords do not match")).toBeVisible();
+  });
+});

--- a/e2e/helpers/supabase.ts
+++ b/e2e/helpers/supabase.ts
@@ -17,11 +17,22 @@ export async function createTestUser(email: string, password: string): Promise<s
     password,
     email_confirm: true,
   });
-  if (error) throw new Error(`createTestUser failed: ${error.message}`);
-  return data.user.id;
+  if (!error) return data.user.id;
+
+  // If the user already exists (e.g. from a previous interrupted run), look them up
+  if (error.message.includes("already been registered")) {
+    const { data: list } = await supabase.auth.admin.listUsers();
+    const existing = list?.users?.find((u) => u.email === email);
+    if (existing) return existing.id;
+  }
+
+  throw new Error(`createTestUser failed: ${error.message}`);
 }
 
 export async function deleteTestUser(userId: string): Promise<void> {
+  if (!userId) return;
   const supabase = getAdminClient();
+  // Remove profile first to avoid FK constraint blocking auth user deletion
+  await supabase.from("profiles").delete().eq("id", userId);
   await supabase.auth.admin.deleteUser(userId);
 }

--- a/e2e/helpers/supabase.ts
+++ b/e2e/helpers/supabase.ts
@@ -1,0 +1,27 @@
+// e2e/helpers/supabase.ts
+import { createClient } from "@supabase/supabase-js";
+
+const SUPABASE_URL = process.env.NEXT_PUBLIC_SUPABASE_URL ?? "http://localhost:54321";
+const SERVICE_ROLE_KEY = process.env.SUPABASE_SERVICE_ROLE_KEY ?? "";
+
+function getAdminClient() {
+  return createClient(SUPABASE_URL, SERVICE_ROLE_KEY, {
+    auth: { autoRefreshToken: false, persistSession: false },
+  });
+}
+
+export async function createTestUser(email: string, password: string): Promise<string> {
+  const supabase = getAdminClient();
+  const { data, error } = await supabase.auth.admin.createUser({
+    email,
+    password,
+    email_confirm: true,
+  });
+  if (error) throw new Error(`createTestUser failed: ${error.message}`);
+  return data.user.id;
+}
+
+export async function deleteTestUser(userId: string): Promise<void> {
+  const supabase = getAdminClient();
+  await supabase.auth.admin.deleteUser(userId);
+}

--- a/lib/auth/route-rules.test.ts
+++ b/lib/auth/route-rules.test.ts
@@ -1,0 +1,128 @@
+import { describe, expect, it } from "vitest";
+import { decideRedirect, isAdminPath, isAuthPage, isProtected } from "./route-rules";
+
+describe("isProtected", () => {
+  it.each([
+    ["/chat", true],
+    ["/chat/thread-1", true],
+    ["/clinics", true],
+    ["/clinics/123", true],
+    ["/learn", true],
+    ["/learn/topic", true],
+    ["/profile", true],
+    ["/admin", true],
+    ["/admin/users", true],
+    ["/", false],
+    ["/login", false],
+    ["/about", false],
+    ["/chatter", false],
+  ])("%s -> %s", (path, expected) => {
+    expect(isProtected(path)).toBe(expected);
+  });
+});
+
+describe("isAuthPage", () => {
+  it.each([
+    ["/login", true],
+    ["/register", true],
+    ["/forgot-password", true],
+    ["/reset-password", true],
+    ["/reset-password/token", true],
+    ["/", false],
+    ["/chat", false],
+    ["/loginish", false],
+  ])("%s -> %s", (path, expected) => {
+    expect(isAuthPage(path)).toBe(expected);
+  });
+});
+
+describe("isAdminPath", () => {
+  it("matches /admin and /admin/*, not unrelated paths", () => {
+    expect(isAdminPath("/admin")).toBe(true);
+    expect(isAdminPath("/admin/users")).toBe(true);
+    expect(isAdminPath("/administration")).toBe(false);
+    expect(isAdminPath("/chat")).toBe(false);
+  });
+});
+
+describe("decideRedirect", () => {
+  it("redirects unauthenticated users from protected routes to /login", () => {
+    expect(
+      decideRedirect({
+        pathname: "/chat",
+        isAuthenticated: false,
+        isAdmin: false,
+      })
+    ).toEqual({ type: "redirect", to: "/login" });
+  });
+
+  it("redirects unauthenticated users from /admin to /login", () => {
+    expect(
+      decideRedirect({
+        pathname: "/admin",
+        isAuthenticated: false,
+        isAdmin: false,
+      })
+    ).toEqual({ type: "redirect", to: "/login" });
+  });
+
+  it("redirects authenticated users away from auth pages to /chat", () => {
+    expect(
+      decideRedirect({
+        pathname: "/login",
+        isAuthenticated: true,
+        isAdmin: false,
+      })
+    ).toEqual({ type: "redirect", to: "/chat" });
+  });
+
+  it("redirects non-admin authenticated users from /admin to /chat", () => {
+    expect(
+      decideRedirect({
+        pathname: "/admin/users",
+        isAuthenticated: true,
+        isAdmin: false,
+      })
+    ).toEqual({ type: "redirect", to: "/chat" });
+  });
+
+  it("allows admin users on /admin routes", () => {
+    expect(
+      decideRedirect({
+        pathname: "/admin/users",
+        isAuthenticated: true,
+        isAdmin: true,
+      })
+    ).toEqual({ type: "allow" });
+  });
+
+  it("allows authenticated users on non-admin protected routes", () => {
+    expect(
+      decideRedirect({
+        pathname: "/chat",
+        isAuthenticated: true,
+        isAdmin: false,
+      })
+    ).toEqual({ type: "allow" });
+  });
+
+  it("allows unauthenticated users on public routes", () => {
+    expect(
+      decideRedirect({
+        pathname: "/",
+        isAuthenticated: false,
+        isAdmin: false,
+      })
+    ).toEqual({ type: "allow" });
+  });
+
+  it("allows authenticated non-admin users on public routes", () => {
+    expect(
+      decideRedirect({
+        pathname: "/about",
+        isAuthenticated: true,
+        isAdmin: false,
+      })
+    ).toEqual({ type: "allow" });
+  });
+});

--- a/lib/auth/route-rules.test.ts
+++ b/lib/auth/route-rules.test.ts
@@ -76,6 +76,16 @@ describe("decideRedirect", () => {
     ).toEqual({ type: "redirect", to: "/chat" });
   });
 
+  it("allows authenticated users on /reset-password (recovery flow needs active session)", () => {
+    expect(
+      decideRedirect({
+        pathname: "/reset-password",
+        isAuthenticated: true,
+        isAdmin: false,
+      })
+    ).toEqual({ type: "allow" });
+  });
+
   it("redirects non-admin authenticated users from /admin to /chat", () => {
     expect(
       decideRedirect({

--- a/lib/auth/route-rules.ts
+++ b/lib/auth/route-rules.ts
@@ -33,7 +33,10 @@ export function decideRedirect(params: {
     return { type: "redirect", to: "/login" };
   }
 
-  if (isAuthenticated && isAuthPage(pathname)) {
+  // /reset-password is exempt: the recovery flow lands here WITH an active
+  // session (callback just exchanged the code), and the page needs that
+  // session to call updateUser. Bouncing to /chat would break the flow.
+  if (isAuthenticated && isAuthPage(pathname) && !matchesAny(pathname, ["/reset-password"])) {
     return { type: "redirect", to: "/chat" };
   }
 

--- a/lib/auth/route-rules.ts
+++ b/lib/auth/route-rules.ts
@@ -1,0 +1,45 @@
+export const PROTECTED_PATHS = ["/chat", "/clinics", "/learn", "/profile", "/admin"] as const;
+
+export const AUTH_PATHS = ["/login", "/register", "/forgot-password", "/reset-password"] as const;
+
+export const ADMIN_PATHS = ["/admin"] as const;
+
+function matchesAny(pathname: string, paths: readonly string[]): boolean {
+  return paths.some((p) => pathname === p || pathname.startsWith(`${p}/`));
+}
+
+export function isProtected(pathname: string): boolean {
+  return matchesAny(pathname, PROTECTED_PATHS);
+}
+
+export function isAuthPage(pathname: string): boolean {
+  return matchesAny(pathname, AUTH_PATHS);
+}
+
+export function isAdminPath(pathname: string): boolean {
+  return matchesAny(pathname, ADMIN_PATHS);
+}
+
+export type RedirectDecision = { type: "redirect"; to: string } | { type: "allow" };
+
+export function decideRedirect(params: {
+  pathname: string;
+  isAuthenticated: boolean;
+  isAdmin: boolean;
+}): RedirectDecision {
+  const { pathname, isAuthenticated, isAdmin } = params;
+
+  if (!isAuthenticated && isProtected(pathname)) {
+    return { type: "redirect", to: "/login" };
+  }
+
+  if (isAuthenticated && isAuthPage(pathname)) {
+    return { type: "redirect", to: "/chat" };
+  }
+
+  if (isAuthenticated && isAdminPath(pathname) && !isAdmin) {
+    return { type: "redirect", to: "/chat" };
+  }
+
+  return { type: "allow" };
+}

--- a/lib/validations/auth.ts
+++ b/lib/validations/auth.ts
@@ -1,0 +1,37 @@
+// lib/validations/auth.ts
+import { z } from "zod";
+
+export const loginSchema = z.object({
+  email: z.string().email("Please enter a valid email address"),
+  password: z.string().min(6, "Password must be at least 6 characters"),
+});
+
+export const registerSchema = z
+  .object({
+    email: z.string().email("Please enter a valid email address"),
+    password: z.string().min(8, "Password must be at least 8 characters"),
+    confirmPassword: z.string(),
+  })
+  .refine((data) => data.password === data.confirmPassword, {
+    message: "Passwords do not match",
+    path: ["confirmPassword"],
+  });
+
+export const forgotPasswordSchema = z.object({
+  email: z.string().email("Please enter a valid email address"),
+});
+
+export const resetPasswordSchema = z
+  .object({
+    password: z.string().min(8, "Password must be at least 8 characters"),
+    confirmPassword: z.string(),
+  })
+  .refine((data) => data.password === data.confirmPassword, {
+    message: "Passwords do not match",
+    path: ["confirmPassword"],
+  });
+
+export type LoginFormValues = z.infer<typeof loginSchema>;
+export type RegisterFormValues = z.infer<typeof registerSchema>;
+export type ForgotPasswordFormValues = z.infer<typeof forgotPasswordSchema>;
+export type ResetPasswordFormValues = z.infer<typeof resetPasswordSchema>;

--- a/lib/validations/auth.ts
+++ b/lib/validations/auth.ts
@@ -1,5 +1,8 @@
 // lib/validations/auth.ts
-import { z } from "zod";
+// Import from zod/v3 so that @hookform/resolvers' zodResolver Zod-v3 overload
+// matches correctly.  Zod 4.x ships zod/v3 as a first-class compatibility
+// sub-path; the runtime behaviour is identical to `import { z } from "zod"`.
+import { z } from "zod/v3";
 
 export const loginSchema = z.object({
   email: z.string().email("Please enter a valid email address"),

--- a/lib/validations/profile.test.ts
+++ b/lib/validations/profile.test.ts
@@ -1,0 +1,123 @@
+import { describe, expect, it } from "vitest";
+import { LOCALES, type Locale, passwordSchema, profileInfoSchema } from "./profile";
+
+describe("LOCALES", () => {
+  it("contains exactly en and zh", () => {
+    expect(LOCALES).toEqual(["en", "zh"]);
+  });
+});
+
+describe("profileInfoSchema", () => {
+  it("accepts a valid English profile", () => {
+    const result = profileInfoSchema.safeParse({
+      displayName: "Alice",
+      locale: "en",
+    });
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.displayName).toBe("Alice");
+      expect(result.data.locale).toBe("en");
+    }
+  });
+
+  it("accepts a valid Chinese profile", () => {
+    const result = profileInfoSchema.safeParse({
+      displayName: "B",
+      locale: "zh",
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it("trims surrounding whitespace on displayName", () => {
+    const result = profileInfoSchema.safeParse({
+      displayName: "  Alice  ",
+      locale: "en",
+    });
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.displayName).toBe("Alice");
+    }
+  });
+
+  it("rejects an empty displayName", () => {
+    const result = profileInfoSchema.safeParse({
+      displayName: "",
+      locale: "en",
+    });
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.error.issues[0].message).toBe("Display name is required");
+      expect(result.error.issues[0].path).toEqual(["displayName"]);
+    }
+  });
+
+  it("rejects a whitespace-only displayName after trim", () => {
+    const result = profileInfoSchema.safeParse({
+      displayName: "     ",
+      locale: "en",
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects a displayName longer than 60 characters", () => {
+    const result = profileInfoSchema.safeParse({
+      displayName: "a".repeat(61),
+      locale: "en",
+    });
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.error.issues[0].message).toBe("Display name must be 60 characters or fewer");
+    }
+  });
+
+  it("accepts a displayName of exactly 60 characters", () => {
+    const result = profileInfoSchema.safeParse({
+      displayName: "a".repeat(60),
+      locale: "en",
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it("rejects an unknown locale", () => {
+    const result = profileInfoSchema.safeParse({
+      displayName: "Alice",
+      locale: "fr" as unknown as Locale,
+    });
+    expect(result.success).toBe(false);
+  });
+});
+
+describe("passwordSchema", () => {
+  it("accepts matching 8-character passwords", () => {
+    const result = passwordSchema.safeParse({
+      password: "abcd1234",
+      confirmPassword: "abcd1234",
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it("rejects a 7-character password", () => {
+    const result = passwordSchema.safeParse({
+      password: "abcd123",
+      confirmPassword: "abcd123",
+    });
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.error.issues[0].message).toBe("Password must be at least 8 characters");
+      expect(result.error.issues[0].path).toEqual(["password"]);
+    }
+  });
+
+  it("rejects mismatched confirmation with path confirmPassword", () => {
+    const result = passwordSchema.safeParse({
+      password: "abcd1234",
+      confirmPassword: "abcd1235",
+    });
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      const issue = result.error.issues.find((i) => i.path[0] === "confirmPassword");
+      expect(issue).toBeDefined();
+      expect(issue?.message).toBe("Passwords do not match");
+    }
+  });
+});

--- a/lib/validations/profile.test.ts
+++ b/lib/validations/profile.test.ts
@@ -1,38 +1,22 @@
 import { describe, expect, it } from "vitest";
-import { LOCALES, type Locale, passwordSchema, profileInfoSchema } from "./profile";
-
-describe("LOCALES", () => {
-  it("contains exactly en and zh", () => {
-    expect(LOCALES).toEqual(["en", "zh"]);
-  });
-});
+import { passwordSchema, profileInfoSchema } from "./profile";
 
 describe("profileInfoSchema", () => {
-  it("accepts a valid English profile", () => {
-    const result = profileInfoSchema.safeParse({
-      displayName: "Alice",
-      locale: "en",
-    });
+  it("accepts a valid display name", () => {
+    const result = profileInfoSchema.safeParse({ displayName: "Alice" });
     expect(result.success).toBe(true);
     if (result.success) {
       expect(result.data.displayName).toBe("Alice");
-      expect(result.data.locale).toBe("en");
     }
   });
 
-  it("accepts a valid Chinese profile", () => {
-    const result = profileInfoSchema.safeParse({
-      displayName: "B",
-      locale: "zh",
-    });
+  it("accepts a single character", () => {
+    const result = profileInfoSchema.safeParse({ displayName: "B" });
     expect(result.success).toBe(true);
   });
 
   it("trims surrounding whitespace on displayName", () => {
-    const result = profileInfoSchema.safeParse({
-      displayName: "  Alice  ",
-      locale: "en",
-    });
+    const result = profileInfoSchema.safeParse({ displayName: "  Alice  " });
     expect(result.success).toBe(true);
     if (result.success) {
       expect(result.data.displayName).toBe("Alice");
@@ -40,10 +24,7 @@ describe("profileInfoSchema", () => {
   });
 
   it("rejects an empty displayName", () => {
-    const result = profileInfoSchema.safeParse({
-      displayName: "",
-      locale: "en",
-    });
+    const result = profileInfoSchema.safeParse({ displayName: "" });
     expect(result.success).toBe(false);
     if (!result.success) {
       expect(result.error.issues[0].message).toBe("Display name is required");
@@ -52,18 +33,12 @@ describe("profileInfoSchema", () => {
   });
 
   it("rejects a whitespace-only displayName after trim", () => {
-    const result = profileInfoSchema.safeParse({
-      displayName: "     ",
-      locale: "en",
-    });
+    const result = profileInfoSchema.safeParse({ displayName: "     " });
     expect(result.success).toBe(false);
   });
 
   it("rejects a displayName longer than 60 characters", () => {
-    const result = profileInfoSchema.safeParse({
-      displayName: "a".repeat(61),
-      locale: "en",
-    });
+    const result = profileInfoSchema.safeParse({ displayName: "a".repeat(61) });
     expect(result.success).toBe(false);
     if (!result.success) {
       expect(result.error.issues[0].message).toBe("Display name must be 60 characters or fewer");
@@ -71,19 +46,8 @@ describe("profileInfoSchema", () => {
   });
 
   it("accepts a displayName of exactly 60 characters", () => {
-    const result = profileInfoSchema.safeParse({
-      displayName: "a".repeat(60),
-      locale: "en",
-    });
+    const result = profileInfoSchema.safeParse({ displayName: "a".repeat(60) });
     expect(result.success).toBe(true);
-  });
-
-  it("rejects an unknown locale", () => {
-    const result = profileInfoSchema.safeParse({
-      displayName: "Alice",
-      locale: "fr" as unknown as Locale,
-    });
-    expect(result.success).toBe(false);
   });
 });
 

--- a/lib/validations/profile.ts
+++ b/lib/validations/profile.ts
@@ -3,18 +3,12 @@
 // matches correctly, same pattern as lib/validations/auth.ts.
 import { z } from "zod/v3";
 
-export const LOCALES = ["en", "zh"] as const;
-export type Locale = (typeof LOCALES)[number];
-
 export const profileInfoSchema = z.object({
   displayName: z
     .string()
     .trim()
     .min(1, "Display name is required")
     .max(60, "Display name must be 60 characters or fewer"),
-  locale: z.enum(LOCALES, {
-    errorMap: () => ({ message: "Please choose a language" }),
-  }),
 });
 
 export const passwordSchema = z

--- a/lib/validations/profile.ts
+++ b/lib/validations/profile.ts
@@ -1,0 +1,31 @@
+// lib/validations/profile.ts
+// Import from zod/v3 so @hookform/resolvers' zodResolver Zod-v3 overload
+// matches correctly, same pattern as lib/validations/auth.ts.
+import { z } from "zod/v3";
+
+export const LOCALES = ["en", "zh"] as const;
+export type Locale = (typeof LOCALES)[number];
+
+export const profileInfoSchema = z.object({
+  displayName: z
+    .string()
+    .trim()
+    .min(1, "Display name is required")
+    .max(60, "Display name must be 60 characters or fewer"),
+  locale: z.enum(LOCALES, {
+    errorMap: () => ({ message: "Please choose a language" }),
+  }),
+});
+
+export const passwordSchema = z
+  .object({
+    password: z.string().min(8, "Password must be at least 8 characters"),
+    confirmPassword: z.string(),
+  })
+  .refine((data) => data.password === data.confirmPassword, {
+    message: "Passwords do not match",
+    path: ["confirmPassword"],
+  });
+
+export type ProfileInfoFormValues = z.infer<typeof profileInfoSchema>;
+export type PasswordFormValues = z.infer<typeof passwordSchema>;

--- a/middleware.ts
+++ b/middleware.ts
@@ -1,18 +1,13 @@
+import { decideRedirect, isAdminPath } from "@/lib/auth/route-rules";
+import type { Database } from "@/types/supabase";
 import { createServerClient } from "@supabase/ssr";
 import { type NextRequest, NextResponse } from "next/server";
-
-// URL paths for app/(app)/* — route group parentheses don't appear in the URL.
-const PROTECTED_PATHS = ["/chat", "/clinics", "/learn", "/profile", "/admin"];
-
-function isProtected(pathname: string): boolean {
-  return PROTECTED_PATHS.some((p) => pathname === p || pathname.startsWith(`${p}/`));
-}
 
 export async function middleware(request: NextRequest) {
   // supabaseResponse must be returned so cookie mutations from setAll() reach the browser.
   let supabaseResponse = NextResponse.next({ request });
 
-  const supabase = createServerClient(
+  const supabase = createServerClient<Database>(
     // biome-ignore lint/style/noNonNullAssertion: env vars are always set in middleware
     process.env.NEXT_PUBLIC_SUPABASE_URL!,
     // biome-ignore lint/style/noNonNullAssertion: env vars are always set in middleware
@@ -40,9 +35,28 @@ export async function middleware(request: NextRequest) {
     data: { user },
   } = await supabase.auth.getUser();
 
-  if (!user && isProtected(request.nextUrl.pathname)) {
+  const pathname = request.nextUrl.pathname;
+
+  // Only query profiles.role when actually needed (admin gate).
+  let isAdmin = false;
+  if (user && isAdminPath(pathname)) {
+    const { data: profile } = await supabase
+      .from("profiles")
+      .select("role")
+      .eq("id", user.id)
+      .maybeSingle();
+    isAdmin = profile?.role === "admin";
+  }
+
+  const decision = decideRedirect({
+    pathname,
+    isAuthenticated: !!user,
+    isAdmin,
+  });
+
+  if (decision.type === "redirect") {
     const url = request.nextUrl.clone();
-    url.pathname = "/login";
+    url.pathname = decision.to;
     return NextResponse.redirect(url);
   }
 
@@ -50,5 +64,8 @@ export async function middleware(request: NextRequest) {
 }
 
 export const config = {
-  matcher: ["/((?!_next/static|_next/image|favicon.ico|.*\\.(?:svg|png|jpg|jpeg|gif|webp)$).*)"],
+  matcher: [
+    // Match everything except: Next internals, favicon, static image assets, and /api/webhooks.
+    "/((?!_next/static|_next/image|favicon.ico|api/webhooks|.*\\.(?:svg|png|jpg|jpeg|gif|webp)$).*)",
+  ],
 };

--- a/middleware.ts
+++ b/middleware.ts
@@ -1,0 +1,54 @@
+import { createServerClient } from "@supabase/ssr";
+import { type NextRequest, NextResponse } from "next/server";
+
+// URL paths for app/(app)/* — route group parentheses don't appear in the URL.
+const PROTECTED_PATHS = ["/chat", "/clinics", "/learn", "/profile", "/admin"];
+
+function isProtected(pathname: string): boolean {
+  return PROTECTED_PATHS.some((p) => pathname === p || pathname.startsWith(`${p}/`));
+}
+
+export async function middleware(request: NextRequest) {
+  // supabaseResponse must be returned so cookie mutations from setAll() reach the browser.
+  let supabaseResponse = NextResponse.next({ request });
+
+  const supabase = createServerClient(
+    // biome-ignore lint/style/noNonNullAssertion: env vars are always set in middleware
+    process.env.NEXT_PUBLIC_SUPABASE_URL!,
+    // biome-ignore lint/style/noNonNullAssertion: env vars are always set in middleware
+    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!,
+    {
+      cookies: {
+        getAll() {
+          return request.cookies.getAll();
+        },
+        setAll(cookiesToSet) {
+          for (const { name, value } of cookiesToSet) {
+            request.cookies.set(name, value);
+          }
+          supabaseResponse = NextResponse.next({ request });
+          for (const { name, value, options } of cookiesToSet) {
+            supabaseResponse.cookies.set(name, value, options);
+          }
+        },
+      },
+    }
+  );
+
+  // Use getUser() not getSession() — validates the token server-side and rotates it.
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+
+  if (!user && isProtected(request.nextUrl.pathname)) {
+    const url = request.nextUrl.clone();
+    url.pathname = "/login";
+    return NextResponse.redirect(url);
+  }
+
+  return supabaseResponse;
+}
+
+export const config = {
+  matcher: ["/((?!_next/static|_next/image|favicon.ico|.*\\.(?:svg|png|jpg|jpeg|gif|webp)$).*)"],
+};

--- a/package.json
+++ b/package.json
@@ -24,10 +24,12 @@
     "clsx": "^2.1.1",
     "lucide-react": "^1.7.0",
     "next": "14.2.29",
+    "next-themes": "^0.4.6",
     "react": "^18",
     "react-dom": "^18",
     "react-hook-form": "^7.72.1",
     "shadcn": "^4.2.0",
+    "sonner": "^2.0.7",
     "tailwind-merge": "^3.5.0",
     "tw-animate-css": "^1.4.0",
     "zod": "^4.3.6"

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
   },
   "dependencies": {
     "@base-ui/react": "^1.3.0",
+    "@hookform/resolvers": "^5.2.2",
     "@supabase/ssr": "^0.10.2",
     "@supabase/supabase-js": "^2.103.0",
     "class-variance-authority": "^0.7.1",
@@ -21,12 +22,15 @@
     "next": "14.2.29",
     "react": "^18",
     "react-dom": "^18",
+    "react-hook-form": "^7.72.1",
     "shadcn": "^4.2.0",
     "tailwind-merge": "^3.5.0",
-    "tw-animate-css": "^1.4.0"
+    "tw-animate-css": "^1.4.0",
+    "zod": "^4.3.6"
   },
   "devDependencies": {
     "@biomejs/biome": "^1.9.4",
+    "@playwright/test": "^1.59.1",
     "@types/node": "^20",
     "@types/react": "^18",
     "@types/react-dom": "^18",

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
   "dependencies": {
     "@base-ui/react": "^1.3.0",
     "@hookform/resolvers": "^5.2.2",
+    "@radix-ui/react-slot": "^1.2.4",
     "@supabase/ssr": "^0.10.2",
     "@supabase/supabase-js": "^2.103.0",
     "class-variance-authority": "^0.7.1",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -8,7 +8,7 @@ export default defineConfig({
   reporter: "list",
   use: {
     baseURL: "http://localhost:3000",
-    trace: "on-first-retry",
+    trace: "retain-on-failure",
   },
   projects: [
     {

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,0 +1,26 @@
+import { defineConfig, devices } from "@playwright/test";
+
+export default defineConfig({
+  testDir: "./e2e",
+  fullyParallel: false,
+  retries: 0,
+  workers: 1,
+  reporter: "list",
+  use: {
+    baseURL: "http://localhost:3000",
+    trace: "on-first-retry",
+  },
+  projects: [
+    {
+      name: "chromium",
+      use: { ...devices["Desktop Chrome"] },
+    },
+  ],
+  webServer: {
+    command: "pnpm dev",
+    url: "http://localhost:3000",
+    reuseExistingServer: !process.env.CI,
+    stdout: "ignore",
+    stderr: "pipe",
+  },
+});

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -2,7 +2,20 @@ import { readFileSync } from "node:fs";
 import { resolve } from "node:path";
 import { defineConfig, devices } from "@playwright/test";
 
-// Load .env.local for e2e helpers (Supabase service role key)
+// Force local dev Supabase env vars for the test process.
+// These must always point at the local stack regardless of any shell env overrides,
+// so the Supabase admin helper in e2e/helpers/supabase.ts uses the correct instance.
+const LOCAL_SUPABASE_URL = "http://127.0.0.1:54321";
+const LOCAL_ANON_KEY =
+  "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZS1kZW1vIiwicm9sZSI6ImFub24iLCJleHAiOjE5ODM4MTI5OTZ9.CRXP1A7WOeoJeXxjNni43kdQwgnWNReilDMblYTn_I0";
+const LOCAL_SERVICE_ROLE_KEY =
+  "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZS1kZW1vIiwicm9sZSI6InNlcnZpY2Vfcm9sZSIsImV4cCI6MTk4MzgxMjk5Nn0.EGIM96RAZx35lJzdJsyH-qQwv8Hdp7fsn3W0YpN81IU";
+
+process.env.NEXT_PUBLIC_SUPABASE_URL = LOCAL_SUPABASE_URL;
+process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY = LOCAL_ANON_KEY;
+process.env.SUPABASE_SERVICE_ROLE_KEY = LOCAL_SERVICE_ROLE_KEY;
+
+// Load remaining vars from .env.local (e.g. API keys used by the dev server)
 try {
   const envFile = readFileSync(resolve(process.cwd(), ".env.local"), "utf8");
   for (const line of envFile.split("\n")) {

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,4 +1,22 @@
 import { defineConfig, devices } from "@playwright/test";
+import { readFileSync } from "fs";
+import { resolve } from "path";
+
+// Load .env.local for e2e helpers (Supabase service role key)
+try {
+  const envFile = readFileSync(resolve(process.cwd(), ".env.local"), "utf8");
+  for (const line of envFile.split("\n")) {
+    const trimmed = line.trim();
+    if (!trimmed || trimmed.startsWith("#")) continue;
+    const eqIdx = trimmed.indexOf("=");
+    if (eqIdx === -1) continue;
+    const key = trimmed.slice(0, eqIdx).trim();
+    const value = trimmed.slice(eqIdx + 1).trim();
+    if (!process.env[key]) process.env[key] = value;
+  }
+} catch {
+  // .env.local not found, continue
+}
 
 export default defineConfig({
   testDir: "./e2e",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,6 +1,6 @@
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
 import { defineConfig, devices } from "@playwright/test";
-import { readFileSync } from "fs";
-import { resolve } from "path";
 
 // Load .env.local for e2e helpers (Supabase service role key)
 try {
@@ -40,5 +40,12 @@ export default defineConfig({
     reuseExistingServer: !process.env.CI,
     stdout: "ignore",
     stderr: "pipe",
+    env: {
+      NEXT_PUBLIC_SUPABASE_URL: "http://127.0.0.1:54321",
+      NEXT_PUBLIC_SUPABASE_ANON_KEY:
+        "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZS1kZW1vIiwicm9sZSI6ImFub24iLCJleHAiOjE5ODM4MTI5OTZ9.CRXP1A7WOeoJeXxjNni43kdQwgnWNReilDMblYTn_I0",
+      SUPABASE_SERVICE_ROLE_KEY:
+        "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZS1kZW1vIiwicm9sZSI6InNlcnZpY2Vfcm9sZSIsImV4cCI6MTk4MzgxMjk5Nn0.EGIM96RAZx35lJzdJsyH-qQwv8Hdp7fsn3W0YpN81IU",
+    },
   },
 });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,6 +11,9 @@ importers:
       '@base-ui/react':
         specifier: ^1.3.0
         version: 1.3.0(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@hookform/resolvers':
+        specifier: ^5.2.2
+        version: 5.2.2(react-hook-form@7.72.1(react@18.3.1))
       '@supabase/ssr':
         specifier: ^0.10.2
         version: 0.10.2(@supabase/supabase-js@2.103.0)
@@ -28,13 +31,16 @@ importers:
         version: 1.7.0(react@18.3.1)
       next:
         specifier: 14.2.29
-        version: 14.2.29(@babel/core@7.29.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+        version: 14.2.29(@babel/core@7.29.0)(@playwright/test@1.59.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       react:
         specifier: ^18
         version: 18.3.1
       react-dom:
         specifier: ^18
         version: 18.3.1(react@18.3.1)
+      react-hook-form:
+        specifier: ^7.72.1
+        version: 7.72.1(react@18.3.1)
       shadcn:
         specifier: ^4.2.0
         version: 4.2.0(@types/node@20.19.39)(typescript@5.9.3)
@@ -44,10 +50,16 @@ importers:
       tw-animate-css:
         specifier: ^1.4.0
         version: 1.4.0
+      zod:
+        specifier: ^4.3.6
+        version: 4.3.6
     devDependencies:
       '@biomejs/biome':
         specifier: ^1.9.4
         version: 1.9.4
+      '@playwright/test':
+        specifier: ^1.59.1
+        version: 1.59.1
       '@types/node':
         specifier: ^20
         version: 20.19.39
@@ -318,6 +330,11 @@ packages:
     peerDependencies:
       hono: ^4
 
+  '@hookform/resolvers@5.2.2':
+    resolution: {integrity: sha512-A/IxlMLShx3KjV/HeTcTfaMxdwy690+L/ZADoeaTltLx+CVuzkeVIPuybK3jrRfw7YZnmdKsVVHAlEPIAEUNlA==}
+    peerDependencies:
+      react-hook-form: ^7.55.0
+
   '@inquirer/ansi@1.0.2':
     resolution: {integrity: sha512-S8qNSZiYzFd0wAcyG5AXCvUHC5Sr7xpZ9wZ2py9XR88jUz8wooStVx5M6dRzczbBWjic9NP7+rY0Xi7qqK/aMQ==}
     engines: {node: '>=18'}
@@ -477,12 +494,20 @@ packages:
   '@open-draft/until@2.1.0':
     resolution: {integrity: sha512-U69T3ItWHvLwGg5eJ0n3I62nWuE6ilHlmz7zM0npLBRvPRd7e6NYmg54vvRtP5mZG7kZqZCFVdsTWo7BPtBujg==}
 
+  '@playwright/test@1.59.1':
+    resolution: {integrity: sha512-PG6q63nQg5c9rIi4/Z5lR5IVF7yU5MqmKaPOe0HSc0O2cX1fPi96sUQu5j7eo4gKCkB2AnNGoWt7y4/Xx3Kcqg==}
+    engines: {node: '>=18'}
+    hasBin: true
+
   '@sec-ant/readable-stream@0.4.1':
     resolution: {integrity: sha512-831qok9r2t8AlxLko40y2ebgSDhenenCatLVeW/uBtnHPyhHOvG0C7TvfgecV+wHzIm5KUICgzmVpWS+IMEAeg==}
 
   '@sindresorhus/merge-streams@4.0.0':
     resolution: {integrity: sha512-tlqY9xq5ukxTUZBmoOp+m61cqwQD5pHJtFY3Mn8CA8ps6yghLH/Hw8UPdqg4OLmFW3IFlcXnQNmo/dh8HzXYIQ==}
     engines: {node: '>=18'}
+
+  '@standard-schema/utils@0.3.0':
+    resolution: {integrity: sha512-e7Mew686owMaPJVNNLs55PUvgz371nKgwsc4vxE49zsODpJEnxgxRo2y/OKrqueavXgZNMDVj3DdHFlaSAeU8g==}
 
   '@supabase/auth-js@2.103.0':
     resolution: {integrity: sha512-6zAanO6c+6gpHOlt5Lb9TlBBkJdZiUWkWCJKAxzkywBDcwaHlLJKXnjQGX6GyVCyKRR1e7sTq4re/yRTH6U/9A==}
@@ -964,6 +989,11 @@ packages:
   fs-extra@11.3.4:
     resolution: {integrity: sha512-CTXd6rk/M3/ULNQj8FBqBWHYBVYybQ3VPBw0xGKFe3tuH7ytT6ACnvzpIQ3UZtB8yvUKC2cXn1a+x+5EVQLovA==}
     engines: {node: '>=14.14'}
+
+  fsevents@2.3.2:
+    resolution: {integrity: sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==}
+    engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
+    os: [darwin]
 
   fsevents@2.3.3:
     resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
@@ -1460,6 +1490,16 @@ packages:
     resolution: {integrity: sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ==}
     engines: {node: '>=16.20.0'}
 
+  playwright-core@1.59.1:
+    resolution: {integrity: sha512-HBV/RJg81z5BiiZ9yPzIiClYV/QMsDCKUyogwH9p3MCP6IYjUFu/MActgYAvK0oWyV9NlwM3GLBjADyWgydVyg==}
+    engines: {node: '>=18'}
+    hasBin: true
+
+  playwright@1.59.1:
+    resolution: {integrity: sha512-C8oWjPR3F81yljW9o5OxcWzfh6avkVwDD2VYdwIGqTkl+OGFISgypqzfu7dOe4QNLL2aqcWBmI3PMtLIK233lw==}
+    engines: {node: '>=18'}
+    hasBin: true
+
   postcss-import@15.1.0:
     resolution: {integrity: sha512-hpr+J05B2FVYUAXHeK1YyI267J/dDDhMU6B6civm8hSY1jYJnBXxzKDKDswzJmtLHryrjhnDjqqp/49t8FALew==}
     engines: {node: '>=14.0.0'}
@@ -1550,6 +1590,12 @@ packages:
     resolution: {integrity: sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==}
     peerDependencies:
       react: ^18.3.1
+
+  react-hook-form@7.72.1:
+    resolution: {integrity: sha512-RhwBoy2ygeVZje+C+bwJ8g0NjTdBmDlJvAUHTxRjTmSUKPYsKfMphkS2sgEMotsY03bP358yEYlnUeZy//D9Ig==}
+    engines: {node: '>=18.0.0'}
+    peerDependencies:
+      react: ^16.8.0 || ^17 || ^18 || ^19
 
   react@18.3.1:
     resolution: {integrity: sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==}
@@ -1937,6 +1983,9 @@ packages:
   zod@3.25.76:
     resolution: {integrity: sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==}
 
+  zod@4.3.6:
+    resolution: {integrity: sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==}
+
 snapshots:
 
   '@alloc/quick-lru@5.2.0': {}
@@ -2226,6 +2275,11 @@ snapshots:
     dependencies:
       hono: 4.12.12
 
+  '@hookform/resolvers@5.2.2(react-hook-form@7.72.1(react@18.3.1))':
+    dependencies:
+      '@standard-schema/utils': 0.3.0
+      react-hook-form: 7.72.1(react@18.3.1)
+
   '@inquirer/ansi@1.0.2': {}
 
   '@inquirer/confirm@5.1.21(@types/node@20.19.39)':
@@ -2362,9 +2416,15 @@ snapshots:
 
   '@open-draft/until@2.1.0': {}
 
+  '@playwright/test@1.59.1':
+    dependencies:
+      playwright: 1.59.1
+
   '@sec-ant/readable-stream@0.4.1': {}
 
   '@sindresorhus/merge-streams@4.0.0': {}
+
+  '@standard-schema/utils@0.3.0': {}
 
   '@supabase/auth-js@2.103.0':
     dependencies:
@@ -2850,6 +2910,9 @@ snapshots:
       jsonfile: 6.2.0
       universalify: 2.0.1
 
+  fsevents@2.3.2:
+    optional: true
+
   fsevents@2.3.3:
     optional: true
 
@@ -3129,7 +3192,7 @@ snapshots:
 
   negotiator@1.0.0: {}
 
-  next@14.2.29(@babel/core@7.29.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
+  next@14.2.29(@babel/core@7.29.0)(@playwright/test@1.59.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
     dependencies:
       '@next/env': 14.2.29
       '@swc/helpers': 0.5.5
@@ -3150,6 +3213,7 @@ snapshots:
       '@next/swc-win32-arm64-msvc': 14.2.29
       '@next/swc-win32-ia32-msvc': 14.2.29
       '@next/swc-win32-x64-msvc': 14.2.29
+      '@playwright/test': 1.59.1
     transitivePeerDependencies:
       - '@babel/core'
       - babel-plugin-macros
@@ -3261,6 +3325,14 @@ snapshots:
 
   pkce-challenge@5.0.1: {}
 
+  playwright-core@1.59.1: {}
+
+  playwright@1.59.1:
+    dependencies:
+      playwright-core: 1.59.1
+    optionalDependencies:
+      fsevents: 2.3.2
+
   postcss-import@15.1.0(postcss@8.5.9):
     dependencies:
       postcss: 8.5.9
@@ -3345,6 +3417,10 @@ snapshots:
       loose-envify: 1.4.0
       react: 18.3.1
       scheduler: 0.23.2
+
+  react-hook-form@7.72.1(react@18.3.1):
+    dependencies:
+      react: 18.3.1
 
   react@18.3.1:
     dependencies:
@@ -3766,3 +3842,5 @@ snapshots:
       zod: 3.25.76
 
   zod@3.25.76: {}
+
+  zod@4.3.6: {}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -35,6 +35,9 @@ importers:
       next:
         specifier: 14.2.29
         version: 14.2.29(@babel/core@7.29.0)(@playwright/test@1.59.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      next-themes:
+        specifier: ^0.4.6
+        version: 0.4.6(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       react:
         specifier: ^18
         version: 18.3.1
@@ -47,6 +50,9 @@ importers:
       shadcn:
         specifier: ^4.2.0
         version: 4.2.0(@types/node@20.19.39)(typescript@5.9.3)
+      sonner:
+        specifier: ^2.0.7
+        version: 2.0.7(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       tailwind-merge:
         specifier: ^3.5.0
         version: 3.5.0
@@ -1827,6 +1833,12 @@ packages:
     resolution: {integrity: sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==}
     engines: {node: '>= 0.6'}
 
+  next-themes@0.4.6:
+    resolution: {integrity: sha512-pZvgD5L0IEvX5/9GWyHMf3m8BKiVQwsCMHfoFosXtXBMnaS0ZnIJ9ST4b4NqLVKDEm8QBxoNNGNaBv2JNF6XNA==}
+    peerDependencies:
+      react: ^16.8 || ^17 || ^18 || ^19 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17 || ^18 || ^19 || ^19.0.0-rc
+
   next@14.2.29:
     resolution: {integrity: sha512-s98mCOMOWLGGpGOfgKSnleXLuegvvH415qtRZXpSp00HeEgdmrxmwL9cgKU+h4XrhB16zEI5d/7BnkS3ATInsA==}
     engines: {node: '>=18.17.0'}
@@ -2228,6 +2240,12 @@ packages:
 
   sisteransi@1.0.5:
     resolution: {integrity: sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg==}
+
+  sonner@2.0.7:
+    resolution: {integrity: sha512-W6ZN4p58k8aDKA4XPcx2hpIQXBRAgyiWVkYhT7CvK6D3iAu7xjvVyhQHg2/iaKJZ1XVJ4r7XuwGL+WGEK37i9w==}
+    peerDependencies:
+      react: ^18.0.0 || ^19.0.0 || ^19.0.0-rc
+      react-dom: ^18.0.0 || ^19.0.0 || ^19.0.0-rc
 
   source-map-js@1.2.1:
     resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
@@ -4235,6 +4253,11 @@ snapshots:
 
   negotiator@1.0.0: {}
 
+  next-themes@0.4.6(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
+    dependencies:
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+
   next@14.2.29(@babel/core@7.29.0)(@playwright/test@1.59.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
     dependencies:
       '@next/env': 14.2.29
@@ -4691,6 +4714,11 @@ snapshots:
   signal-exit@4.1.0: {}
 
   sisteransi@1.0.5: {}
+
+  sonner@2.0.7(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
+    dependencies:
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
 
   source-map-js@1.2.1: {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -14,6 +14,9 @@ importers:
       '@hookform/resolvers':
         specifier: ^5.2.2
         version: 5.2.2(react-hook-form@7.72.1(react@18.3.1))
+      '@radix-ui/react-slot':
+        specifier: ^1.2.4
+        version: 1.2.4(@types/react@18.3.28)(react@18.3.1)
       '@supabase/ssr':
         specifier: ^0.10.2
         version: 0.10.2(@supabase/supabase-js@2.103.0)
@@ -498,6 +501,24 @@ packages:
     resolution: {integrity: sha512-PG6q63nQg5c9rIi4/Z5lR5IVF7yU5MqmKaPOe0HSc0O2cX1fPi96sUQu5j7eo4gKCkB2AnNGoWt7y4/Xx3Kcqg==}
     engines: {node: '>=18'}
     hasBin: true
+
+  '@radix-ui/react-compose-refs@1.1.2':
+    resolution: {integrity: sha512-z4eqJvfiNnFMHIIvXP3CY57y2WJs5g2v3X0zm9mEJkrkNv4rDxu+sg9Jh8EkXyeqBkB7SOcboo9dMVqhyrACIg==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@radix-ui/react-slot@1.2.4':
+    resolution: {integrity: sha512-Jl+bCv8HxKnlTLVrcDE8zTMJ09R9/ukw4qBs/oZClOfoQk/cOTbDn+NceXfV7j09YPVQUryJPHurafcSg6EVKA==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
 
   '@sec-ant/readable-stream@0.4.1':
     resolution: {integrity: sha512-831qok9r2t8AlxLko40y2ebgSDhenenCatLVeW/uBtnHPyhHOvG0C7TvfgecV+wHzIm5KUICgzmVpWS+IMEAeg==}
@@ -2419,6 +2440,19 @@ snapshots:
   '@playwright/test@1.59.1':
     dependencies:
       playwright: 1.59.1
+
+  '@radix-ui/react-compose-refs@1.1.2(@types/react@18.3.28)(react@18.3.1)':
+    dependencies:
+      react: 18.3.1
+    optionalDependencies:
+      '@types/react': 18.3.28
+
+  '@radix-ui/react-slot@1.2.4(@types/react@18.3.28)(react@18.3.1)':
+    dependencies:
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@18.3.28)(react@18.3.1)
+      react: 18.3.1
+    optionalDependencies:
+      '@types/react': 18.3.28
 
   '@sec-ant/readable-stream@0.4.1': {}
 

--- a/supabase/config.toml
+++ b/supabase/config.toml
@@ -152,8 +152,13 @@ enabled = true
 # The base URL of your website. Used as an allow-list for redirects and for constructing URLs used
 # in emails.
 site_url = "http://127.0.0.1:3000"
-# A list of *exact* URLs that auth providers are permitted to redirect to post authentication.
-additional_redirect_urls = ["https://127.0.0.1:3000"]
+# A list of URLs that auth providers are permitted to redirect to post authentication.
+# Supports wildcards: `*` (one path segment) and `**` (multiple segments).
+# Both 127.0.0.1 and localhost origins are whitelisted because browsers treat them as distinct.
+additional_redirect_urls = [
+  "http://127.0.0.1:3000/**",
+  "http://localhost:3000/**",
+]
 # How long tokens are valid for, in seconds. Defaults to 3600 (1 hour), maximum 604,800 (1 week).
 jwt_expiry = 3600
 # JWT issuer URL. If not set, defaults to the local API URL (http://127.0.0.1:<port>/auth/v1).
@@ -241,7 +246,7 @@ otp_expiry = 3600
 # Allow/disallow new user signups via SMS to your project.
 enable_signup = false
 # If enabled, users need to confirm their phone number before signing in.
-enable_confirmations = true
+enable_confirmations = false
 # Template for sending OTP to users
 template = "Your code is {{ .Code }}"
 # Controls the minimum amount of time that must pass before sending another sms otp.

--- a/supabase/config.toml
+++ b/supabase/config.toml
@@ -206,7 +206,7 @@ enable_signup = true
 # addresses. If disabled, only the new email is required to confirm.
 double_confirm_changes = true
 # If enabled, users need to confirm their email address before signing in.
-enable_confirmations = false
+enable_confirmations = true
 # If enabled, users will need to reauthenticate or have logged in recently to change their password.
 secure_password_change = false
 # Controls the minimum amount of time that must pass before sending another signup confirmation or password reset email.
@@ -241,7 +241,7 @@ otp_expiry = 3600
 # Allow/disallow new user signups via SMS to your project.
 enable_signup = false
 # If enabled, users need to confirm their phone number before signing in.
-enable_confirmations = false
+enable_confirmations = true
 # Template for sending OTP to users
 template = "Your code is {{ .Code }}"
 # Controls the minimum amount of time that must pass before sending another sms otp.

--- a/supabase/migrations/20260409165311_enable_pgvector_and_create_profiles.sql
+++ b/supabase/migrations/20260409165311_enable_pgvector_and_create_profiles.sql
@@ -3,13 +3,15 @@ create extension if not exists vector;
 
 -- Profiles table - one row per auth.users entry
 create table public.profiles (
-  id         uuid references auth.users primary key,
-  email      text,
-  role       text check (role in ('guest', 'user', 'admin')) default 'user',
-  full_name  text,
-  avatar_url text,
-  locale     text default 'en',
-  created_at timestamptz default now()
+  id           uuid references auth.users(id) on delete cascade primary key,
+  email        text,
+  role         text check (role in ('guest', 'user', 'admin')) default 'user',
+  full_name    text,
+  avatar_url   text,
+  display_name text,
+  locale       text default 'en',
+  created_at   timestamptz default now(),
+  updated_at   timestamptz default now()
 );
 
 -- Helper: returns true if the calling user has role = 'admin' in profiles.
@@ -24,12 +26,18 @@ returns boolean as $$
 $$ language sql security definer stable
    set search_path = '';
 
--- Auto-create a profile row whenever a new user signs up via Supabase Auth
+-- Auto-create a profile row whenever a new user signs up via Supabase Auth.
+-- Copies display_name from auth metadata when present; nullif() coerces empty
+-- strings to null so the column stays clean.
 create or replace function public.handle_new_user()
 returns trigger as $$
 begin
-  insert into public.profiles (id, email)
-  values (new.id, new.email)
+  insert into public.profiles (id, email, display_name)
+  values (
+    new.id,
+    new.email,
+    nullif(new.raw_user_meta_data->>'display_name', '')
+  )
   on conflict (id) do nothing;
   return new;
 end;
@@ -39,6 +47,21 @@ $$ language plpgsql security definer
 create trigger on_auth_user_created
   after insert on auth.users
   for each row execute function public.handle_new_user();
+
+-- Auto-advance public.profiles.updated_at on every row update. Not
+-- SECURITY DEFINER — this is a row-local mutation, the caller's role is fine.
+create or replace function public.handle_profile_updated_at()
+returns trigger as $$
+begin
+  new.updated_at = clock_timestamp();
+  return new;
+end;
+$$ language plpgsql;
+
+drop trigger if exists profiles_set_updated_at on public.profiles;
+create trigger profiles_set_updated_at
+  before update on public.profiles
+  for each row execute function public.handle_profile_updated_at();
 
 -- RLS
 alter table public.profiles enable row level security;

--- a/supabase/migrations/20260409165311_enable_pgvector_and_create_profiles.sql
+++ b/supabase/migrations/20260409165311_enable_pgvector_and_create_profiles.sql
@@ -62,17 +62,3 @@ drop trigger if exists profiles_set_updated_at on public.profiles;
 create trigger profiles_set_updated_at
   before update on public.profiles
   for each row execute function public.handle_profile_updated_at();
-
--- RLS
-alter table public.profiles enable row level security;
-
--- A user can read their own profile; admins can read any profile
-create policy "profiles: self or admin can select"
-  on public.profiles for select
-  using (auth.uid() = id or public.is_admin());
-
--- A user can update their own profile; admins can update any
-create policy "profiles: self or admin can update"
-  on public.profiles for update
-  using (auth.uid() = id or public.is_admin())
-  with check (auth.uid() = id or public.is_admin());

--- a/supabase/migrations/20260409170402_create_chat_tables.sql
+++ b/supabase/migrations/20260409170402_create_chat_tables.sql
@@ -34,31 +34,3 @@ create table public.chat_messages (
 );
 
 create index on public.chat_messages (session_id);
-
--- RLS: chat_sessions
-alter table public.chat_sessions enable row level security;
-
-create policy "chat_sessions: owner or admin"
-  on public.chat_sessions for all
-  using (auth.uid() = user_id or public.is_admin())
-  with check (auth.uid() = user_id or public.is_admin());
-
--- RLS: chat_messages (access via session ownership)
-alter table public.chat_messages enable row level security;
-
-create policy "chat_messages: owner or admin"
-  on public.chat_messages for all
-  using (
-    exists (
-      select 1 from public.chat_sessions s
-      where s.id = chat_messages.session_id
-        and (s.user_id = auth.uid() or public.is_admin())
-    )
-  )
-  with check (
-    exists (
-      select 1 from public.chat_sessions s
-      where s.id = chat_messages.session_id
-        and (s.user_id = auth.uid() or public.is_admin())
-    )
-  );

--- a/supabase/migrations/20260409170904_create_knowledge_chunks.sql
+++ b/supabase/migrations/20260409170904_create_knowledge_chunks.sql
@@ -44,25 +44,3 @@ as $$
   order by embedding <=> query_embedding
   limit match_count;
 $$;
-
--- RLS: knowledge_chunks
-alter table public.knowledge_chunks enable row level security;
-
--- Public health content - all roles (anon and authenticated) can read.
--- The server-side RAG agent uses the anon key, so anon must be permitted.
-create policy "knowledge_chunks: anyone can read"
-  on public.knowledge_chunks for select
-  using (true);
-
--- Only admins can ingest (insert), update, or delete chunks
-create policy "knowledge_chunks: admins can insert"
-  on public.knowledge_chunks for insert
-  with check (public.is_admin());
-
-create policy "knowledge_chunks: admins can update"
-  on public.knowledge_chunks for update
-  using (public.is_admin());
-
-create policy "knowledge_chunks: admins can delete"
-  on public.knowledge_chunks for delete
-  using (public.is_admin());

--- a/supabase/migrations/20260409171255_create_analytics_events.sql
+++ b/supabase/migrations/20260409171255_create_analytics_events.sql
@@ -12,16 +12,3 @@ create index on public.analytics_events (user_id);
 
 -- Index for common admin queries: events by type over time
 create index on public.analytics_events (event_type, created_at desc);
-
--- RLS: analytics_events
-alter table public.analytics_events enable row level security;
-
--- Authenticated users can log their own events
-create policy "analytics_events: users can insert own"
-  on public.analytics_events for insert
-  with check (auth.uid() = user_id);
-
--- Only admins can read events (for the analytics dashboard)
-create policy "analytics_events: admins can read all"
-  on public.analytics_events for select
-  using (public.is_admin());

--- a/supabase/migrations/20260413143757_rls_policies.sql
+++ b/supabase/migrations/20260413143757_rls_policies.sql
@@ -1,0 +1,126 @@
+-- Epic 2 · #12 · RLS policies for all Epic-1 tables.
+--
+-- Sole source of truth for RLS. Inline policies in the creation migrations
+-- were removed in the same commit as this file. Per-policy comments explain
+-- the role model; see docs/database.md for the high-level matrix.
+--
+-- Depends on the public.is_admin() helper defined in
+-- 20260409165311_enable_pgvector_and_create_profiles.sql, which is a
+-- SECURITY DEFINER function that reads profiles.role without triggering
+-- its own RLS (avoids the classic "policy recursion on profiles" trap).
+
+-- ───── profiles ──────────────────────────────────────────────────────────
+alter table public.profiles enable row level security;
+
+-- A user can read their own row; admins can read every row.
+create policy "profiles: self or admin can select"
+  on public.profiles for select
+  using (auth.uid() = id or public.is_admin());
+
+-- A user can update their own row; admins can update any row.
+-- The WITH CHECK mirrors USING so a user can't re-target the row to another id.
+create policy "profiles: self or admin can update"
+  on public.profiles for update
+  using (auth.uid() = id or public.is_admin())
+  with check (auth.uid() = id or public.is_admin());
+
+-- No INSERT or DELETE policy: inserts happen via the SECURITY DEFINER
+-- trigger public.handle_new_user() on auth.users (bypasses RLS), and user
+-- rows are deleted via auth.users cascade when an account is removed.
+
+-- ───── chat_sessions ─────────────────────────────────────────────────────
+alter table public.chat_sessions enable row level security;
+
+-- Owners have full CRUD over their own sessions.
+create policy "chat_sessions: owner full access"
+  on public.chat_sessions for all
+  to authenticated
+  using (auth.uid() = user_id)
+  with check (auth.uid() = user_id);
+
+-- Admins are read-only — the analytics dashboard and moderation tooling
+-- need to see conversations but must not mutate user data.
+create policy "chat_sessions: admin read all"
+  on public.chat_sessions for select
+  to authenticated
+  using (public.is_admin());
+
+-- ───── chat_messages ─────────────────────────────────────────────────────
+alter table public.chat_messages enable row level security;
+
+-- Owners have full CRUD over messages in their own sessions. The ownership
+-- check joins via chat_sessions rather than storing user_id on the row,
+-- keeping the schema normalised.
+create policy "chat_messages: owner full access via session"
+  on public.chat_messages for all
+  to authenticated
+  using (
+    exists (
+      select 1 from public.chat_sessions s
+      where s.id = chat_messages.session_id
+        and s.user_id = auth.uid()
+    )
+  )
+  with check (
+    exists (
+      select 1 from public.chat_sessions s
+      where s.id = chat_messages.session_id
+        and s.user_id = auth.uid()
+    )
+  );
+
+-- Admins can read every message for analytics/moderation (read-only).
+create policy "chat_messages: admin read all"
+  on public.chat_messages for select
+  to authenticated
+  using (public.is_admin());
+
+-- ───── knowledge_chunks ──────────────────────────────────────────────────
+alter table public.knowledge_chunks enable row level security;
+
+-- Authenticated users (including non-admins) can read the health knowledge
+-- base. NOTE: the original migration used `using (true)` so the anon key
+-- could serve guest chat; #12 tightens this to authenticated-only. If a
+-- guest-chat feature is built later, relax this policy or route guest
+-- traffic through the service role in /api/chat.
+create policy "knowledge_chunks: authenticated can select"
+  on public.knowledge_chunks for select
+  to authenticated
+  using (true);
+
+-- Only admins can ingest, update, or delete knowledge chunks.
+create policy "knowledge_chunks: admins can insert"
+  on public.knowledge_chunks for insert
+  to authenticated
+  with check (public.is_admin());
+
+create policy "knowledge_chunks: admins can update"
+  on public.knowledge_chunks for update
+  to authenticated
+  using (public.is_admin())
+  with check (public.is_admin());
+
+create policy "knowledge_chunks: admins can delete"
+  on public.knowledge_chunks for delete
+  to authenticated
+  using (public.is_admin());
+
+-- ───── analytics_events ──────────────────────────────────────────────────
+alter table public.analytics_events enable row level security;
+
+-- Authenticated users can log events attributed to themselves; they cannot
+-- forge events with another user's id (WITH CHECK on user_id).
+create policy "analytics_events: users can insert own"
+  on public.analytics_events for insert
+  to authenticated
+  with check (auth.uid() = user_id);
+
+-- Only admins can read the analytics table (powers the admin dashboard).
+create policy "analytics_events: admins can select all"
+  on public.analytics_events for select
+  to authenticated
+  using (public.is_admin());
+
+-- No UPDATE or DELETE policy: events are append-only for audit purposes.
+-- The GDPR delete flow nulls out user_id via the FK (ON DELETE SET NULL)
+-- set in 20260409171500_fix_analytics_events_fk_on_delete.sql.

--- a/supabase/migrations/20260413143757_rls_policies.sql
+++ b/supabase/migrations/20260413143757_rls_policies.sql
@@ -15,12 +15,14 @@ alter table public.profiles enable row level security;
 -- A user can read their own row; admins can read every row.
 create policy "profiles: self or admin can select"
   on public.profiles for select
+  to authenticated
   using (auth.uid() = id or public.is_admin());
 
 -- A user can update their own row; admins can update any row.
 -- The WITH CHECK mirrors USING so a user can't re-target the row to another id.
 create policy "profiles: self or admin can update"
   on public.profiles for update
+  to authenticated
   using (auth.uid() = id or public.is_admin())
   with check (auth.uid() = id or public.is_admin());
 

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -29,7 +29,8 @@ const config: Config = {
         ring: "var(--ring)",
       },
       fontFamily: {
-        sans: ["var(--font-camera)", "ui-sans-serif", "system-ui"],
+        // var(--font-camera) re-enabled once the licensed CameraPlainVariable font is added
+        sans: ["ui-sans-serif", "system-ui"],
       },
       fontWeight: {
         // Override to ensure 700 is never reachable via Tailwind utilities

--- a/tests/api/auth-callback.test.ts
+++ b/tests/api/auth-callback.test.ts
@@ -1,0 +1,83 @@
+// tests/api/auth-callback.test.ts
+// @vitest-environment node
+
+import { NextRequest } from "next/server";
+import { beforeEach, describe, expect, test, vi } from "vitest";
+
+vi.mock("@/lib/supabase/server", () => ({
+  createClient: vi.fn(),
+}));
+
+import { GET } from "@/app/api/auth/callback/route";
+import { createClient } from "@/lib/supabase/server";
+
+type MockedClient = {
+  auth: {
+    exchangeCodeForSession: ReturnType<typeof vi.fn>;
+    verifyOtp: ReturnType<typeof vi.fn>;
+  };
+};
+
+function mockClient(overrides: Partial<MockedClient["auth"]> = {}): MockedClient {
+  return {
+    auth: {
+      exchangeCodeForSession: vi.fn().mockResolvedValue({ error: null }),
+      verifyOtp: vi.fn().mockResolvedValue({ error: null }),
+      ...overrides,
+    },
+  };
+}
+
+describe("GET /api/auth/callback", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  test("with valid ?code= exchanges for session and redirects to next", async () => {
+    const client = mockClient();
+    vi.mocked(createClient).mockReturnValue(client as never);
+
+    const req = new NextRequest(
+      "http://localhost:3000/api/auth/callback?code=abc123&next=/reset-password"
+    );
+    const res = await GET(req);
+
+    expect(client.auth.exchangeCodeForSession).toHaveBeenCalledWith("abc123");
+    expect(res.headers.get("location")).toBe("http://localhost:3000/reset-password");
+  });
+
+  test("with ?code= but exchange error redirects to /login?error=link-expired", async () => {
+    const client = mockClient({
+      exchangeCodeForSession: vi.fn().mockResolvedValue({ error: new Error("bad code") }),
+    });
+    vi.mocked(createClient).mockReturnValue(client as never);
+
+    const req = new NextRequest("http://localhost:3000/api/auth/callback?code=bad");
+    const res = await GET(req);
+
+    expect(res.headers.get("location")).toBe("http://localhost:3000/login?error=link-expired");
+  });
+
+  test("with ?token_hash= and ?type= still works (existing behavior)", async () => {
+    const client = mockClient();
+    vi.mocked(createClient).mockReturnValue(client as never);
+
+    const req = new NextRequest(
+      "http://localhost:3000/api/auth/callback?token_hash=hash123&type=recovery&next=/reset-password"
+    );
+    const res = await GET(req);
+
+    expect(client.auth.verifyOtp).toHaveBeenCalledWith({
+      token_hash: "hash123",
+      type: "recovery",
+    });
+    expect(res.headers.get("location")).toBe("http://localhost:3000/reset-password");
+  });
+
+  test("with no params redirects to /login?error=link-expired", async () => {
+    const req = new NextRequest("http://localhost:3000/api/auth/callback");
+    const res = await GET(req);
+
+    expect(res.headers.get("location")).toBe("http://localhost:3000/login?error=link-expired");
+  });
+});

--- a/tests/db/profiles.test.ts
+++ b/tests/db/profiles.test.ts
@@ -1,0 +1,139 @@
+// tests/db/profiles.test.ts
+// @vitest-environment node
+
+import { type SupabaseClient, createClient } from "@supabase/supabase-js";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+
+const SUPABASE_URL = process.env.SUPABASE_URL ?? "http://127.0.0.1:54321";
+const SERVICE_ROLE = process.env.SUPABASE_SERVICE_ROLE_KEY;
+
+// Skip the entire suite when the local Supabase service role key is not
+// available — lets the test be part of the default `pnpm test` run without
+// breaking CI environments that don't have Supabase up.
+describe.runIf(Boolean(SERVICE_ROLE))("profiles migration (#11)", () => {
+  let supabase: SupabaseClient;
+  const createdUserIds: string[] = [];
+
+  beforeAll(() => {
+    supabase = createClient(SUPABASE_URL, SERVICE_ROLE as string, {
+      auth: { persistSession: false, autoRefreshToken: false },
+    });
+  });
+
+  afterAll(async () => {
+    for (const id of createdUserIds) {
+      await supabase.auth.admin.deleteUser(id);
+    }
+  });
+
+  it("has display_name and updated_at columns on public.profiles", async () => {
+    const { data, error } = await supabase
+      .from("profiles")
+      .select("id, email, display_name, role, locale, created_at, updated_at")
+      .limit(0);
+    expect(error).toBeNull();
+    expect(data).toBeDefined();
+  });
+
+  it("auto-creates a profile row on signup with null display_name when no metadata is sent", async () => {
+    const email = `epic2-no-meta-${Date.now()}@example.com`;
+    const { data, error } = await supabase.auth.admin.createUser({
+      email,
+      password: "password1234",
+      email_confirm: true,
+    });
+    expect(error).toBeNull();
+    const userId = data.user?.id as string;
+    createdUserIds.push(userId);
+
+    const { data: profile, error: pErr } = await supabase
+      .from("profiles")
+      .select("id, email, display_name, created_at, updated_at")
+      .eq("id", userId)
+      .single();
+    expect(pErr).toBeNull();
+    expect(profile?.id).toBe(userId);
+    expect(profile?.email).toBe(email);
+    expect(profile?.display_name).toBeNull();
+    expect(profile?.created_at).toBeTruthy();
+    expect(profile?.updated_at).toBeTruthy();
+  });
+
+  it("populates display_name from raw_user_meta_data on signup", async () => {
+    const email = `epic2-with-meta-${Date.now()}@example.com`;
+    const { data, error } = await supabase.auth.admin.createUser({
+      email,
+      password: "password1234",
+      email_confirm: true,
+      user_metadata: { display_name: "Ada Lovelace" },
+    });
+    expect(error).toBeNull();
+    const userId = data.user?.id as string;
+    createdUserIds.push(userId);
+
+    const { data: profile, error: pErr } = await supabase
+      .from("profiles")
+      .select("display_name")
+      .eq("id", userId)
+      .single();
+    expect(pErr).toBeNull();
+    expect(profile?.display_name).toBe("Ada Lovelace");
+  });
+
+  it("coerces an empty-string display_name in metadata to null", async () => {
+    const email = `epic2-empty-meta-${Date.now()}@example.com`;
+    const { data, error } = await supabase.auth.admin.createUser({
+      email,
+      password: "password1234",
+      email_confirm: true,
+      user_metadata: { display_name: "" },
+    });
+    expect(error).toBeNull();
+    const userId = data.user?.id as string;
+    createdUserIds.push(userId);
+
+    const { data: profile, error: pErr } = await supabase
+      .from("profiles")
+      .select("display_name")
+      .eq("id", userId)
+      .single();
+    expect(pErr).toBeNull();
+    expect(profile?.display_name).toBeNull();
+  });
+
+  it("advances updated_at when a profile row is updated", async () => {
+    const email = `epic2-updated-at-${Date.now()}@example.com`;
+    const { data } = await supabase.auth.admin.createUser({
+      email,
+      password: "password1234",
+      email_confirm: true,
+    });
+    const userId = data.user?.id as string;
+    createdUserIds.push(userId);
+
+    const { data: before } = await supabase
+      .from("profiles")
+      .select("updated_at")
+      .eq("id", userId)
+      .single();
+
+    // Wait a few ms so the new timestamp is measurably later.
+    await new Promise((r) => setTimeout(r, 20));
+
+    const { error: uErr } = await supabase
+      .from("profiles")
+      .update({ locale: "zh" })
+      .eq("id", userId);
+    expect(uErr).toBeNull();
+
+    const { data: after } = await supabase
+      .from("profiles")
+      .select("updated_at")
+      .eq("id", userId)
+      .single();
+
+    const beforeMs = new Date(before?.updated_at as string).getTime();
+    const afterMs = new Date(after?.updated_at as string).getTime();
+    expect(afterMs).toBeGreaterThan(beforeMs);
+  });
+});

--- a/tests/db/rls-policies.test.ts
+++ b/tests/db/rls-policies.test.ts
@@ -124,25 +124,14 @@ describe.runIf(canRun)("RLS policies (#12)", () => {
         .eq("id", userAId);
       expect(error).toBeNull();
 
-      const { data } = await admin
-        .from("profiles")
-        .select("locale")
-        .eq("id", userAId)
-        .single();
+      const { data } = await admin.from("profiles").select("locale").eq("id", userAId).single();
       expect(data?.locale).toBe("zh");
     });
 
     it("user cannot update another user's profile", async () => {
-      const { error } = await userAClient
-        .from("profiles")
-        .update({ locale: "fr" })
-        .eq("id", userBId);
+      await userAClient.from("profiles").update({ locale: "fr" }).eq("id", userBId);
       // RLS update-mismatch: either a PGRST error or a silent 0-row update — both acceptable.
-      const { data } = await admin
-        .from("profiles")
-        .select("locale")
-        .eq("id", userBId)
-        .single();
+      const { data } = await admin.from("profiles").select("locale").eq("id", userBId).single();
       expect(data?.locale).not.toBe("fr");
     });
 
@@ -195,9 +184,7 @@ describe.runIf(canRun)("RLS policies (#12)", () => {
     });
 
     it("user A can read only their own chat sessions", async () => {
-      const { data, error } = await userAClient
-        .from("chat_sessions")
-        .select("id, user_id");
+      const { data, error } = await userAClient.from("chat_sessions").select("id, user_id");
       expect(error).toBeNull();
       expect(data?.every((row) => row.user_id === userAId)).toBe(true);
       expect(data?.some((row) => row.id === userASession)).toBe(true);
@@ -231,10 +218,7 @@ describe.runIf(canRun)("RLS policies (#12)", () => {
     });
 
     it("user A can delete their own session (and cascade its messages)", async () => {
-      const { error } = await userAClient
-        .from("chat_sessions")
-        .delete()
-        .eq("id", userASession);
+      const { error } = await userAClient.from("chat_sessions").delete().eq("id", userASession);
       expect(error).toBeNull();
       const { data } = await admin
         .from("chat_sessions")
@@ -260,7 +244,7 @@ describe.runIf(canRun)("RLS policies (#12)", () => {
         .select("id, session_id")
         .eq("session_id", userBSession);
       expect(error).toBeNull();
-      expect((data?.length ?? 0)).toBeGreaterThan(0);
+      expect(data?.length ?? 0).toBeGreaterThan(0);
     });
   });
 
@@ -324,15 +308,9 @@ describe.runIf(canRun)("RLS policies (#12)", () => {
     });
 
     it("non-admin user cannot DELETE a knowledge_chunk", async () => {
-      await userAClient
-        .from("knowledge_chunks")
-        .delete()
-        .in("id", createdChunkIds);
+      await userAClient.from("knowledge_chunks").delete().in("id", createdChunkIds);
       // RLS blocks the delete (either a PGRST error or silent 0-row delete).
-      const { data } = await admin
-        .from("knowledge_chunks")
-        .select("id")
-        .in("id", createdChunkIds);
+      const { data } = await admin.from("knowledge_chunks").select("id").in("id", createdChunkIds);
       expect(data?.length).toBe(1);
     });
 
@@ -369,9 +347,7 @@ describe.runIf(canRun)("RLS policies (#12)", () => {
     });
 
     it("non-admin user cannot SELECT analytics events", async () => {
-      const { data, error } = await userAClient
-        .from("analytics_events")
-        .select("id");
+      const { data, error } = await userAClient.from("analytics_events").select("id");
       // Either an error or an empty result — both acceptable, both mean denied.
       expect(error !== null || (data?.length ?? 0) === 0).toBe(true);
     });
@@ -381,7 +357,7 @@ describe.runIf(canRun)("RLS policies (#12)", () => {
         .from("analytics_events")
         .select("id, user_id, event_type");
       expect(error).toBeNull();
-      expect((data?.length ?? 0)).toBeGreaterThan(0);
+      expect(data?.length ?? 0).toBeGreaterThan(0);
       expect(data?.some((row) => row.user_id === userAId)).toBe(true);
     });
   });

--- a/tests/db/rls-policies.test.ts
+++ b/tests/db/rls-policies.test.ts
@@ -137,16 +137,13 @@ describe.runIf(canRun)("RLS policies (#12)", () => {
         .from("profiles")
         .update({ locale: "fr" })
         .eq("id", userBId);
-      // RLS update-mismatch surfaces as either an error or a 0-row update.
-      // Either way the row must be unchanged.
+      // RLS update-mismatch: either a PGRST error or a silent 0-row update — both acceptable.
       const { data } = await admin
         .from("profiles")
         .select("locale")
         .eq("id", userBId)
         .single();
       expect(data?.locale).not.toBe("fr");
-      // Explicit: the error path is acceptable; the silent 0-row path is too.
-      expect(error === null || typeof error === "object").toBe(true);
     });
 
     it("admin can read every profile", async () => {
@@ -183,6 +180,7 @@ describe.runIf(canRun)("RLS policies (#12)", () => {
         .single();
       expect(error).toBeNull();
       userBSession = data?.id as string;
+      expect(userBSession).toBeTruthy();
     });
 
     it("user A cannot create a chat session owned by user B", async () => {
@@ -313,29 +311,29 @@ describe.runIf(canRun)("RLS policies (#12)", () => {
     });
 
     it("non-admin user cannot UPDATE a knowledge_chunk", async () => {
-      const { error } = await userAClient
+      await userAClient
         .from("knowledge_chunks")
         .update({ source: "tampered" })
         .in("id", createdChunkIds);
+      // RLS blocks the update (either a PGRST error or silent 0-row update).
       const { data } = await admin
         .from("knowledge_chunks")
         .select("source")
         .in("id", createdChunkIds);
       expect(data?.every((r) => r.source !== "tampered")).toBe(true);
-      expect(error === null || typeof error === "object").toBe(true);
     });
 
     it("non-admin user cannot DELETE a knowledge_chunk", async () => {
-      const { error } = await userAClient
+      await userAClient
         .from("knowledge_chunks")
         .delete()
         .in("id", createdChunkIds);
+      // RLS blocks the delete (either a PGRST error or silent 0-row delete).
       const { data } = await admin
         .from("knowledge_chunks")
         .select("id")
         .in("id", createdChunkIds);
       expect(data?.length).toBe(1);
-      expect(error === null || typeof error === "object").toBe(true);
     });
 
     it("admin user can INSERT a knowledge_chunk", async () => {

--- a/tests/db/rls-policies.test.ts
+++ b/tests/db/rls-policies.test.ts
@@ -1,0 +1,390 @@
+// tests/db/rls-policies.test.ts
+// @vitest-environment node
+
+import { type SupabaseClient, createClient } from "@supabase/supabase-js";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+
+const SUPABASE_URL = process.env.SUPABASE_URL ?? "http://127.0.0.1:54321";
+const SERVICE_ROLE = process.env.SUPABASE_SERVICE_ROLE_KEY;
+const ANON_KEY = process.env.SUPABASE_ANON_KEY;
+
+// The suite only runs when the local Supabase instance is up and both keys
+// are exported. This matches the pattern in tests/db/profiles.test.ts so the
+// default `pnpm test` run doesn't break on machines that aren't set up.
+const canRun = Boolean(SERVICE_ROLE) && Boolean(ANON_KEY);
+
+describe.runIf(canRun)("RLS policies (#12)", () => {
+  let admin: SupabaseClient; // service-role client (bypasses RLS)
+  let userAClient: SupabaseClient; // anon-key client signed in as userA
+  let userBClient: SupabaseClient; // anon-key client signed in as userB
+  let adminUserClient: SupabaseClient; // anon-key client signed in as adminUser
+  let anonClient: SupabaseClient; // anon-key client with no session
+
+  let userAId = "";
+  let userBId = "";
+  let adminUserId = "";
+
+  const createdUserIds: string[] = [];
+  const createdChunkIds: string[] = [];
+
+  const password = "password1234";
+  const suffix = Date.now();
+  const userAEmail = `rls-user-a-${suffix}@example.com`;
+  const userBEmail = `rls-user-b-${suffix}@example.com`;
+  const adminEmail = `rls-admin-${suffix}@example.com`;
+
+  /**
+   * Create a fresh anon-key client and sign it in with the given credentials.
+   * The returned client talks to PostgREST with the user's JWT, so RLS is
+   * evaluated against that user — which is exactly what we want to test.
+   */
+  async function signedInClient(email: string): Promise<SupabaseClient> {
+    const client = createClient(SUPABASE_URL, ANON_KEY as string, {
+      auth: { persistSession: false, autoRefreshToken: false },
+    });
+    const { error } = await client.auth.signInWithPassword({ email, password });
+    if (error) throw error;
+    return client;
+  }
+
+  beforeAll(async () => {
+    admin = createClient(SUPABASE_URL, SERVICE_ROLE as string, {
+      auth: { persistSession: false, autoRefreshToken: false },
+    });
+
+    anonClient = createClient(SUPABASE_URL, ANON_KEY as string, {
+      auth: { persistSession: false, autoRefreshToken: false },
+    });
+
+    // Create three auth users via the admin API. email_confirm:true skips the
+    // confirmation step so signInWithPassword works immediately.
+    for (const email of [userAEmail, userBEmail, adminEmail]) {
+      const { data, error } = await admin.auth.admin.createUser({
+        email,
+        password,
+        email_confirm: true,
+      });
+      if (error) throw error;
+      const id = data.user?.id as string;
+      createdUserIds.push(id);
+      if (email === userAEmail) userAId = id;
+      if (email === userBEmail) userBId = id;
+      if (email === adminEmail) adminUserId = id;
+    }
+
+    // Promote adminUser to role='admin' via service role (bypasses RLS).
+    const { error: roleErr } = await admin
+      .from("profiles")
+      .update({ role: "admin" })
+      .eq("id", adminUserId);
+    if (roleErr) throw roleErr;
+
+    userAClient = await signedInClient(userAEmail);
+    userBClient = await signedInClient(userBEmail);
+    adminUserClient = await signedInClient(adminEmail);
+  });
+
+  afterAll(async () => {
+    // Best-effort teardown. Chunks first (no FK to users), then auth users
+    // (cascade deletes profiles + chat_sessions + chat_messages).
+    if (createdChunkIds.length > 0) {
+      await admin.from("knowledge_chunks").delete().in("id", createdChunkIds);
+    }
+    for (const id of createdUserIds) {
+      await admin.auth.admin.deleteUser(id);
+    }
+  });
+
+  // ───── profiles ────────────────────────────────────────────────────────
+  describe("profiles", () => {
+    it("user can read their own profile", async () => {
+      const { data, error } = await userAClient
+        .from("profiles")
+        .select("id, email, role")
+        .eq("id", userAId)
+        .single();
+      expect(error).toBeNull();
+      expect(data?.id).toBe(userAId);
+    });
+
+    it("user cannot read another user's profile", async () => {
+      const { data, error } = await userAClient
+        .from("profiles")
+        .select("id")
+        .eq("id", userBId)
+        .maybeSingle();
+      expect(error).toBeNull();
+      expect(data).toBeNull();
+    });
+
+    it("user can update their own profile", async () => {
+      const { error } = await userAClient
+        .from("profiles")
+        .update({ locale: "zh" })
+        .eq("id", userAId);
+      expect(error).toBeNull();
+
+      const { data } = await admin
+        .from("profiles")
+        .select("locale")
+        .eq("id", userAId)
+        .single();
+      expect(data?.locale).toBe("zh");
+    });
+
+    it("user cannot update another user's profile", async () => {
+      const { error } = await userAClient
+        .from("profiles")
+        .update({ locale: "fr" })
+        .eq("id", userBId);
+      // RLS update-mismatch surfaces as either an error or a 0-row update.
+      // Either way the row must be unchanged.
+      const { data } = await admin
+        .from("profiles")
+        .select("locale")
+        .eq("id", userBId)
+        .single();
+      expect(data?.locale).not.toBe("fr");
+      // Explicit: the error path is acceptable; the silent 0-row path is too.
+      expect(error === null || typeof error === "object").toBe(true);
+    });
+
+    it("admin can read every profile", async () => {
+      const { data, error } = await adminUserClient
+        .from("profiles")
+        .select("id")
+        .in("id", [userAId, userBId, adminUserId]);
+      expect(error).toBeNull();
+      expect(data?.length).toBe(3);
+    });
+  });
+
+  // ───── chat_sessions & chat_messages ──────────────────────────────────
+  describe("chat_sessions & chat_messages", () => {
+    let userASession = "";
+    let userBSession = "";
+
+    it("user A can create a chat session for themselves", async () => {
+      const { data, error } = await userAClient
+        .from("chat_sessions")
+        .insert({ user_id: userAId, title: "A's session" })
+        .select("id")
+        .single();
+      expect(error).toBeNull();
+      userASession = data?.id as string;
+      expect(userASession).toBeTruthy();
+    });
+
+    it("user B can create a chat session for themselves", async () => {
+      const { data, error } = await userBClient
+        .from("chat_sessions")
+        .insert({ user_id: userBId, title: "B's session" })
+        .select("id")
+        .single();
+      expect(error).toBeNull();
+      userBSession = data?.id as string;
+    });
+
+    it("user A cannot create a chat session owned by user B", async () => {
+      const { data, error } = await userAClient
+        .from("chat_sessions")
+        .insert({ user_id: userBId, title: "hijack" })
+        .select("id")
+        .maybeSingle();
+      // WITH CHECK violation — error non-null, data null.
+      expect(error).not.toBeNull();
+      expect(data).toBeNull();
+    });
+
+    it("user A can read only their own chat sessions", async () => {
+      const { data, error } = await userAClient
+        .from("chat_sessions")
+        .select("id, user_id");
+      expect(error).toBeNull();
+      expect(data?.every((row) => row.user_id === userAId)).toBe(true);
+      expect(data?.some((row) => row.id === userASession)).toBe(true);
+    });
+
+    it("user A can insert a message into their own session", async () => {
+      const { error } = await userAClient
+        .from("chat_messages")
+        .insert({ session_id: userASession, role: "user", content: "hello" });
+      expect(error).toBeNull();
+    });
+
+    it("user A cannot insert a message into user B's session", async () => {
+      const { error } = await userAClient
+        .from("chat_messages")
+        .insert({ session_id: userBSession, role: "user", content: "hijack" });
+      expect(error).not.toBeNull();
+    });
+
+    it("user A cannot read messages from user B's session", async () => {
+      // First, give B a message via admin (bypass RLS).
+      await admin
+        .from("chat_messages")
+        .insert({ session_id: userBSession, role: "user", content: "B only" });
+      const { data, error } = await userAClient
+        .from("chat_messages")
+        .select("id, session_id")
+        .eq("session_id", userBSession);
+      expect(error).toBeNull();
+      expect(data?.length).toBe(0);
+    });
+
+    it("user A can delete their own session (and cascade its messages)", async () => {
+      const { error } = await userAClient
+        .from("chat_sessions")
+        .delete()
+        .eq("id", userASession);
+      expect(error).toBeNull();
+      const { data } = await admin
+        .from("chat_sessions")
+        .select("id")
+        .eq("id", userASession)
+        .maybeSingle();
+      expect(data).toBeNull();
+    });
+
+    it("admin can read every chat session", async () => {
+      const { data, error } = await adminUserClient
+        .from("chat_sessions")
+        .select("id, user_id")
+        .in("user_id", [userAId, userBId]);
+      expect(error).toBeNull();
+      // At least B's session still exists.
+      expect(data?.some((row) => row.user_id === userBId)).toBe(true);
+    });
+
+    it("admin can read every chat message", async () => {
+      const { data, error } = await adminUserClient
+        .from("chat_messages")
+        .select("id, session_id")
+        .eq("session_id", userBSession);
+      expect(error).toBeNull();
+      expect((data?.length ?? 0)).toBeGreaterThan(0);
+    });
+  });
+
+  // ───── knowledge_chunks ───────────────────────────────────────────────
+  describe("knowledge_chunks", () => {
+    beforeAll(async () => {
+      // Seed one chunk via service role so there's something to select against.
+      const embedding = Array.from({ length: 1536 }, () => 0);
+      const { data, error } = await admin
+        .from("knowledge_chunks")
+        .insert({
+          source: "rls-test",
+          content: "rls fixture content",
+          embedding,
+        })
+        .select("id")
+        .single();
+      if (error) throw error;
+      createdChunkIds.push(data?.id as string);
+    });
+
+    it("anonymous client cannot SELECT knowledge_chunks", async () => {
+      const { data, error } = await anonClient
+        .from("knowledge_chunks")
+        .select("id")
+        .in("id", createdChunkIds);
+      // Either an explicit error or empty array — both prove denial.
+      expect(error !== null || (data?.length ?? 0) === 0).toBe(true);
+    });
+
+    it("authenticated user can SELECT knowledge_chunks", async () => {
+      const { data, error } = await userAClient
+        .from("knowledge_chunks")
+        .select("id")
+        .in("id", createdChunkIds);
+      expect(error).toBeNull();
+      expect(data?.length).toBe(1);
+    });
+
+    it("non-admin user cannot INSERT a knowledge_chunk", async () => {
+      const embedding = Array.from({ length: 1536 }, () => 0);
+      const { error } = await userAClient.from("knowledge_chunks").insert({
+        source: "rls-test",
+        content: "should fail",
+        embedding,
+      });
+      expect(error).not.toBeNull();
+    });
+
+    it("non-admin user cannot UPDATE a knowledge_chunk", async () => {
+      const { error } = await userAClient
+        .from("knowledge_chunks")
+        .update({ source: "tampered" })
+        .in("id", createdChunkIds);
+      const { data } = await admin
+        .from("knowledge_chunks")
+        .select("source")
+        .in("id", createdChunkIds);
+      expect(data?.every((r) => r.source !== "tampered")).toBe(true);
+      expect(error === null || typeof error === "object").toBe(true);
+    });
+
+    it("non-admin user cannot DELETE a knowledge_chunk", async () => {
+      const { error } = await userAClient
+        .from("knowledge_chunks")
+        .delete()
+        .in("id", createdChunkIds);
+      const { data } = await admin
+        .from("knowledge_chunks")
+        .select("id")
+        .in("id", createdChunkIds);
+      expect(data?.length).toBe(1);
+      expect(error === null || typeof error === "object").toBe(true);
+    });
+
+    it("admin user can INSERT a knowledge_chunk", async () => {
+      const embedding = Array.from({ length: 1536 }, () => 0);
+      const { data, error } = await adminUserClient
+        .from("knowledge_chunks")
+        .insert({
+          source: "rls-test-admin",
+          content: "admin-inserted",
+          embedding,
+        })
+        .select("id")
+        .single();
+      expect(error).toBeNull();
+      if (data?.id) createdChunkIds.push(data.id);
+    });
+  });
+
+  // ───── analytics_events ──────────────────────────────────────────────
+  describe("analytics_events", () => {
+    it("user can insert an event for themselves", async () => {
+      const { error } = await userAClient
+        .from("analytics_events")
+        .insert({ user_id: userAId, event_type: "page_view", payload: {} });
+      expect(error).toBeNull();
+    });
+
+    it("user cannot insert an event with someone else's user_id", async () => {
+      const { error } = await userAClient
+        .from("analytics_events")
+        .insert({ user_id: userBId, event_type: "page_view", payload: {} });
+      expect(error).not.toBeNull();
+    });
+
+    it("non-admin user cannot SELECT analytics events", async () => {
+      const { data, error } = await userAClient
+        .from("analytics_events")
+        .select("id");
+      // Either an error or an empty result — both acceptable, both mean denied.
+      expect(error !== null || (data?.length ?? 0) === 0).toBe(true);
+    });
+
+    it("admin user can SELECT analytics events", async () => {
+      const { data, error } = await adminUserClient
+        .from("analytics_events")
+        .select("id, user_id, event_type");
+      expect(error).toBeNull();
+      expect((data?.length ?? 0)).toBeGreaterThan(0);
+      expect(data?.some((row) => row.user_id === userAId)).toBe(true);
+    });
+  });
+});

--- a/types/supabase.ts
+++ b/types/supabase.ts
@@ -164,29 +164,35 @@ export type Database = {
         Row: {
           avatar_url: string | null
           created_at: string | null
+          display_name: string | null
           email: string | null
           full_name: string | null
           id: string
           locale: string | null
           role: string | null
+          updated_at: string | null
         }
         Insert: {
           avatar_url?: string | null
           created_at?: string | null
+          display_name?: string | null
           email?: string | null
           full_name?: string | null
           id: string
           locale?: string | null
           role?: string | null
+          updated_at?: string | null
         }
         Update: {
           avatar_url?: string | null
           created_at?: string | null
+          display_name?: string | null
           email?: string | null
           full_name?: string | null
           id?: string
           locale?: string | null
           role?: string | null
+          updated_at?: string | null
         }
         Relationships: []
       }


### PR DESCRIPTION
## Summary
This branch landed accumulated Epic 2 work locally over the past few weeks. Pushing to main now so #17 (Epic 3 chat-tables index) can branch from a clean base.

**Primary issue:**
- Closes #15 — User Profile Edit Page (the latest feature on this branch)

**Already-closed issues whose code lives on this branch** (issues were closed when work was completed locally — this PR finally moves that code to main):
- #9 — Register / Login / Forgot Password pages
- #10 — Supabase Auth (email/password)
- #11 — Profiles table + auto-create trigger
- #12 — RLS policies
- #13 — Next.js middleware route guards

**Misc fixes also on this branch:**
- Password reset flow end-to-end repair
- Password visibility toggle on all password inputs
- Toast style change

## Scope
44 commits ahead of `main`. Diff covers `app/`, `lib/`, `middleware.ts`, `supabase/migrations/`, `tests/`, `docs/`, plus `package.json` deps for RHF / Zod / Playwright / shadcn primitives.

## Test plan
- [ ] CI / Vitest passes on the branch
- [ ] `supabase db reset` applies cleanly
- [ ] RLS suite (`tests/db/rls-policies.test.ts`) green with local Supabase up
- [ ] Manual: `/profile` page loads, can update display name / locale / password

🤖 Generated with [Claude Code](https://claude.com/claude-code)