### PR TITLE
feat(agents): #26 — intent classification (orchestrator-lite)

### DIFF
--- a/app/api/chat/route.ts
+++ b/app/api/chat/route.ts
@@ -1,3 +1,4 @@
+import { classifyIntent } from "@/lib/agents/orchestrator";
 import { runResponseAgent } from "@/lib/agents/response-agent";
 import { loadRecentMessages } from "@/lib/ai/context-window";
 import { type ChatStreamEvent, encodeChatStreamEvent } from "@/lib/ai/streaming";
@@ -26,6 +27,12 @@ export async function POST(request: Request) {
   if (!parsed.success) {
     return Response.json({ error: "invalid_request" }, { status: 400 });
   }
+
+  // Pre-step: classify the user's intent. Logged for now; #27 wires it into
+  // dispatch. classifyIntent never throws — on internal failure it returns a
+  // fallback intent — so we don't gate the rest of the request on it.
+  const { intent } = await classifyIntent(parsed.data.message);
+  console.info(`[/api/chat] classified intent: ${intent}`);
 
   // 3. Resolve session id — create one if the caller didn't supply it
   let sessionId = parsed.data.sessionId;

--- a/docs/superpowers/plans/2026-05-01-epic3-intent-classification.md
+++ b/docs/superpowers/plans/2026-05-01-epic3-intent-classification.md
@@ -1,0 +1,571 @@
+# Epic 3 — #26 Intent Classification (Orchestrator-Lite) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a lightweight orchestrator at `lib/agents/orchestrator.ts` that classifies a user message into one of `health_question | news_request | events_request | general_chat`. The classifier uses a non-streaming Claude call with `temperature: 0` and a tight classifier prompt; on Claude error or unparseable output it falls back to keyword rules. Wired into `/api/chat` as a **logging-only** pre-step — actual dispatch lands in #27.
+
+**Architecture:** The orchestrator is a pure function `classifyIntent(userMessage): Promise<{ intent: Intent; confidence?: number }>`. Internally it calls `anthropic.messages.create()` (not `.stream()`) with a deterministic prompt that asks Claude to return one of the four labels. Output is trimmed/lowercased and validated against the enum; if Claude returns garbage, the function falls back to keyword rules (regex match on `news`/`event`/etc.) with `general_chat` as the safe default. The route awaits the classifier before calling the response agent and `console.log`s the result — no behavioral change for the client.
+
+**Tech Stack:** TypeScript strict, `@anthropic-ai/sdk` `messages.create()`, Vitest, Biome.
+
+**Issue:** [#26](https://github.com/Zoeyyhc/cervix-assistant/issues/26)
+**Source ticket doc:** [`docs/epics/epic3-ai-health-assistant-tickets.md`](../../epics/epic3-ai-health-assistant-tickets.md) §EPIC3-10
+**Depends on:** #25 (response agent extraction — on `main`).
+
+---
+
+## Pre-existing scaffolding
+
+- ✅ `getAnthropicClient()` and `CLAUDE_MODEL` from `lib/ai/anthropic.ts` (#18)
+- ✅ `runResponseAgent` from `lib/agents/response-agent.ts` (#25)
+- ✅ `app/api/chat/route.ts` — the integration target (just inject a logging pre-step)
+- ✅ `types/supabase.ts` — confirms `types/` is a real top-level dir; `types/agents.ts` slots in next to it
+
+## Gaps vs #26 acceptance criteria
+
+| AC | Status | Action |
+|---|---|---|
+| `lib/agents/orchestrator.ts` exports `classifyIntent` | ❌ | **Task 3** |
+| Returns `{ intent: Intent; confidence?: number }` | ❌ | Task 3 |
+| Implementation: non-streaming Claude call, temperature 0, classifier prompt | ❌ | Task 3 |
+| Rule-based fallback when classifier errors | ❌ | Task 3 |
+| `Intent` type exported from `types/agents.ts` | ❌ | **Task 2** |
+| Orchestrator is a pure function (no DB / no Supabase / no app HTTP — Claude calls are fine, same as response agent) | ❌ | Task 3 |
+| Integrated into `/api/chat` as a logging pre-step | ❌ | **Task 4** |
+| Vitest tests: clear health Q, news, events, small talk, classifier-error fallback | ❌ | Task 3 |
+
+## Decisions documented in this plan
+
+- **Classifier signature**: `classifyIntent(userMessage: string): Promise<ClassifyResult>`. No history parameter for v1 — the four categories are well-disambiguated by the current message alone in the cases we care about. If context-aware classification turns out to matter, extending the signature is a one-line change later.
+- **`temperature: 0`** for determinism. Sonnet 4.6 still supports temperature (the removal in Opus 4.7 doesn't apply to Sonnet).
+- **`max_tokens: 16`** — the classifier outputs one short label; small `max_tokens` keeps the call cheap and bounds the response.
+- **Classifier prompt** lives inline in `lib/agents/orchestrator.ts` as a private `CLASSIFIER_SYSTEM_PROMPT` constant. Not in `lib/ai/system-prompt.ts` — that file is for the user-facing assistant; this is a meta-prompt for a specific internal task.
+- **Output parsing**: trim, lowercase, check against the four valid intents. Anything else → fall back.
+- **Fallback rules** (keyword regex on the user message):
+  - `/\b(news|latest|recent updates?|articles?|headlines?)\b/i` → `news_request`
+  - `/\b(events?|meetups?|conferences?|near me)\b/i` → `events_request`
+  - else → `general_chat` (safe default — response agent handles it)
+  - **No** keyword-based detection of `health_question` — too easy to over-fire on words like "HPV" in a small-talk turn ("ever heard of HPV?"). When unsure, default to `general_chat` and let the response agent handle it.
+- **`confidence` is currently unused** but kept in the return type per the AC. Future work can populate it (e.g., from the classifier's logprobs or a self-reported confidence).
+- **Integration in `/api/chat`**: classifier runs before the response agent, in the same try-block. On classifier failure (the function returns a fallback rather than throwing), we still proceed. The route logs the result to stdout via `console.info` — keeps it visible during local dev without polluting `console.error`.
+
+---
+
+## File Structure
+
+| File | Change | Responsibility |
+|---|---|---|
+| `types/agents.ts` | **Create** | Single-source definition of the `Intent` union type. |
+| `lib/agents/orchestrator.ts` | **Create** | `classifyIntent(userMessage)` async function. Private classifier prompt + Claude call + fallback rules. |
+| `lib/agents/orchestrator.test.ts` | **Create** | Vitest unit tests covering each intent case + the classifier-error fallback. |
+| `app/api/chat/route.ts` | **Modify** | Add a logging pre-step that calls `classifyIntent` and `console.info`s the result. No routing change. |
+
+**Files not touched:**
+- `lib/agents/response-agent.ts` — the agent doesn't need to know about intent for #26.
+- `tests/api/chat.test.ts` — the route's behavior is unchanged from a client perspective. The classifier call mocks happily through the existing `vi.mock("@/lib/ai/anthropic", ...)` setup, but we'll need a tiny update to handle the new `messages.create()` (non-streaming) call shape — see Task 4.
+
+---
+
+## Pre-flight
+
+- [ ] **Step A: Confirm we're on the right branch**
+
+```bash
+git branch --show-current
+```
+Expected: `feat/intent-classification-26`.
+
+- [ ] **Step B: Confirm #25's surface is on `main`**
+
+```bash
+ls lib/agents/response-agent.ts && grep -n "runResponseAgent" app/api/chat/route.ts
+```
+Expected: file exists; route imports and uses the agent.
+
+- [ ] **Step C: Baseline tests + Biome + tsc green**
+
+```bash
+pnpm test 2>&1 | tail -5 && pnpm biome check . 2>&1 | tail -3 && pnpm exec tsc --noEmit -p tsconfig.json 2>&1 | tail -3
+```
+Expected: 156/156 with real Supabase env, or 144/156 (12 skipped) without. Biome and tsc clean.
+
+---
+
+## Task 1: Decide and document the orchestrator's contract
+
+**Files:** none — design notes that flow into Tasks 2–4.
+
+These decisions are explicit so the executor doesn't have to make them mid-implementation:
+
+1. **`Intent` is a string-literal union, not an enum.** TypeScript best practice for discriminated unions; consumes / serializes more cleanly than `enum`.
+2. **`classifyIntent` always resolves**, never throws. On Claude error or unparseable output it returns a fallback intent. The route can then proceed without a try/catch on the classifier call.
+3. **The classifier is a synchronous logical step in the request flow** — not fire-and-forget. Keeps things simple; ~100–500ms latency added before stream start is acceptable for v1, and #27 needs the result for dispatch anyway.
+4. **`history` is NOT a parameter for v1.** Classifier sees only the current message. Sufficient for the four-way split per the AC test cases.
+5. **The classifier prompt is short, deterministic, label-only output** — no JSON, no chain-of-thought, no explanation. Cheap and fast.
+
+- [ ] **Step 1: Acknowledge the decisions** — no code yet.
+
+---
+
+## Task 2: Add the `Intent` type
+
+**Files:** `types/agents.ts`.
+
+- [ ] **Step 1: Create the type file**
+
+```typescript
+/**
+ * Output of the orchestrator's classifier. Drives downstream dispatch in #27:
+ *
+ * - `health_question` → RAG agent → response agent (Epic 4 wiring)
+ * - `news_request` / `events_request` → external-tool agents (Epic 9)
+ * - `general_chat` → response agent directly
+ */
+export type Intent = "health_question" | "news_request" | "events_request" | "general_chat";
+```
+
+- [ ] **Step 2: Biome**
+
+```bash
+pnpm biome check --write types/agents.ts
+```
+
+(No commit yet — the type isn't referenced from anywhere until Task 3 lands. Tasks 2 + 3 commit together.)
+
+---
+
+## Task 3: Build the orchestrator (TDD)
+
+**Files:** `lib/agents/orchestrator.ts`, `lib/agents/orchestrator.test.ts`.
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `lib/agents/orchestrator.test.ts`:
+
+```typescript
+// @vitest-environment node
+
+import type { Intent } from "@/types/agents";
+import { beforeEach, describe, expect, test, vi } from "vitest";
+
+vi.mock("@/lib/ai/anthropic", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/lib/ai/anthropic")>();
+  return {
+    ...actual,
+    getAnthropicClient: vi.fn(),
+  };
+});
+
+import { getAnthropicClient } from "@/lib/ai/anthropic";
+import { classifyIntent } from "./orchestrator";
+
+function mockAnthropicCreate(replyText: string | Error) {
+  return {
+    messages: {
+      create:
+        replyText instanceof Error
+          ? vi.fn().mockRejectedValue(replyText)
+          : vi.fn().mockResolvedValue({
+              content: [{ type: "text", text: replyText }],
+            }),
+      stream: vi.fn(),
+    },
+  };
+}
+
+describe("classifyIntent", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  // ───── Claude-success path ─────────────────────────────────────────────
+
+  test("returns health_question for a clear health question", async () => {
+    const anthropic = mockAnthropicCreate("health_question");
+    vi.mocked(getAnthropicClient).mockReturnValue(anthropic as never);
+
+    const result = await classifyIntent("What is HPV and how is it transmitted?");
+    expect(result.intent satisfies Intent).toBe("health_question");
+  });
+
+  test("returns news_request when the model says so", async () => {
+    const anthropic = mockAnthropicCreate("news_request");
+    vi.mocked(getAnthropicClient).mockReturnValue(anthropic as never);
+
+    const result = await classifyIntent("latest news on HPV vaccine");
+    expect(result.intent).toBe("news_request");
+  });
+
+  test("returns events_request when the model says so", async () => {
+    const anthropic = mockAnthropicCreate("events_request");
+    vi.mocked(getAnthropicClient).mockReturnValue(anthropic as never);
+
+    const result = await classifyIntent("events near me");
+    expect(result.intent).toBe("events_request");
+  });
+
+  test("returns general_chat for small talk", async () => {
+    const anthropic = mockAnthropicCreate("general_chat");
+    vi.mocked(getAnthropicClient).mockReturnValue(anthropic as never);
+
+    const result = await classifyIntent("hello!");
+    expect(result.intent).toBe("general_chat");
+  });
+
+  test("trims and lowercases the model's output before matching", async () => {
+    const anthropic = mockAnthropicCreate("  HEALTH_QUESTION  \n");
+    vi.mocked(getAnthropicClient).mockReturnValue(anthropic as never);
+
+    const result = await classifyIntent("anything");
+    expect(result.intent).toBe("health_question");
+  });
+
+  test("calls Claude with temperature 0 and max_tokens small", async () => {
+    const anthropic = mockAnthropicCreate("general_chat");
+    vi.mocked(getAnthropicClient).mockReturnValue(anthropic as never);
+
+    await classifyIntent("hi");
+
+    const args = anthropic.messages.create.mock.calls[0] as unknown as [
+      { temperature: number; max_tokens: number; model: string; system: string },
+    ];
+    expect(args[0].temperature).toBe(0);
+    expect(args[0].max_tokens).toBeLessThan(64); // tight bound for a single label
+    expect(args[0].model).toBe("claude-sonnet-4-6");
+    expect(typeof args[0].system).toBe("string");
+    expect(args[0].system.length).toBeGreaterThan(0);
+  });
+
+  // ───── Fallback path ───────────────────────────────────────────────────
+
+  test("falls back to news_request via keyword when Claude errors and the message mentions news", async () => {
+    const anthropic = mockAnthropicCreate(new Error("Claude exploded"));
+    vi.mocked(getAnthropicClient).mockReturnValue(anthropic as never);
+
+    const result = await classifyIntent("latest news on HPV vaccine");
+    expect(result.intent).toBe("news_request");
+  });
+
+  test("falls back to events_request via keyword when Claude errors and the message mentions events", async () => {
+    const anthropic = mockAnthropicCreate(new Error("Claude exploded"));
+    vi.mocked(getAnthropicClient).mockReturnValue(anthropic as never);
+
+    const result = await classifyIntent("any events near me?");
+    expect(result.intent).toBe("events_request");
+  });
+
+  test("falls back to general_chat as the safe default when Claude errors and no keyword matches", async () => {
+    const anthropic = mockAnthropicCreate(new Error("Claude exploded"));
+    vi.mocked(getAnthropicClient).mockReturnValue(anthropic as never);
+
+    const result = await classifyIntent("What is HPV?");
+    expect(result.intent).toBe("general_chat");
+  });
+
+  test("falls back when the model returns garbage that doesn't match any intent", async () => {
+    const anthropic = mockAnthropicCreate("not_a_real_intent");
+    vi.mocked(getAnthropicClient).mockReturnValue(anthropic as never);
+
+    const result = await classifyIntent("hello");
+    // garbage from the model + no keyword match → safe default
+    expect(result.intent).toBe("general_chat");
+  });
+
+  test("never throws — always resolves to a valid Intent", async () => {
+    const anthropic = mockAnthropicCreate(new Error("anything"));
+    vi.mocked(getAnthropicClient).mockReturnValue(anthropic as never);
+
+    // Won't reject even though the SDK threw.
+    await expect(classifyIntent("anything")).resolves.toBeTruthy();
+  });
+});
+```
+
+- [ ] **Step 2: Run the tests to confirm they fail**
+
+```bash
+pnpm test lib/agents/orchestrator.test.ts 2>&1 | tail -10
+```
+Expected: import-resolution failure for `classifyIntent` and/or `@/types/agents`.
+
+- [ ] **Step 3: Write the implementation**
+
+Create `lib/agents/orchestrator.ts`:
+
+```typescript
+import { CLAUDE_MODEL, getAnthropicClient } from "@/lib/ai/anthropic";
+import type { Intent } from "@/types/agents";
+
+/**
+ * Tight classifier prompt. Returns ONE of four labels and nothing else.
+ * Kept short to minimize tokens — the cost of mis-classification is bounded
+ * by the rule-based fallback below.
+ */
+const CLASSIFIER_SYSTEM_PROMPT = `You classify the user's message into exactly ONE of these categories. Return ONLY the category name (lowercase, with underscores), nothing else — no explanation, no punctuation.
+
+Categories:
+- health_question  : questions about cervical health, HPV, screening, vaccination, symptoms, treatments, anatomy
+- news_request     : explicit requests for recent news, articles, headlines, or updates
+- events_request   : questions about upcoming events, meetups, screening clinics, conferences, or local activity
+- general_chat     : greetings, off-topic questions, or anything that doesn't fit above
+
+If unsure, choose general_chat.`;
+
+const VALID_INTENTS: ReadonlySet<Intent> = new Set([
+  "health_question",
+  "news_request",
+  "events_request",
+  "general_chat",
+]);
+
+const NEWS_RE = /\b(news|latest|recent updates?|articles?|headlines?)\b/i;
+const EVENTS_RE = /\b(events?|meetups?|conferences?|near me)\b/i;
+
+export type ClassifyResult = {
+  intent: Intent;
+  confidence?: number;
+};
+
+/**
+ * Classify a user message. Always resolves with a valid `Intent` — on Claude
+ * error or unparseable output, falls back to keyword rules with `general_chat`
+ * as the safe default.
+ */
+export async function classifyIntent(userMessage: string): Promise<ClassifyResult> {
+  try {
+    const anthropic = getAnthropicClient();
+    const response = await anthropic.messages.create({
+      model: CLAUDE_MODEL,
+      max_tokens: 16,
+      temperature: 0,
+      system: CLASSIFIER_SYSTEM_PROMPT,
+      messages: [{ role: "user", content: userMessage }],
+    });
+
+    const raw = response.content
+      .map((block) => (block.type === "text" ? block.text : ""))
+      .join("")
+      .trim()
+      .toLowerCase();
+
+    if (VALID_INTENTS.has(raw as Intent)) {
+      return { intent: raw as Intent };
+    }
+    // Model returned something we can't parse — fall through to keyword rules.
+  } catch (err) {
+    // Log server-side, then fall through. The classifier never throws.
+    console.error(
+      "[orchestrator] classifyIntent: Claude error, falling back to keyword rules:",
+      err instanceof Error ? err.message : err,
+    );
+  }
+
+  return { intent: fallbackIntent(userMessage) };
+}
+
+function fallbackIntent(message: string): Intent {
+  if (NEWS_RE.test(message)) return "news_request";
+  if (EVENTS_RE.test(message)) return "events_request";
+  // No keyword for health_question — too easy to over-fire on common health
+  // terms in small-talk turns. Default to general_chat; the response agent
+  // handles it the same way #27's dispatch will.
+  return "general_chat";
+}
+```
+
+- [ ] **Step 4: Run the tests**
+
+```bash
+pnpm test lib/agents/orchestrator.test.ts 2>&1 | tail -5
+```
+Expected: 11/11 passing.
+
+- [ ] **Step 5: Biome + tsc**
+
+```bash
+pnpm biome check --write types/agents.ts lib/agents/orchestrator.ts lib/agents/orchestrator.test.ts
+pnpm exec tsc --noEmit -p tsconfig.json 2>&1 | tail -5
+```
+Expected: clean.
+
+- [ ] **Step 6: Commit (type + agent + tests together)**
+
+```bash
+git add types/agents.ts lib/agents/orchestrator.ts lib/agents/orchestrator.test.ts
+git commit -m "feat(agents): add classifyIntent orchestrator with keyword-rule fallback"
+```
+
+---
+
+## Task 4: Wire the orchestrator into `/api/chat` as a logging pre-step
+
+**Files:** `app/api/chat/route.ts`, `tests/api/chat.test.ts`.
+
+- [ ] **Step 1: Update the route**
+
+In `app/api/chat/route.ts`:
+
+- Add `import { classifyIntent } from "@/lib/agents/orchestrator";` at the top
+- After validating the body and before persisting the user message (so the classifier sees the validated input but doesn't gate the persist on it), add:
+
+```typescript
+  // Pre-step: classify the user's intent. Logged for now; #27 wires it into
+  // dispatch. The classifier never throws — on internal failure it returns a
+  // fallback intent — so we don't gate the rest of the request on it.
+  const { intent } = await classifyIntent(parsed.data.message);
+  console.info(`[/api/chat] classified intent: ${intent}`);
+```
+
+Place this right after the Zod parse succeeds, before the session-resolve / history-load / persist block. The logging is the entire integration for #26.
+
+- [ ] **Step 2: Update the chat-route tests**
+
+The route now calls `messages.create()` (the classifier) before `messages.stream()` (the agent). The existing `mockAnthropic` / `mockAnthropicStream` helpers already declare a `create: vi.fn()` slot — but they don't mock its return value. Need to make the mock return a valid intent string so the classifier returns successfully.
+
+In `tests/api/chat.test.ts`, update the helper functions:
+
+```typescript
+// Default classifier response: "general_chat" — keeps existing tests passing
+// without altering their assertions about routing behavior.
+const DEFAULT_CLASSIFIER_REPLY = {
+  content: [{ type: "text", text: "general_chat" }],
+};
+
+function mockAnthropic(reply: string): MockedAnthropic {
+  return {
+    messages: {
+      create: vi.fn().mockResolvedValue(DEFAULT_CLASSIFIER_REPLY),
+      stream: vi.fn(() => ({
+        async *[Symbol.asyncIterator]() {
+          yield {
+            type: "content_block_delta",
+            delta: { type: "text_delta", text: reply },
+          } as StreamEventLike;
+        },
+      })),
+    },
+  };
+}
+
+function mockAnthropicStream(
+  events: StreamEventLike[],
+  opts: { throwAt?: number } = {},
+): MockedAnthropic {
+  return {
+    messages: {
+      create: vi.fn().mockResolvedValue(DEFAULT_CLASSIFIER_REPLY),
+      stream: vi.fn(() => ({
+        async *[Symbol.asyncIterator]() {
+          for (let i = 0; i < events.length; i++) {
+            if (opts.throwAt === i) throw new Error("upstream stream boom");
+            yield events[i];
+          }
+          if (opts.throwAt === events.length) throw new Error("upstream stream boom");
+        },
+      })),
+    },
+  };
+}
+```
+
+- [ ] **Step 3: Run the chat-route tests**
+
+```bash
+pnpm test tests/api/chat.test.ts 2>&1 | tail -8
+```
+Expected: 11/11 still passing — the classifier integration adds an upfront `messages.create()` call that the now-stocked `create` mock handles gracefully.
+
+- [ ] **Step 4: Biome + tsc**
+
+```bash
+pnpm biome check --write app/api/chat/route.ts tests/api/chat.test.ts
+pnpm exec tsc --noEmit -p tsconfig.json 2>&1 | tail -5
+```
+Expected: clean.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add app/api/chat/route.ts tests/api/chat.test.ts
+git commit -m "feat(api): log classified intent on /api/chat before response agent"
+```
+
+---
+
+## Task 5: Final verification + push + PR
+
+- [ ] **Step 1: Full test sweep**
+
+```bash
+eval "$(supabase status -o env)" && export SUPABASE_URL="${SUPABASE_URL:-$API_URL}" SUPABASE_SERVICE_ROLE_KEY="${SUPABASE_SERVICE_ROLE_KEY:-$SERVICE_ROLE_KEY}" SUPABASE_ANON_KEY="${SUPABASE_ANON_KEY:-$ANON_KEY}"
+pnpm test 2>&1 | tail -5
+```
+Expected: 156 baseline + **11 new** (`classifyIntent`) = 167.
+
+- [ ] **Step 2: Biome + tsc + build**
+
+```bash
+pnpm biome check . 2>&1 | tail -3 && pnpm exec tsc --noEmit -p tsconfig.json 2>&1 | tail -5 && pnpm build 2>&1 | grep -E "/api/chat|/chat" | head -5
+```
+Expected: all clean; `/api/chat` and `/chat` both compile.
+
+- [ ] **Step 3: Commit the plan**
+
+```bash
+git add docs/superpowers/plans/2026-05-01-epic3-intent-classification.md
+git commit -m "docs(plan): add Epic 3 #26 intent classification implementation plan"
+```
+
+- [ ] **Step 4: Push**
+
+```bash
+git push -u origin feat/intent-classification-26
+```
+
+- [ ] **Step 5: Open the PR**
+
+```bash
+gh pr create --repo Zoeyyhc/cervix-assistant --base main --head feat/intent-classification-26 \
+  --title "feat(agents): #26 — intent classification (orchestrator-lite)" \
+  --body "$(cat <<'EOF'
+## Summary
+- Add `lib/agents/orchestrator.ts` — exports `classifyIntent(userMessage)` returning `{ intent: Intent; confidence? }`
+- Add `types/agents.ts` — single-source `Intent` union (`health_question | news_request | events_request | general_chat`)
+- Implementation: non-streaming Claude call (`messages.create`), `temperature: 0`, `max_tokens: 16`, tight classifier prompt
+- Fallback when Claude errors OR returns unparseable output: keyword regex with `general_chat` as the safe default
+- Wired into `/api/chat` as a logging pre-step (`console.info`); **does NOT change routing** — that lands in #27
+
+## Decisions
+- `Intent` is a string-literal union (not an enum) — cleaner discriminated unions and serialization
+- `classifyIntent` always resolves; never throws. Route doesn't need a try/catch around it
+- No `history` parameter for v1 — current message is enough for the four-way split
+- No keyword-based detection of `health_question` in the fallback — too easy to over-fire on common health terms ("HPV") in small-talk turns. `general_chat` is the safe default; response agent handles it identically to `health_question` until #27's dispatch lands
+
+## Tests added
+- `classifyIntent` (11): each of the four intents from a Claude success response, output trim/lowercase tolerance, Claude-call shape (model, temperature, max_tokens, non-empty system prompt), keyword-fallback for news, keyword-fallback for events, default-to-general_chat fallback, garbage-from-model fallback, "never throws" guarantee
+
+## Tests modified
+- `tests/api/chat.test.ts` — `mockAnthropic` / `mockAnthropicStream` helpers now stock `messages.create` with a `general_chat` reply so the new pre-step doesn't break existing assertions
+
+## Test plan
+- [x] `pnpm test` — 167/167 across 15 files (was 156 — +11 from the orchestrator)
+- [x] `pnpm biome check .` — clean
+- [x] `pnpm exec tsc --noEmit` — clean
+- [x] `pnpm build` — `/api/chat` + `/chat` + `/chat/[sessionId]` all compile
+
+Closes #26. Prerequisite for the orchestrator wiring in #27.
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+---
+
+## Self-review checks performed
+
+- **Spec coverage:** every AC in #26 maps to a Task — agent at the documented path with the documented function/return shape; non-streaming Claude call with `temperature: 0`; rule-based fallback; `Intent` exported from `types/agents.ts`; pure (no DB / Supabase / app HTTP — Claude calls are fine, same as response agent); route logs the result; tests cover all five enumerated cases plus edge cases.
+- **Placeholder scan:** no TBD/TODO. The decision not to add a `health_question` fallback rule is explicit (with rationale) — not a placeholder.
+- **Type consistency:** `Intent` is a single source of truth in `types/agents.ts`; both the orchestrator and (eventually) the route's dispatch in #27 import it from there.
+- **Failure-mode honesty:** `classifyIntent` never throws — the spec says "rule-based fallback when the classifier errors", and the implementation matches. The route doesn't need to handle classifier failure at all.
+- **Test-mock impact**: the route's pre-existing tests have a slot for `create` that wasn't producing useful return values. Updating the helpers to return `general_chat` is the minimum change needed; assertions on routing/streaming behavior all stay the same.

--- a/lib/agents/orchestrator.test.ts
+++ b/lib/agents/orchestrator.test.ts
@@ -1,0 +1,144 @@
+// @vitest-environment node
+
+import type { Intent } from "@/types/agents";
+import { beforeEach, describe, expect, test, vi } from "vitest";
+
+vi.mock("@/lib/ai/anthropic", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/lib/ai/anthropic")>();
+  return {
+    ...actual,
+    getAnthropicClient: vi.fn(),
+  };
+});
+
+import { getAnthropicClient } from "@/lib/ai/anthropic";
+import { classifyIntent } from "./orchestrator";
+
+function mockAnthropicCreate(replyText: string | Error) {
+  return {
+    messages: {
+      create:
+        replyText instanceof Error
+          ? vi.fn().mockRejectedValue(replyText)
+          : vi.fn().mockResolvedValue({
+              content: [{ type: "text", text: replyText }],
+            }),
+      stream: vi.fn(),
+    },
+  };
+}
+
+describe("classifyIntent", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  // ───── Claude-success path ─────────────────────────────────────────────
+
+  test("returns health_question for a clear health question", async () => {
+    const anthropic = mockAnthropicCreate("health_question");
+    vi.mocked(getAnthropicClient).mockReturnValue(anthropic as never);
+
+    const result = await classifyIntent("What is HPV and how is it transmitted?");
+    expect(result.intent satisfies Intent).toBe("health_question");
+  });
+
+  test("returns news_request when the model says so", async () => {
+    const anthropic = mockAnthropicCreate("news_request");
+    vi.mocked(getAnthropicClient).mockReturnValue(anthropic as never);
+
+    const result = await classifyIntent("latest news on HPV vaccine");
+    expect(result.intent).toBe("news_request");
+  });
+
+  test("returns events_request when the model says so", async () => {
+    const anthropic = mockAnthropicCreate("events_request");
+    vi.mocked(getAnthropicClient).mockReturnValue(anthropic as never);
+
+    const result = await classifyIntent("events near me");
+    expect(result.intent).toBe("events_request");
+  });
+
+  test("returns general_chat for small talk", async () => {
+    const anthropic = mockAnthropicCreate("general_chat");
+    vi.mocked(getAnthropicClient).mockReturnValue(anthropic as never);
+
+    const result = await classifyIntent("hello!");
+    expect(result.intent).toBe("general_chat");
+  });
+
+  test("trims and lowercases the model's output before matching", async () => {
+    const anthropic = mockAnthropicCreate("  HEALTH_QUESTION  \n");
+    vi.mocked(getAnthropicClient).mockReturnValue(anthropic as never);
+
+    const result = await classifyIntent("anything");
+    expect(result.intent).toBe("health_question");
+  });
+
+  test("calls Claude with temperature 0 and max_tokens small", async () => {
+    const anthropic = mockAnthropicCreate("general_chat");
+    vi.mocked(getAnthropicClient).mockReturnValue(anthropic as never);
+
+    await classifyIntent("hi");
+
+    const args = anthropic.messages.create.mock.calls[0] as unknown as [
+      { temperature: number; max_tokens: number; model: string; system: string },
+    ];
+    expect(args[0].temperature).toBe(0);
+    expect(args[0].max_tokens).toBeLessThan(64); // tight bound for a single label
+    expect(args[0].model).toBe("claude-sonnet-4-6");
+    expect(typeof args[0].system).toBe("string");
+    expect(args[0].system.length).toBeGreaterThan(0);
+  });
+
+  // ───── Fallback path ───────────────────────────────────────────────────
+
+  test("falls back to news_request via keyword when Claude errors and the message mentions news", async () => {
+    const anthropic = mockAnthropicCreate(new Error("Claude exploded"));
+    vi.mocked(getAnthropicClient).mockReturnValue(anthropic as never);
+    const errSpy = vi.spyOn(console, "error").mockImplementation(() => undefined);
+
+    const result = await classifyIntent("latest news on HPV vaccine");
+    expect(result.intent).toBe("news_request");
+    errSpy.mockRestore();
+  });
+
+  test("falls back to events_request via keyword when Claude errors and the message mentions events", async () => {
+    const anthropic = mockAnthropicCreate(new Error("Claude exploded"));
+    vi.mocked(getAnthropicClient).mockReturnValue(anthropic as never);
+    const errSpy = vi.spyOn(console, "error").mockImplementation(() => undefined);
+
+    const result = await classifyIntent("any events near me?");
+    expect(result.intent).toBe("events_request");
+    errSpy.mockRestore();
+  });
+
+  test("falls back to general_chat as the safe default when Claude errors and no keyword matches", async () => {
+    const anthropic = mockAnthropicCreate(new Error("Claude exploded"));
+    vi.mocked(getAnthropicClient).mockReturnValue(anthropic as never);
+    const errSpy = vi.spyOn(console, "error").mockImplementation(() => undefined);
+
+    const result = await classifyIntent("What is HPV?");
+    expect(result.intent).toBe("general_chat");
+    errSpy.mockRestore();
+  });
+
+  test("falls back when the model returns garbage that doesn't match any intent", async () => {
+    const anthropic = mockAnthropicCreate("not_a_real_intent");
+    vi.mocked(getAnthropicClient).mockReturnValue(anthropic as never);
+
+    const result = await classifyIntent("hello");
+    // garbage from the model + no keyword match → safe default
+    expect(result.intent).toBe("general_chat");
+  });
+
+  test("never throws — always resolves to a valid Intent", async () => {
+    const anthropic = mockAnthropicCreate(new Error("anything"));
+    vi.mocked(getAnthropicClient).mockReturnValue(anthropic as never);
+    const errSpy = vi.spyOn(console, "error").mockImplementation(() => undefined);
+
+    // Won't reject even though the SDK threw.
+    await expect(classifyIntent("anything")).resolves.toBeTruthy();
+    errSpy.mockRestore();
+  });
+});

--- a/lib/agents/orchestrator.ts
+++ b/lib/agents/orchestrator.ts
@@ -1,0 +1,78 @@
+import { CLAUDE_MODEL, getAnthropicClient } from "@/lib/ai/anthropic";
+import type { Intent } from "@/types/agents";
+
+/**
+ * Tight classifier prompt. Returns ONE of four labels and nothing else.
+ * Kept short to minimize tokens — the cost of mis-classification is bounded
+ * by the rule-based fallback below.
+ */
+const CLASSIFIER_SYSTEM_PROMPT = `You classify the user's message into exactly ONE of these categories. Return ONLY the category name (lowercase, with underscores), nothing else — no explanation, no punctuation.
+
+Categories:
+- health_question  : questions about cervical health, HPV, screening, vaccination, symptoms, treatments, anatomy
+- news_request     : explicit requests for recent news, articles, headlines, or updates
+- events_request   : questions about upcoming events, meetups, screening clinics, conferences, or local activity
+- general_chat     : greetings, off-topic questions, or anything that doesn't fit above
+
+If unsure, choose general_chat.`;
+
+const VALID_INTENTS: ReadonlySet<Intent> = new Set<Intent>([
+  "health_question",
+  "news_request",
+  "events_request",
+  "general_chat",
+]);
+
+const NEWS_RE = /\b(news|latest|recent updates?|articles?|headlines?)\b/i;
+const EVENTS_RE = /\b(events?|meetups?|conferences?|near me)\b/i;
+
+export type ClassifyResult = {
+  intent: Intent;
+  confidence?: number;
+};
+
+/**
+ * Classify a user message. Always resolves with a valid `Intent` — on Claude
+ * error or unparseable output, falls back to keyword rules with `general_chat`
+ * as the safe default.
+ */
+export async function classifyIntent(userMessage: string): Promise<ClassifyResult> {
+  try {
+    const anthropic = getAnthropicClient();
+    const response = await anthropic.messages.create({
+      model: CLAUDE_MODEL,
+      max_tokens: 16,
+      temperature: 0,
+      system: CLASSIFIER_SYSTEM_PROMPT,
+      messages: [{ role: "user", content: userMessage }],
+    });
+
+    const raw = response.content
+      .map((block) => (block.type === "text" ? block.text : ""))
+      .join("")
+      .trim()
+      .toLowerCase();
+
+    if (VALID_INTENTS.has(raw as Intent)) {
+      return { intent: raw as Intent };
+    }
+    // Model returned something we can't parse — fall through to keyword rules.
+  } catch (err) {
+    // Log server-side, then fall through. The classifier never throws.
+    console.error(
+      "[orchestrator] classifyIntent: Claude error, falling back to keyword rules:",
+      err instanceof Error ? err.message : err
+    );
+  }
+
+  return { intent: fallbackIntent(userMessage) };
+}
+
+function fallbackIntent(message: string): Intent {
+  if (NEWS_RE.test(message)) return "news_request";
+  if (EVENTS_RE.test(message)) return "events_request";
+  // No keyword for health_question — too easy to over-fire on common health
+  // terms in small-talk turns. Default to general_chat; the response agent
+  // handles it the same way #27's dispatch will.
+  return "general_chat";
+}

--- a/tests/api/chat.test.ts
+++ b/tests/api/chat.test.ts
@@ -93,11 +93,19 @@ type StreamEventLike = {
   delta: { type: "text_delta"; text: string };
 };
 
+// The /api/chat route now calls messages.create() once for the intent
+// classifier (#26) before messages.stream() for the response agent. Default
+// the classifier to general_chat so existing assertions about routing
+// behavior are unaffected.
+const DEFAULT_CLASSIFIER_REPLY = {
+  content: [{ type: "text", text: "general_chat" }],
+};
+
 /** Mocks the Anthropic SDK with a `messages.stream(...)` returning the given events as an async iterable. */
 function mockAnthropic(reply: string): MockedAnthropic {
   return {
     messages: {
-      create: vi.fn(),
+      create: vi.fn().mockResolvedValue(DEFAULT_CLASSIFIER_REPLY),
       stream: vi.fn(() => ({
         async *[Symbol.asyncIterator]() {
           yield {
@@ -117,7 +125,7 @@ function mockAnthropicStream(
 ): MockedAnthropic {
   return {
     messages: {
-      create: vi.fn(),
+      create: vi.fn().mockResolvedValue(DEFAULT_CLASSIFIER_REPLY),
       stream: vi.fn(() => ({
         async *[Symbol.asyncIterator]() {
           for (let i = 0; i < events.length; i++) {
@@ -278,12 +286,16 @@ describe("POST /api/chat", () => {
   test("returns 500 if creating the chat_sessions row fails", async () => {
     const fromChain = mockSupabaseChain({ sessionInsertError: new Error("db down") });
     vi.mocked(createClient).mockReturnValue(mockSupabase({ id: "u1" }, fromChain) as never);
+    // The classifier (#26) calls getAnthropicClient unconditionally; stock
+    // it so it succeeds, then assert the response agent's stream() never ran.
+    const anthropic = mockAnthropic("ignored");
+    vi.mocked(getAnthropicClient).mockReturnValue(anthropic as never);
     const errSpy = vi.spyOn(console, "error").mockImplementation(() => undefined);
 
     const res = await POST(postRequest({ message: "Hi" }));
 
     expect(res.status).toBe(500);
-    expect(getAnthropicClient).not.toHaveBeenCalled();
+    expect(anthropic.messages.stream).not.toHaveBeenCalled();
     expect(fromChain.messageInsert).not.toHaveBeenCalled();
     errSpy.mockRestore();
   });
@@ -291,6 +303,8 @@ describe("POST /api/chat", () => {
   test("returns 404 when the user-message insert fails (RLS denial / unowned session)", async () => {
     const fromChain = mockSupabaseChain({ messageInsertError: new Error("RLS violation") });
     vi.mocked(createClient).mockReturnValue(mockSupabase({ id: "u1" }, fromChain) as never);
+    const anthropic = mockAnthropic("ignored");
+    vi.mocked(getAnthropicClient).mockReturnValue(anthropic as never);
     const errSpy = vi.spyOn(console, "error").mockImplementation(() => undefined);
 
     const res = await POST(
@@ -301,7 +315,7 @@ describe("POST /api/chat", () => {
     );
 
     expect(res.status).toBe(404);
-    expect(getAnthropicClient).not.toHaveBeenCalled();
+    expect(anthropic.messages.stream).not.toHaveBeenCalled();
     expect(fromChain.messageInsert).toHaveBeenCalledTimes(1); // only the failed user write
     errSpy.mockRestore();
   });
@@ -311,12 +325,14 @@ describe("POST /api/chat", () => {
       historyError: new Error("history query exploded"),
     });
     vi.mocked(createClient).mockReturnValue(mockSupabase({ id: "u1" }, fromChain) as never);
+    const anthropic = mockAnthropic("ignored");
+    vi.mocked(getAnthropicClient).mockReturnValue(anthropic as never);
     const errSpy = vi.spyOn(console, "error").mockImplementation(() => undefined);
 
     const res = await POST(postRequest({ message: "Hi" }));
 
     expect(res.status).toBe(500);
-    expect(getAnthropicClient).not.toHaveBeenCalled();
+    expect(anthropic.messages.stream).not.toHaveBeenCalled();
     errSpy.mockRestore();
   });
 

--- a/types/agents.ts
+++ b/types/agents.ts
@@ -1,0 +1,8 @@
+/**
+ * Output of the orchestrator's classifier. Drives downstream dispatch in #27:
+ *
+ * - `health_question` → RAG agent → response agent (Epic 4 wiring)
+ * - `news_request` / `events_request` → external-tool agents (Epic 9)
+ * - `general_chat` → response agent directly
+ */
+export type Intent = "health_question" | "news_request" | "events_request" | "general_chat";


### PR DESCRIPTION
## Summary
- Add `lib/agents/orchestrator.ts` — exports `classifyIntent(userMessage)` returning `{ intent: Intent; confidence? }`
- Add `types/agents.ts` — single-source `Intent` union (`health_question | news_request | events_request | general_chat`)
- Implementation: non-streaming Claude call (`messages.create`), `temperature: 0`, `max_tokens: 16`, tight classifier prompt
- Fallback when Claude errors OR returns unparseable output: keyword regex with `general_chat` as the safe default
- Wired into `/api/chat` as a logging pre-step (`console.info`); **does NOT change routing** — that lands in #27

## Decisions
- `Intent` is a string-literal union (not an enum) — cleaner discriminated unions and serialization
- `classifyIntent` always resolves; never throws. Route doesn't need a try/catch around it
- No `history` parameter for v1 — the current message is enough for the four-way split per the AC
- No keyword-based detection of `health_question` in the fallback — too easy to over-fire on common health terms ("HPV") in small-talk turns. `general_chat` is the safe default; response agent handles it identically to `health_question` until #27's dispatch lands

## Tests added
- `classifyIntent` (11): each of the four intents from a Claude success response, output trim/lowercase tolerance, Claude-call shape (model, temperature, max_tokens, non-empty system prompt), keyword fallback for news, keyword fallback for events, default-to-general_chat fallback, garbage-from-model fallback, "never throws" guarantee

## Tests modified
- `tests/api/chat.test.ts` — `mockAnthropic` / `mockAnthropicStream` helpers now stock `messages.create` with a `general_chat` reply (the new pre-step calls it on every request)
- The three pre-classifier-bail tests (session-create fail, RLS denial, history-load fail) now stock `getAnthropicClient` and assert `messages.stream()` (not `getAnthropicClient` itself) wasn't called — `getAnthropicClient` IS now called by the classifier on every path past Zod validation

## Test plan
- [x] `pnpm test` — 167/167 across 15 files (was 156 — +11 from the orchestrator)
- [x] `pnpm biome check .` — clean
- [x] `pnpm exec tsc --noEmit` — clean

Closes #26. Prerequisite for the orchestrator wiring in #27.

🤖 Generated with [Claude Code](https://claude.com/claude-code)