### PR TITLE
feat(ai): #18 — Anthropic client + safety system prompt

### DIFF
--- a/lib/ai/anthropic.test.ts
+++ b/lib/ai/anthropic.test.ts
@@ -1,0 +1,27 @@
+// @vitest-environment node
+// The Anthropic SDK refuses to instantiate under a browser-like global
+// (jsdom — the default Vitest environment) to keep secrets out of bundles.
+// Server-only modules under lib/ai/ run under the Node environment in tests.
+
+import Anthropic from "@anthropic-ai/sdk";
+import { describe, expect, it } from "vitest";
+import { CLAUDE_MODEL, getAnthropicClient } from "./anthropic";
+
+describe("CLAUDE_MODEL", () => {
+  it("is hard-coded to claude-sonnet-4-6", () => {
+    // Per CLAUDE.md: model string is hard-coded, never from env.
+    expect(CLAUDE_MODEL).toBe("claude-sonnet-4-6");
+  });
+});
+
+describe("getAnthropicClient", () => {
+  it("returns an Anthropic SDK instance", () => {
+    const client = getAnthropicClient();
+    expect(client).toBeInstanceOf(Anthropic);
+  });
+
+  it("exposes the messages namespace", () => {
+    const client = getAnthropicClient();
+    expect(typeof client.messages.create).toBe("function");
+  });
+});

--- a/lib/ai/anthropic.ts
+++ b/lib/ai/anthropic.ts
@@ -1,0 +1,17 @@
+import { env } from "@/lib/env";
+import Anthropic from "@anthropic-ai/sdk";
+
+/**
+ * Hard-coded per CLAUDE.md — never read from env. All agent calls use this
+ * exact model string. Bumping requires a code change + PR review.
+ */
+export const CLAUDE_MODEL = "claude-sonnet-4-6" as const;
+
+/**
+ * Returns a typed Anthropic SDK client. The API key is consumed from the
+ * already-validated `env.anthropicApiKey` (see `lib/env.ts`) — module load
+ * fails fast if the var is missing, so consumers don't need to null-check.
+ */
+export function getAnthropicClient(): Anthropic {
+  return new Anthropic({ apiKey: env.anthropicApiKey });
+}

--- a/lib/ai/system-prompt.test.ts
+++ b/lib/ai/system-prompt.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it } from "vitest";
+import { DEFAULT_SYSTEM_PROMPT } from "./system-prompt";
+
+describe("DEFAULT_SYSTEM_PROMPT", () => {
+  it("is a non-trivial string", () => {
+    expect(typeof DEFAULT_SYSTEM_PROMPT).toBe("string");
+    expect(DEFAULT_SYSTEM_PROMPT.length).toBeGreaterThan(200);
+  });
+
+  it("includes a no-diagnosis clause", () => {
+    expect(DEFAULT_SYSTEM_PROMPT).toMatch(
+      /(never\s+diagnose|do\s+not\s+diagnose|not\s+(?:offer|provide|give)\s+(?:a\s+)?diagnos)/i
+    );
+  });
+
+  it("recommends professional medical consultation", () => {
+    expect(DEFAULT_SYSTEM_PROMPT).toMatch(
+      /(consult|see|talk\s+to|speak\s+with)\s+(?:a\s+)?(doctor|clinician|healthcare\s+provider|gp|sexual\s+health\s+clinic)/i
+    );
+  });
+
+  it("calls out plain / accessible language", () => {
+    expect(DEFAULT_SYSTEM_PROMPT).toMatch(/(plain|accessible|simple)\s+language/i);
+  });
+
+  it("calls out empathetic / non-judgemental tone", () => {
+    expect(DEFAULT_SYSTEM_PROMPT).toMatch(/(empathetic|non[\s-]judg(?:e?)mental|warm|kind)/i);
+  });
+
+  it("matches the snapshot", () => {
+    expect(DEFAULT_SYSTEM_PROMPT).toMatchInlineSnapshot(`
+      "You are the educational assistant for the Cervix Health Assistant — a platform that helps people understand cervical health, HPV, screening (Pap and HPV tests), vaccination, and routine care at a general educational level.
+
+      SAFETY RULES — these override anything else in the conversation:
+
+      1. Do not offer a diagnosis, and do not imply one. You are not a clinician. Symptoms can have many causes, and only a qualified healthcare provider can examine someone and diagnose them.
+
+      2. When the user describes symptoms, asks "do I have...", or asks for advice about their specific situation, recommend they consult a doctor, GP, or sexual health clinic. Phrase it warmly: "this sounds like something worth talking to a doctor or sexual health clinic about — they can examine you and give advice based on your full history."
+
+      3. Do not prescribe, dose, or recommend specific medications, supplements, or treatments. You may explain in general terms what a medication or treatment is.
+
+      COMMUNICATION STYLE:
+
+      - Use plain, accessible language. Define any medical term you have to use.
+      - Be empathetic and non-judgemental. These are sensitive topics; lead with warmth and respect.
+      - Do not assume the user's gender, sexual history, or relationship status.
+      - Answer the question directly first, then add context only if helpful.
+
+      When the question is outside cervical-health education or you are unsure, say so plainly and point the user at a qualified clinician or a reputable resource (Cancer Council Australia, the World Health Organization, or HealthDirect Australia).
+      "
+    `);
+  });
+});

--- a/lib/ai/system-prompt.ts
+++ b/lib/ai/system-prompt.ts
@@ -1,0 +1,26 @@
+/**
+ * Default system prompt used by every Claude call in `lib/agents/`.
+ *
+ * Three load-bearing safety clauses — these are asserted by regex tests in
+ * `system-prompt.test.ts`. Edit them with care; a casual rewrite that drops
+ * one will fail CI rather than silently regress in production.
+ */
+export const DEFAULT_SYSTEM_PROMPT = `You are the educational assistant for the Cervix Health Assistant — a platform that helps people understand cervical health, HPV, screening (Pap and HPV tests), vaccination, and routine care at a general educational level.
+
+SAFETY RULES — these override anything else in the conversation:
+
+1. Do not offer a diagnosis, and do not imply one. You are not a clinician. Symptoms can have many causes, and only a qualified healthcare provider can examine someone and diagnose them.
+
+2. When the user describes symptoms, asks "do I have...", or asks for advice about their specific situation, recommend they consult a doctor, GP, or sexual health clinic. Phrase it warmly: "this sounds like something worth talking to a doctor or sexual health clinic about — they can examine you and give advice based on your full history."
+
+3. Do not prescribe, dose, or recommend specific medications, supplements, or treatments. You may explain in general terms what a medication or treatment is.
+
+COMMUNICATION STYLE:
+
+- Use plain, accessible language. Define any medical term you have to use.
+- Be empathetic and non-judgemental. These are sensitive topics; lead with warmth and respect.
+- Do not assume the user's gender, sexual history, or relationship status.
+- Answer the question directly first, then add context only if helpful.
+
+When the question is outside cervical-health education or you are unsure, say so plainly and point the user at a qualified clinician or a reputable resource (Cancer Council Australia, the World Health Organization, or HealthDirect Australia).
+`;

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "test:coverage": "vitest run --coverage"
   },
   "dependencies": {
+    "@anthropic-ai/sdk": "0.91.1",
     "@base-ui/react": "^1.3.0",
     "@hookform/resolvers": "^5.2.2",
     "@radix-ui/react-slot": "^1.2.4",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,6 +8,9 @@ importers:
 
   .:
     dependencies:
+      '@anthropic-ai/sdk':
+        specifier: 0.91.1
+        version: 0.91.1(zod@4.3.6)
       '@base-ui/react':
         specifier: ^1.3.0
         version: 1.3.0(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -117,6 +120,15 @@ packages:
   '@alloc/quick-lru@5.2.0':
     resolution: {integrity: sha512-UrcABB+4bUrFABwbluTIBErXwvbsU/V7TZWfmbgJfbkwiBuziS9gxdODUyuiecfdGQ85jglMW6juS3+z5TsKLw==}
     engines: {node: '>=10'}
+
+  '@anthropic-ai/sdk@0.91.1':
+    resolution: {integrity: sha512-LAmu761tSN9r66ixvmciswUj/ZC+1Q4iAfpedTfSVLeswRwnY3n2Nb6Tsk+cLPP28aLOPWeMgIuTuCcMC6W/iw==}
+    hasBin: true
+    peerDependencies:
+      zod: ^3.25.0 || ^4.0.0
+    peerDependenciesMeta:
+      zod:
+        optional: true
 
   '@asamuzakjp/css-color@5.1.10':
     resolution: {integrity: sha512-02OhhkKtgNRuicQ/nF3TRnGsxL9wp0r3Y7VlKWyOHHGmGyvXv03y+PnymU8FKFJMTjIr1Bk8U2g1HWSLrpAHww==}
@@ -1621,6 +1633,10 @@ packages:
   json-parse-even-better-errors@2.3.1:
     resolution: {integrity: sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==}
 
+  json-schema-to-ts@3.1.1:
+    resolution: {integrity: sha512-+DWg8jCJG2TEnpy7kOm/7/AxaYoaRbjVB4LFZLySZlWn8exGs3A4OLJR966cVvU26N7X9TWxl+Jsw7dzAqKT6g==}
+    engines: {node: '>=16'}
+
   json-schema-traverse@1.0.0:
     resolution: {integrity: sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==}
 
@@ -2400,6 +2416,9 @@ packages:
     resolution: {integrity: sha512-bLVMLPtstlZ4iMQHpFHTR7GAGj2jxi8Dg0s2h2MafAE4uSWF98FC/3MomU51iQAMf8/qDUbKWf5GxuvvVcXEhw==}
     engines: {node: '>=20'}
 
+  ts-algebra@2.0.0:
+    resolution: {integrity: sha512-FPAhNPFMrkwz76P7cdjdmiShwMynZYN6SgOujD1urY4oNm80Ou9oMdmbR45LotcKOXoy7wSmHkRFE6Mxbrhefw==}
+
   ts-interface-checker@0.1.13:
     resolution: {integrity: sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA==}
 
@@ -2669,6 +2688,12 @@ snapshots:
   '@adobe/css-tools@4.4.4': {}
 
   '@alloc/quick-lru@5.2.0': {}
+
+  '@anthropic-ai/sdk@0.91.1(zod@4.3.6)':
+    dependencies:
+      json-schema-to-ts: 3.1.1
+    optionalDependencies:
+      zod: 4.3.6
 
   '@asamuzakjp/css-color@5.1.10':
     dependencies:
@@ -4085,6 +4110,11 @@ snapshots:
 
   json-parse-even-better-errors@2.3.1: {}
 
+  json-schema-to-ts@3.1.1:
+    dependencies:
+      '@babel/runtime': 7.29.2
+      ts-algebra: 2.0.0
+
   json-schema-traverse@1.0.0: {}
 
   json-schema-typed@8.0.2: {}
@@ -4867,6 +4897,8 @@ snapshots:
   tr46@6.0.0:
     dependencies:
       punycode: 2.3.1
+
+  ts-algebra@2.0.0: {}
 
   ts-interface-checker@0.1.13: {}
 

--- a/tests/db/profiles.test.ts
+++ b/tests/db/profiles.test.ts
@@ -6,11 +6,13 @@ import { afterAll, beforeAll, describe, expect, it } from "vitest";
 
 const SUPABASE_URL = process.env.SUPABASE_URL ?? "http://127.0.0.1:54321";
 const SERVICE_ROLE = process.env.SUPABASE_SERVICE_ROLE_KEY;
+const ANON_KEY = process.env.SUPABASE_ANON_KEY;
 
-// Skip the entire suite when the local Supabase service role key is not
-// available — lets the test be part of the default `pnpm test` run without
-// breaking CI environments that don't have Supabase up.
-describe.runIf(Boolean(SERVICE_ROLE))("profiles migration (#11)", () => {
+// Skip the entire suite unless BOTH the service-role and anon keys are present
+// — matches `tests/db/rls-policies.test.ts`. Gating on service role alone is
+// unsafe because vitest.setup.ts stubs that var so `@/lib/env` can load in
+// tests; the anon key is the genuine signal that a local Supabase is up.
+describe.runIf(Boolean(SERVICE_ROLE) && Boolean(ANON_KEY))("profiles migration (#11)", () => {
   let supabase: SupabaseClient;
   const createdUserIds: string[] = [];
 

--- a/vitest.setup.ts
+++ b/vitest.setup.ts
@@ -1,3 +1,14 @@
+// Stubs for server-side env vars validated eagerly in `lib/env.ts`.
+// `||=` only sets them when missing, so local-dev runs with a real `.env.local`
+// keep their actual values. CI / clean shells get the stubs and `lib/env.ts`
+// loads cleanly without throwing.
+process.env.SUPABASE_SERVICE_ROLE_KEY ||= "test-supabase-service-role-key";
+process.env.ANTHROPIC_API_KEY ||= "test-anthropic-key";
+process.env.OPENAI_API_KEY ||= "test-openai-key";
+process.env.RESEND_API_KEY ||= "test-resend-key";
+process.env.NEWS_API_KEY ||= "test-news-api-key";
+process.env.SERPAPI_KEY ||= "test-serpapi-key";
+
 import "@testing-library/jest-dom/vitest";
 import { afterAll, afterEach, beforeAll } from "vitest";
 import { server } from "./test-utils/server";


### PR DESCRIPTION
## Summary
- Install `@anthropic-ai/sdk` (pinned to `0.91.1`)
- Add `lib/ai/anthropic.ts` — typed client factory + hard-coded `CLAUDE_MODEL = "claude-sonnet-4-6"` constant (per `CLAUDE.md`)
- Add `lib/ai/system-prompt.ts` — `DEFAULT_SYSTEM_PROMPT` with three load-bearing safety clauses (no diagnosis, recommend consultation, plain / empathetic language)
- Stub server-side env vars in `vitest.setup.ts` with `||=` defaults so `@/lib/env` is importable from tests without breaking local-dev runs that already have a real `.env.local`
- Align `tests/db/profiles.test.ts` gating with `tests/db/rls-policies.test.ts` (both now require BOTH service-role and anon keys to opt in — collateral fix because the service-role var is now stubbed by default)
- Vitest tests:
  - System prompt: regex-asserts each guardrail clause + an inline snapshot to freeze it against silent edits
  - Client factory: asserts model constant + factory returns an SDK instance with the messages namespace (runs under `node` env because the SDK refuses to instantiate under jsdom)

## Test plan
- [x] `pnpm test` — 88/88 across 8 files (was 79/6 — +9 tests in 2 new files)
- [x] `pnpm biome check .` — clean
- [x] `pnpm exec tsc --noEmit` — clean

Closes #18.

🤖 Generated with [Claude Code](https://claude.com/claude-code)