### PR TITLE
feat(rag): #42 — OpenAI client + embeddings helper

### DIFF
--- a/docs/epics/epic4-rag-knowledge-base-tickets.md
+++ b/docs/epics/epic4-rag-knowledge-base-tickets.md
@@ -1,0 +1,227 @@
+# Epic 4 — RAG Knowledge Base — Ticket Breakdown
+
+> Derived from `docs/sprints.md` §Epic 4. Sprint 3 covers all `M` items (the RAG retrieval pipeline end-to-end). `S` items (fallback polish, HNSW tuning) ship in the same sprint or follow-up.
+
+Each ticket is scoped to a single PR. Dependencies reference other tickets by ID. Acceptance criteria (AC) are the minimum bar for "done".
+
+---
+
+## Schema-level scaffolding ALREADY in place (Epic 1)
+
+The Epic 1 migration `supabase/migrations/20260409170904_create_knowledge_chunks.sql` already shipped:
+
+- ✅ `knowledge_chunks` table — `id`, `source`, `content`, `embedding vector(1536)`, `metadata jsonb`, `created_at`
+- ✅ HNSW index on `embedding` using `vector_cosine_ops` with `m=16, ef_construction=64`
+- ✅ `public.match_knowledge_chunks(query_embedding, threshold, count)` SQL RPC — returns rows above threshold sorted by similarity
+- ✅ RLS policies (Epic 2 #12): admins INSERT/UPDATE/DELETE; all authenticated SELECT
+
+Epic 4 is therefore **almost entirely application-layer code** — no new tables, no new indexes, no new RPCs in v1. Tickets reflect that.
+
+---
+
+## Sprint 3 — RAG pipeline (M-priority)
+
+### EPIC4-01 — OpenAI Client + Embeddings Helper
+**MoSCoW:** M
+**Depends on:** —
+
+Install the OpenAI SDK, expose a typed client factory, and add an `embedText(text)` helper that calls `text-embedding-3-small` and returns a 1536-dim float array.
+
+**AC:**
+- [ ] `openai` SDK added to `package.json` (version pinned)
+- [ ] `OPENAI_API_KEY` already documented in `docs/env-vars.md` and `.env.example` (verify; should be present from Epic 1)
+- [ ] `lib/ai/openai.ts` exports `getOpenAIClient()` factory consuming `env.openaiApiKey`
+- [ ] `lib/rag/embed.ts` exports `embedText(text: string): Promise<number[]>` — calls `text-embedding-3-small`, returns the 1536-dim vector
+- [ ] Model string `text-embedding-3-small` is hard-coded (per `CLAUDE.md` convention)
+- [ ] Vitest unit tests mock the SDK and assert the call shape (model, input) + return-array length
+
+**Technical Notes:**
+- Mirrors the Anthropic client pattern from #18.
+- Rate limits and retries are handled by the SDK's defaults for v1.
+
+---
+
+### EPIC4-02 — Document Chunking (512 tokens / 64 overlap)
+**MoSCoW:** M
+**Depends on:** —
+
+Pure utility that splits a long text into ~512-token chunks with 64-token overlap so adjacent chunks share context across boundaries.
+
+**AC:**
+- [ ] `lib/rag/chunking.ts` exports `chunkText(text, opts?): string[]`
+- [ ] Defaults: `chunkSize: 512`, `overlap: 64`. Both overridable via `opts`.
+- [ ] Token counting: cheap-and-correct approximation (1 token ≈ 4 chars) is fine for v1; the tokenizer choice is documented as "swap to `tiktoken` later if RAG quality drops".
+- [ ] Empty input → empty array
+- [ ] Input shorter than `chunkSize` → single-element array
+- [ ] Each chunk's tail ≈ next chunk's head (overlap enforced)
+- [ ] Vitest unit tests: empty, single chunk, exact-boundary, overlap correctness, deterministic output
+
+**Technical Notes:**
+- Pure function, no I/O.
+- Boundary preference: prefer paragraph breaks, then sentence breaks, then word breaks. Hard cut only if no break exists in the window.
+
+---
+
+### EPIC4-03 — Knowledge Chunks Insert Helper
+**MoSCoW:** M
+**Depends on:** EPIC4-01, EPIC4-02
+
+Server-side helper that takes raw text + metadata, chunks it, embeds each chunk, and bulk-inserts into `knowledge_chunks`. Used by the admin ingest endpoint (#06) and the seed script (#07).
+
+**AC:**
+- [ ] `lib/rag/store.ts` exports `ingestDocument(supabase, { content, source, metadata? }): Promise<{ chunkIds: string[] }>`
+- [ ] Internally: chunks via `chunkText`, embeds each via `embedText`, inserts all chunks in a single Supabase `insert([...])` call
+- [ ] Embeddings generated in parallel where possible (e.g., `Promise.all` with a small concurrency cap)
+- [ ] Returns the inserted chunk IDs for the caller to surface to admins
+- [ ] Vitest unit tests with mocked OpenAI + mocked Supabase: assert chunking happened, embeddings were generated per chunk, inserts contain the right shape
+
+**Technical Notes:**
+- Uses the cookie-aware Supabase server client passed in by the caller (RLS scopes the insert to admins via the policy from Epic 2 #12).
+- Cost note: a 50KB document chunks to ~25 chunks, ~25 embedding API calls per ingest. Acceptable for admin ingest; not for per-request use.
+
+---
+
+### EPIC4-04 — pgvector Cosine Similarity Retrieval Helper
+**MoSCoW:** M
+**Depends on:** EPIC4-01
+
+Wraps the existing `match_knowledge_chunks` RPC in a typed TypeScript helper that the RAG agent calls.
+
+**AC:**
+- [ ] `lib/rag/retrieve.ts` exports `retrieveChunks(supabase, queryEmbedding, opts?): Promise<RetrievedChunk[]>`
+- [ ] Defaults: `threshold: 0.75`, `count: 5`. Both overridable via `opts`.
+- [ ] Calls `supabase.rpc("match_knowledge_chunks", { query_embedding, match_threshold, match_count })` — uses the existing RPC, no new SQL needed
+- [ ] Returns typed `RetrievedChunk[]` with `id`, `source`, `content`, `similarityScore`, `metadata`
+- [ ] Empty result when no chunks above threshold (returns `[]`, not null)
+- [ ] Vitest unit tests with mocked Supabase RPC: returns sorted results, respects threshold, respects count, empty result handled
+
+**Technical Notes:**
+- The threshold value of `0.75` is the project's spec; tunable later.
+- RLS allows all authenticated users to SELECT from `knowledge_chunks`, so the RPC works under any user's session.
+
+---
+
+### EPIC4-05 — RAG Agent — Query Embed + Retrieval + Context
+**MoSCoW:** M
+**Depends on:** EPIC4-01, EPIC4-04
+
+The agent the orchestrator calls for `health_question` intents. Embeds the user query, retrieves top-k chunks, formats them as a context block + structured `Source[]`.
+
+**AC:**
+- [ ] `lib/agents/rag-agent.ts` exports `runRagAgent(supabase, { userMessage }): Promise<{ ragContext: string; ragSources: Source[] }>`
+- [ ] Internally: `embedText(userMessage)` → `retrieveChunks(supabase, embedding)` → format
+- [ ] `ragContext`: a human-readable concatenation of the retrieved `content`s, with citation markers like `[1]`, `[2]` matching the `Source[]` indices
+- [ ] `ragSources`: structured `Source[]` from `types/agents.ts` (chunkId from the chunk row's `id`)
+- [ ] Empty retrieval → returns `{ ragContext: "", ragSources: [] }` (no error)
+- [ ] Per `CLAUDE.md`: pure function (no HTTP / DB / Supabase concerns inside — Claude/OpenAI calls are fine, takes Supabase client as a param)
+- [ ] Vitest unit tests with mocked `embedText` + mocked `retrieveChunks`: assert context format + sources shape, empty-retrieval case
+
+**Technical Notes:**
+- Unblocks Epic 3 #27 (orchestrator wiring).
+- The orchestrator calls this for `health_question` intents, then passes `ragContext` + `ragSources` into `runResponseAgent` (which already accepts both per #28).
+
+---
+
+### EPIC4-06 — Admin Ingestion Endpoint — POST `/api/embeddings/ingest`
+**MoSCoW:** M
+**Depends on:** EPIC4-03
+
+Admin-only HTTP endpoint that accepts a document and ingests it into the knowledge base.
+
+**AC:**
+- [ ] `app/api/embeddings/ingest/route.ts` POST handler
+- [ ] Auth: 401 if no Supabase user; 403 if user is not admin (`profiles.role !== 'admin'`)
+- [ ] Zod-validated body: `{ source: string, content: string, metadata?: object }`
+- [ ] Calls `ingestDocument` and returns `{ chunkIds: string[] }`
+- [ ] 413 if content exceeds a sensible cap (e.g., 500KB raw text)
+- [ ] 500 on embedding/insert failure with server-side logging
+- [ ] Vitest route tests: 401 unauth, 403 non-admin, 200 admin happy path, 400 invalid body
+
+**Technical Notes:**
+- Returns `Response.json(...)` per `CLAUDE.md`.
+- Per `CLAUDE.md`'s admin-route convention: do the role check on every request server-side.
+
+---
+
+### EPIC4-07 — Initial Knowledge Base Content Seed
+**MoSCoW:** M
+**Depends on:** EPIC4-03 (or EPIC4-06)
+
+Curated v1 content from authoritative sources so the RAG agent has something to cite from day one.
+
+**AC:**
+- [ ] `scripts/seed-knowledge-base.ts` (or equivalent) ingests a curated set of documents from Cancer Council Australia, WHO, HealthDirect Australia
+- [ ] Documents stored under version control as plain `.md` or `.txt` files in `supabase/seeds/knowledge/` (or similar) so they can be re-ingested deterministically
+- [ ] License/attribution clearly recorded in each file's frontmatter (or a manifest)
+- [ ] `pnpm seed:kb` (or similar npm script) runs the ingestion against a local Supabase
+- [ ] Verification: `select count(*) from knowledge_chunks` after seeding returns a non-trivial number (~50-200 chunks for v1)
+- [ ] No automated test (this is content + a script); manual smoke-check in the PR
+
+**Technical Notes:**
+- License compliance matters — record attribution per source.
+- Could re-use `ingestDocument` (#03) directly OR call the admin endpoint (#06). Direct is simpler for a one-shot script.
+
+---
+
+## Sprint 3 (or follow-up) — Polish (S-priority)
+
+### EPIC4-08 — Fallback When No Relevant Chunks Found
+**MoSCoW:** S
+**Depends on:** EPIC4-05
+
+When `retrieveChunks` returns nothing above threshold, the RAG agent should signal that to the orchestrator/response agent so the reply doesn't pretend to have sources.
+
+**AC:**
+- [ ] `runRagAgent` already returns `{ ragContext: "", ragSources: [] }` for no-match (per EPIC4-05 AC)
+- [ ] The response agent receives an empty `ragContext` and the system prompt is unchanged from baseline (no "Retrieved context:" header for empty)
+- [ ] Verify in `lib/agents/response-agent.ts` that the empty-`ragContext` case produces the same prompt as the no-`ragContext` case (it already does — see #28's implementation; this ticket adds an explicit unit test pinning that behavior)
+- [ ] Optional: orchestrator logs `health_question` calls that returned zero chunks (helps tune the threshold later)
+
+**Technical Notes:**
+- Most of this is already handled structurally; the ticket exists to add explicit test coverage and the optional logging.
+
+---
+
+### EPIC4-09 — HNSW Index Tuning Verification
+**MoSCoW:** S
+**Depends on:** EPIC4-07
+
+The HNSW index already exists with `m=16, ef_construction=64` (Epic 1). This ticket is a **measurement + decision** — verify those defaults are reasonable for v1's KB size, document the decision, and only retune if numbers say so.
+
+**AC:**
+- [ ] Measure retrieval p50 / p95 query latency against the seeded KB (~50–200 chunks from #07)
+- [ ] Confirm `ef_search` defaults are reasonable (PostgreSQL session-level — can be set via `SET hnsw.ef_search = N` or `set_config`)
+- [ ] Document findings in `docs/database.md` under the `knowledge_chunks` section
+- [ ] **No code change required if measurements are acceptable** — this ticket can close as "no-op, measurements logged" if so
+- [ ] If retuning is needed, ship a migration that drops + recreates the index with new params (HNSW indexes can't be tuned in-place)
+
+**Technical Notes:**
+- For v1's small KB (~hundreds of chunks), defaults are almost certainly fine. This ticket protects against shipping with unknown perf and gives us a baseline to compare against post-launch.
+
+---
+
+## Dependency graph (shorthand)
+
+```
+EPIC4-01 ─┐
+          ├─► EPIC4-03 ─► EPIC4-06 ─► EPIC4-07 ─► EPIC4-09
+          │
+          ├─► EPIC4-04 ─► EPIC4-05 ─► EPIC4-08
+EPIC4-02 ─┘
+```
+
+EPIC4-05 unblocks Epic 3 / #27 (orchestrator wiring).
+
+## Coverage check vs `docs/sprints.md` §Epic 4
+
+| Feature (from sprints.md) | Ticket(s) |
+|---|---|
+| OpenAI `text-embedding-3-small` integration | EPIC4-01 |
+| Document chunking (512 tokens, 64-token overlap) | EPIC4-02 |
+| `knowledge_chunks` write + pgvector storage | EPIC4-03 (write helper); schema is pre-shipped from Epic 1 |
+| pgvector cosine similarity retrieval (threshold > 0.75) | EPIC4-04 |
+| RAG Agent — query embed + retrieval + context injection | EPIC4-05 |
+| Admin ingestion endpoint `/api/embeddings/ingest` | EPIC4-06 |
+| Initial knowledge base content (Cancer Council / WHO / HealthDirect) | EPIC4-07 |
+| Fallback when no relevant chunks found | EPIC4-08 |
+| HNSW index tuning | EPIC4-09 |

--- a/docs/superpowers/plans/2026-05-02-epic4-openai-embeddings.md
+++ b/docs/superpowers/plans/2026-05-02-epic4-openai-embeddings.md
@@ -1,0 +1,457 @@
+# Epic 4 — #42 OpenAI Client + Embeddings Helper Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Install the OpenAI TypeScript SDK, expose a typed `getOpenAIClient()` factory in `lib/ai/openai.ts`, and add an `embedText(text)` helper in `lib/rag/embed.ts` that calls `text-embedding-3-small` and returns the 1536-dim vector. Foundation for the rest of Epic 4 (chunking write helper, retrieval, RAG agent).
+
+**Architecture:** Mirrors the Anthropic client pattern from #18. The SDK uses `openai` (the official Node SDK), the factory consumes `env.openaiApiKey` from the already-validated `lib/env.ts`, the model string `text-embedding-3-small` is hard-coded in `lib/ai/openai.ts` per `CLAUDE.md` convention. The `embedText` helper is the only thing the rest of Epic 4 should call — keeps the SDK surface area small and lets us swap embedding providers later (Voyage, Cohere) without touching downstream code.
+
+**Tech Stack:** `openai` SDK (latest stable), TypeScript strict, Vitest (`node` env — the SDK refuses to instantiate under jsdom for the same security reason as Anthropic), Biome.
+
+**Issue:** [#42](https://github.com/Zoeyyhc/cervix-assistant/issues/42)
+**Source ticket doc:** [`docs/epics/epic4-rag-knowledge-base-tickets.md`](../../epics/epic4-rag-knowledge-base-tickets.md) §EPIC4-01
+**Depends on:** —
+
+---
+
+## Pre-existing scaffolding
+
+- ✅ `OPENAI_API_KEY` already documented in `.env.example` (Epic 1) and `docs/env-vars.md`
+- ✅ `lib/env.ts` already validates and exports `env.openaiApiKey` via `requireEnv()`
+- ✅ `lib/ai/` directory exists (used by Anthropic client + system prompt + streaming + context-window)
+- ❌ `lib/rag/` directory doesn't exist yet — this ticket creates it
+- ✅ `vitest.setup.ts` already stubs `OPENAI_API_KEY` for tests (added in #18)
+
+## Gaps vs #42 acceptance criteria
+
+| AC | Status | Action |
+|---|---|---|
+| `openai` SDK added (version pinned) | ❌ | **Task 2** |
+| `OPENAI_API_KEY` documented | ✅ Already in place | None — verify in pre-flight |
+| `lib/ai/openai.ts` exports `getOpenAIClient()` | ❌ | **Task 3** |
+| `lib/rag/embed.ts` exports `embedText(text): Promise<number[]>` | ❌ | **Task 4** |
+| Model string `text-embedding-3-small` hard-coded | ❌ | Task 3 (`EMBEDDING_MODEL` constant) |
+| Vitest unit tests | ❌ | Tasks 3, 4 |
+
+---
+
+## File Structure
+
+| File | Change | Responsibility |
+|---|---|---|
+| `package.json` / `pnpm-lock.yaml` | **Modify** | Add `openai` dependency (pinned, no caret) |
+| `lib/ai/openai.ts` | **Create** | Exports `EMBEDDING_MODEL` constant + `getOpenAIClient()` factory consuming `env.openaiApiKey` |
+| `lib/ai/openai.test.ts` | **Create** | Factory + constant tests (under `node` env) |
+| `lib/rag/embed.ts` | **Create** | Exports `embedText(text: string): Promise<number[]>` — calls `embeddings.create` with `EMBEDDING_MODEL`, returns the first embedding |
+| `lib/rag/embed.test.ts` | **Create** | Unit tests with mocked SDK: call shape, return shape, error propagation |
+
+**Files not touched:**
+- `.env.example` and `docs/env-vars.md` — `OPENAI_API_KEY` already in place.
+- `lib/env.ts` — `env.openaiApiKey` already exists.
+- `vitest.setup.ts` — env stub already in place.
+
+---
+
+## Pre-flight
+
+- [ ] **Step A: Confirm we're on the right branch**
+
+```bash
+git branch --show-current
+```
+Expected: `feat/openai-embeddings-42`.
+
+- [ ] **Step B: Confirm env-var docs + lib/env.ts already wire `OPENAI_API_KEY`**
+
+```bash
+grep -n "OPENAI_API_KEY\|openaiApiKey" .env.example docs/env-vars.md lib/env.ts
+```
+Expected: hits in all three (`.env.example` line 17, `docs/env-vars.md` Anthropic/OpenAI section, `lib/env.ts` env object).
+
+- [ ] **Step C: Confirm `openai` is not yet installed**
+
+```bash
+grep '"openai"' package.json || echo "not yet installed (expected)"
+```
+
+- [ ] **Step D: Baseline tests + Biome + tsc green**
+
+```bash
+pnpm test 2>&1 | tail -5 && pnpm biome check . 2>&1 | tail -3 && pnpm exec tsc --noEmit -p tsconfig.json 2>&1 | tail -3
+```
+Expected: 177/177 with real Supabase env, or 165/177 (12 skipped) without. Biome and tsc clean.
+
+---
+
+## Task 1: Decide and document the surface
+
+**Files:** none — design notes that flow into Tasks 3-4.
+
+These decisions are explicit so the executor doesn't have to make them mid-implementation:
+
+1. **Two files**: `lib/ai/openai.ts` for the client factory, `lib/rag/embed.ts` for the embedding helper. Per the AC. Keeps `lib/rag/` semantically pure (RAG-specific helpers) and `lib/ai/` for SDK plumbing.
+2. **`EMBEDDING_MODEL = "text-embedding-3-small"`** as a named constant in `lib/ai/openai.ts`. Hard-coded per `CLAUDE.md`. Both `embedText` and any future similarity-checks consume from there.
+3. **`embedText` returns `number[]`**, not the SDK's full response shape. Strips the wrapper so callers don't depend on OpenAI's internal types — easier to swap providers later.
+4. **No retry / fallback logic in v1.** SDK defaults handle transient errors; if persistent failures become an issue we add retry at the call site (e.g., `ingestDocument`).
+5. **Tests run under `node` env** — same as the Anthropic client. The OpenAI SDK has the same browser-detection guard.
+
+- [ ] **Step 1: Acknowledge the decisions** — no code yet.
+
+---
+
+## Task 2: Install the OpenAI SDK
+
+**Files:** `package.json`, `pnpm-lock.yaml`.
+
+- [ ] **Step 1: Add the dependency**
+
+```bash
+pnpm add openai
+```
+
+- [ ] **Step 2: Pin the version (strip the caret)**
+
+Open `package.json`. Find the line like:
+```json
+"openai": "^X.Y.Z",
+```
+Change to:
+```json
+"openai": "X.Y.Z",
+```
+
+(Use whatever version `pnpm add` resolved to. Match the pinning convention from `@anthropic-ai/sdk` in #18.)
+
+Re-run `pnpm install` to refresh the lockfile against the pinned spec:
+```bash
+pnpm install
+```
+
+- [ ] **Step 3: Verify the SDK imports cleanly**
+
+```bash
+pnpm exec tsc --noEmit -p tsconfig.json 2>&1 | head -10
+```
+Expected: no new errors.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add package.json pnpm-lock.yaml
+git commit -m "chore(deps): add openai SDK for Epic 4 embeddings"
+```
+
+---
+
+## Task 3: OpenAI client factory (TDD)
+
+**Files:** `lib/ai/openai.ts`, `lib/ai/openai.test.ts`.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `lib/ai/openai.test.ts`:
+
+```typescript
+// @vitest-environment node
+// The OpenAI SDK refuses to instantiate under a browser-like global (jsdom —
+// the default Vitest environment) to keep secrets out of bundles. Server-only
+// modules under lib/ai/ run under the Node environment in tests.
+
+import OpenAI from "openai";
+import { describe, expect, it } from "vitest";
+import { EMBEDDING_MODEL, getOpenAIClient } from "./openai";
+
+describe("EMBEDDING_MODEL", () => {
+  it("is hard-coded to text-embedding-3-small", () => {
+    // Per CLAUDE.md: model strings are hard-coded, never from env.
+    expect(EMBEDDING_MODEL).toBe("text-embedding-3-small");
+  });
+});
+
+describe("getOpenAIClient", () => {
+  it("returns an OpenAI SDK instance", () => {
+    const client = getOpenAIClient();
+    expect(client).toBeInstanceOf(OpenAI);
+  });
+
+  it("exposes the embeddings namespace", () => {
+    const client = getOpenAIClient();
+    expect(typeof client.embeddings.create).toBe("function");
+  });
+});
+```
+
+- [ ] **Step 2: Run the test to confirm it fails**
+
+```bash
+pnpm test lib/ai/openai.test.ts 2>&1 | tail -10
+```
+Expected: module-resolution failure for `./openai`.
+
+- [ ] **Step 3: Write the implementation**
+
+Create `lib/ai/openai.ts`:
+
+```typescript
+import { env } from "@/lib/env";
+import OpenAI from "openai";
+
+/**
+ * Hard-coded per CLAUDE.md — never read from env. All embedding calls in
+ * lib/rag/ use this exact model string. Bumping requires a code change + PR
+ * review, and a re-embedding of the existing knowledge_chunks rows (the
+ * 1536-dim vector column would need to match a new model's output shape).
+ */
+export const EMBEDDING_MODEL = "text-embedding-3-small" as const;
+
+/**
+ * Returns a typed OpenAI SDK client. The API key is consumed from the
+ * already-validated `env.openaiApiKey` (see `lib/env.ts`) — module load
+ * fails fast if the var is missing, so consumers don't need to null-check.
+ */
+export function getOpenAIClient(): OpenAI {
+  return new OpenAI({ apiKey: env.openaiApiKey });
+}
+```
+
+- [ ] **Step 4: Run the tests to confirm they pass**
+
+```bash
+pnpm test lib/ai/openai.test.ts 2>&1 | tail -5
+```
+Expected: 3/3 passing.
+
+- [ ] **Step 5: Biome**
+
+```bash
+pnpm biome check --write lib/ai/openai.ts lib/ai/openai.test.ts
+```
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add lib/ai/openai.ts lib/ai/openai.test.ts
+git commit -m "feat(ai): add typed OpenAI client factory with hard-coded EMBEDDING_MODEL"
+```
+
+---
+
+## Task 4: `embedText` helper (TDD)
+
+**Files:** `lib/rag/embed.ts`, `lib/rag/embed.test.ts`.
+
+- [ ] **Step 1: Make the directory**
+
+```bash
+mkdir -p lib/rag
+```
+
+(`lib/rag/` is the canonical location per `CLAUDE.md` § Structure — embedding, chunking, retrieval utilities.)
+
+- [ ] **Step 2: Write the failing test**
+
+Create `lib/rag/embed.test.ts`:
+
+```typescript
+// @vitest-environment node
+
+import { beforeEach, describe, expect, test, vi } from "vitest";
+
+vi.mock("@/lib/ai/openai", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/lib/ai/openai")>();
+  return {
+    ...actual,
+    getOpenAIClient: vi.fn(),
+  };
+});
+
+import { EMBEDDING_MODEL, getOpenAIClient } from "@/lib/ai/openai";
+import { embedText } from "./embed";
+
+function mockOpenAI(embedding: number[] | Error) {
+  return {
+    embeddings: {
+      create:
+        embedding instanceof Error
+          ? vi.fn().mockRejectedValue(embedding)
+          : vi.fn().mockResolvedValue({ data: [{ embedding }] }),
+    },
+  };
+}
+
+describe("embedText", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  test("calls embeddings.create with EMBEDDING_MODEL and the input text", async () => {
+    const fakeEmbedding = Array.from({ length: 1536 }, () => 0.1);
+    const openai = mockOpenAI(fakeEmbedding);
+    vi.mocked(getOpenAIClient).mockReturnValue(openai as never);
+
+    await embedText("What is HPV?");
+
+    expect(openai.embeddings.create).toHaveBeenCalledTimes(1);
+    const args = openai.embeddings.create.mock.calls[0] as unknown as [
+      { model: string; input: string },
+    ];
+    expect(args[0].model).toBe(EMBEDDING_MODEL);
+    expect(args[0].input).toBe("What is HPV?");
+  });
+
+  test("returns the first embedding's vector as number[]", async () => {
+    const fakeEmbedding = Array.from({ length: 1536 }, (_, i) => i / 1536);
+    const openai = mockOpenAI(fakeEmbedding);
+    vi.mocked(getOpenAIClient).mockReturnValue(openai as never);
+
+    const result = await embedText("anything");
+
+    expect(Array.isArray(result)).toBe(true);
+    expect(result).toHaveLength(1536);
+    expect(result).toEqual(fakeEmbedding);
+  });
+
+  test("propagates errors from the SDK", async () => {
+    const openai = mockOpenAI(new Error("OpenAI exploded"));
+    vi.mocked(getOpenAIClient).mockReturnValue(openai as never);
+
+    await expect(embedText("anything")).rejects.toThrow("OpenAI exploded");
+  });
+});
+```
+
+- [ ] **Step 3: Run the tests to confirm they fail**
+
+```bash
+pnpm test lib/rag/embed.test.ts 2>&1 | tail -10
+```
+Expected: module-resolution failure for `./embed`.
+
+- [ ] **Step 4: Write the implementation**
+
+Create `lib/rag/embed.ts`:
+
+```typescript
+import { EMBEDDING_MODEL, getOpenAIClient } from "@/lib/ai/openai";
+
+/**
+ * Embed a single text string and return its 1536-dim vector. Wraps the
+ * OpenAI SDK so callers under `lib/rag/` don't depend on the SDK's response
+ * shape — easier to swap providers (Voyage, Cohere) later if needed.
+ *
+ * Errors from the SDK propagate; retries are handled by the SDK's defaults
+ * for v1.
+ */
+export async function embedText(text: string): Promise<number[]> {
+  const openai = getOpenAIClient();
+  const response = await openai.embeddings.create({
+    model: EMBEDDING_MODEL,
+    input: text,
+  });
+  return response.data[0].embedding;
+}
+```
+
+- [ ] **Step 5: Run the tests**
+
+```bash
+pnpm test lib/rag/embed.test.ts 2>&1 | tail -5
+```
+Expected: 3/3 passing.
+
+- [ ] **Step 6: Biome + tsc**
+
+```bash
+pnpm biome check --write lib/rag/embed.ts lib/rag/embed.test.ts
+pnpm exec tsc --noEmit -p tsconfig.json 2>&1 | tail -3
+```
+Expected: clean.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add lib/rag/embed.ts lib/rag/embed.test.ts
+git commit -m "feat(rag): add embedText helper for OpenAI text-embedding-3-small"
+```
+
+---
+
+## Task 5: Final verification + push + PR
+
+- [ ] **Step 1: Full test sweep**
+
+```bash
+eval "$(supabase status -o env)" && export SUPABASE_URL="${SUPABASE_URL:-$API_URL}" SUPABASE_SERVICE_ROLE_KEY="${SUPABASE_SERVICE_ROLE_KEY:-$SERVICE_ROLE_KEY}" SUPABASE_ANON_KEY="${SUPABASE_ANON_KEY:-$ANON_KEY}"
+pnpm test 2>&1 | tail -5
+```
+Expected: 177 baseline + **3** (openai factory) + **3** (embedText) = **183**.
+
+- [ ] **Step 2: Biome + tsc + build**
+
+```bash
+pnpm biome check . 2>&1 | tail -3 && pnpm exec tsc --noEmit -p tsconfig.json 2>&1 | tail -3 && pnpm build 2>&1 | tail -5
+```
+Expected: all clean; build succeeds.
+
+- [ ] **Step 3: Commit the source ticket doc + plan**
+
+The Epic 4 ticket-breakdown doc (`docs/epics/epic4-rag-knowledge-base-tickets.md`) is currently untracked from the brainstorming session. Fold it into this PR alongside the plan — same pattern as Epic 3 #17.
+
+```bash
+git add docs/epics/epic4-rag-knowledge-base-tickets.md
+git commit -m "docs(epic-4): add ticket breakdown for the RAG knowledge base"
+
+git add docs/superpowers/plans/2026-05-02-epic4-openai-embeddings.md
+git commit -m "docs(plan): add Epic 4 #42 OpenAI client + embeddings plan"
+```
+
+- [ ] **Step 4: Push**
+
+```bash
+git push -u origin feat/openai-embeddings-42
+```
+
+- [ ] **Step 5: Open the PR**
+
+```bash
+gh pr create --repo Zoeyyhc/cervix-assistant --base main --head feat/openai-embeddings-42 \
+  --title "feat(rag): #42 — OpenAI client + embeddings helper" \
+  --body "$(cat <<'EOF'
+## Summary
+- Install `openai` SDK (pinned)
+- Add `lib/ai/openai.ts` — typed client factory + hard-coded `EMBEDDING_MODEL = "text-embedding-3-small"` constant (per `CLAUDE.md`)
+- Add `lib/rag/embed.ts` — `embedText(text): Promise<number[]>` returning the 1536-dim vector (strips the SDK's response wrapper so downstream code under `lib/rag/` doesn't depend on OpenAI's internal types)
+- Vitest tests:
+  - Factory: model constant, `OpenAI` instance, `embeddings` namespace exposed (runs under `node` env because the SDK refuses to instantiate under jsdom)
+  - `embedText`: call shape (model + input), return shape (`number[]`, length 1536), error propagation
+
+## Pre-existing scaffolding (no work needed)
+- `OPENAI_API_KEY` was already documented in `.env.example` and `docs/env-vars.md` (Epic 1)
+- `lib/env.ts` already validates and exports `env.openaiApiKey` (Epic 1)
+- `vitest.setup.ts` already stubs the env var so tests load `lib/env.ts` cleanly (#18)
+
+## Drive-by
+- Includes `docs/epics/epic4-rag-knowledge-base-tickets.md` — the ticket-breakdown doc that's been sitting untracked since the Epic 4 brainstorming session. Same pattern as #17 folding the Epic 3 breakdown into the first ticket's PR.
+
+## Test plan
+- [x] `pnpm test` — 183/183 across 18 files (was 177 — +6 net: 3 factory + 3 embedText)
+- [x] `pnpm biome check .` — clean
+- [x] `pnpm exec tsc --noEmit` — clean
+- [x] `pnpm build` — succeeds
+
+Closes #42. Unblocks the rest of Epic 4 (chunking helper consumers, retrieval helper, RAG agent).
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+---
+
+## Self-review checks performed
+
+- **Spec coverage:** every AC in #42 maps to a Task — SDK install (2), factory file path + `getOpenAIClient` (3), `lib/rag/embed.ts` + `embedText` (4), hard-coded model string (3), Vitest tests at both layers (3, 4).
+- **Placeholder scan:** no TBD/TODO. The single `X.Y.Z` placeholder in Task 2 is the literal version `pnpm add` returns at runtime — explicit.
+- **Type consistency:** `EMBEDDING_MODEL` is the single source of truth in `lib/ai/openai.ts`; `embedText` imports it and the test asserts against the same import.
+- **Browser-guard handling:** consistent with #18 — both factory tests use `// @vitest-environment node`. The `embedText` test mocks the factory entirely so it doesn't need the node env, but using node anyway for symmetry doesn't hurt.
+- **Pattern consistency:** Anthropic client (#18) was the reference. Same shape: typed factory, hard-coded model constant, env-driven API key, mocked-SDK tests.

--- a/lib/ai/openai.test.ts
+++ b/lib/ai/openai.test.ts
@@ -1,0 +1,27 @@
+// @vitest-environment node
+// The OpenAI SDK refuses to instantiate under a browser-like global (jsdom —
+// the default Vitest environment) to keep secrets out of bundles. Server-only
+// modules under lib/ai/ run under the Node environment in tests.
+
+import OpenAI from "openai";
+import { describe, expect, it } from "vitest";
+import { EMBEDDING_MODEL, getOpenAIClient } from "./openai";
+
+describe("EMBEDDING_MODEL", () => {
+  it("is hard-coded to text-embedding-3-small", () => {
+    // Per CLAUDE.md: model strings are hard-coded, never from env.
+    expect(EMBEDDING_MODEL).toBe("text-embedding-3-small");
+  });
+});
+
+describe("getOpenAIClient", () => {
+  it("returns an OpenAI SDK instance", () => {
+    const client = getOpenAIClient();
+    expect(client).toBeInstanceOf(OpenAI);
+  });
+
+  it("exposes the embeddings namespace", () => {
+    const client = getOpenAIClient();
+    expect(typeof client.embeddings.create).toBe("function");
+  });
+});

--- a/lib/ai/openai.ts
+++ b/lib/ai/openai.ts
@@ -1,0 +1,19 @@
+import { env } from "@/lib/env";
+import OpenAI from "openai";
+
+/**
+ * Hard-coded per CLAUDE.md — never read from env. All embedding calls in
+ * lib/rag/ use this exact model string. Bumping requires a code change + PR
+ * review, and a re-embedding of the existing knowledge_chunks rows (the
+ * 1536-dim vector column would need to match a new model's output shape).
+ */
+export const EMBEDDING_MODEL = "text-embedding-3-small" as const;
+
+/**
+ * Returns a typed OpenAI SDK client. The API key is consumed from the
+ * already-validated `env.openaiApiKey` (see `lib/env.ts`) — module load
+ * fails fast if the var is missing, so consumers don't need to null-check.
+ */
+export function getOpenAIClient(): OpenAI {
+  return new OpenAI({ apiKey: env.openaiApiKey });
+}

--- a/lib/rag/embed.test.ts
+++ b/lib/rag/embed.test.ts
@@ -1,0 +1,65 @@
+// @vitest-environment node
+
+import { beforeEach, describe, expect, test, vi } from "vitest";
+
+vi.mock("@/lib/ai/openai", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/lib/ai/openai")>();
+  return {
+    ...actual,
+    getOpenAIClient: vi.fn(),
+  };
+});
+
+import { EMBEDDING_MODEL, getOpenAIClient } from "@/lib/ai/openai";
+import { embedText } from "./embed";
+
+function mockOpenAI(embedding: number[] | Error) {
+  return {
+    embeddings: {
+      create:
+        embedding instanceof Error
+          ? vi.fn().mockRejectedValue(embedding)
+          : vi.fn().mockResolvedValue({ data: [{ embedding }] }),
+    },
+  };
+}
+
+describe("embedText", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  test("calls embeddings.create with EMBEDDING_MODEL and the input text", async () => {
+    const fakeEmbedding = Array.from({ length: 1536 }, () => 0.1);
+    const openai = mockOpenAI(fakeEmbedding);
+    vi.mocked(getOpenAIClient).mockReturnValue(openai as never);
+
+    await embedText("What is HPV?");
+
+    expect(openai.embeddings.create).toHaveBeenCalledTimes(1);
+    const args = openai.embeddings.create.mock.calls[0] as unknown as [
+      { model: string; input: string },
+    ];
+    expect(args[0].model).toBe(EMBEDDING_MODEL);
+    expect(args[0].input).toBe("What is HPV?");
+  });
+
+  test("returns the first embedding's vector as number[]", async () => {
+    const fakeEmbedding = Array.from({ length: 1536 }, (_, i) => i / 1536);
+    const openai = mockOpenAI(fakeEmbedding);
+    vi.mocked(getOpenAIClient).mockReturnValue(openai as never);
+
+    const result = await embedText("anything");
+
+    expect(Array.isArray(result)).toBe(true);
+    expect(result).toHaveLength(1536);
+    expect(result).toEqual(fakeEmbedding);
+  });
+
+  test("propagates errors from the SDK", async () => {
+    const openai = mockOpenAI(new Error("OpenAI exploded"));
+    vi.mocked(getOpenAIClient).mockReturnValue(openai as never);
+
+    await expect(embedText("anything")).rejects.toThrow("OpenAI exploded");
+  });
+});

--- a/lib/rag/embed.ts
+++ b/lib/rag/embed.ts
@@ -1,0 +1,18 @@
+import { EMBEDDING_MODEL, getOpenAIClient } from "@/lib/ai/openai";
+
+/**
+ * Embed a single text string and return its 1536-dim vector. Wraps the
+ * OpenAI SDK so callers under `lib/rag/` don't depend on the SDK's response
+ * shape — easier to swap providers (Voyage, Cohere) later if needed.
+ *
+ * Errors from the SDK propagate; retries are handled by the SDK's defaults
+ * for v1.
+ */
+export async function embedText(text: string): Promise<number[]> {
+  const openai = getOpenAIClient();
+  const response = await openai.embeddings.create({
+    model: EMBEDDING_MODEL,
+    input: text,
+  });
+  return response.data[0].embedding;
+}

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "lucide-react": "^1.7.0",
     "next": "14.2.29",
     "next-themes": "^0.4.6",
+    "openai": "6.35.0",
     "react": "^18",
     "react-dom": "^18",
     "react-hook-form": "^7.72.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -41,6 +41,9 @@ importers:
       next-themes:
         specifier: ^0.4.6
         version: 0.4.6(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      openai:
+        specifier: 6.35.0
+        version: 6.35.0(ws@8.20.0)(zod@4.3.6)
       react:
         specifier: ^18
         version: 18.3.1
@@ -1934,6 +1937,18 @@ packages:
   open@11.0.0:
     resolution: {integrity: sha512-smsWv2LzFjP03xmvFoJ331ss6h+jixfA4UUV/Bsiyuu4YJPfN+FIQGOIiv4w9/+MoHkfkJ22UIaQWRVFRfH6Vw==}
     engines: {node: '>=20'}
+
+  openai@6.35.0:
+    resolution: {integrity: sha512-L/skwIGnt5xQZHb0UfTu9uAUKbis3ehKypOuJKi20QvG7UStV6C8IC3myGYHcdiF4kms/bAvOJ9UqqNWqi8x/Q==}
+    hasBin: true
+    peerDependencies:
+      ws: ^8.18.0
+      zod: ^3.25 || ^4.0
+    peerDependenciesMeta:
+      ws:
+        optional: true
+      zod:
+        optional: true
 
   ora@8.2.0:
     resolution: {integrity: sha512-weP+BZ8MVNnlCm8c0Qdc1WSWq4Qn7I+9CJGm7Qali6g44e/PUzbjNqJX5NJ9ljlNMosfJvg1fKEGILklK9cwnw==}
@@ -4369,6 +4384,11 @@ snapshots:
       is-inside-container: 1.0.0
       powershell-utils: 0.1.0
       wsl-utils: 0.3.1
+
+  openai@6.35.0(ws@8.20.0)(zod@4.3.6):
+    optionalDependencies:
+      ws: 8.20.0
+      zod: 4.3.6
 
   ora@8.2.0:
     dependencies:


### PR DESCRIPTION
## Summary
- Install `openai` SDK (pinned to `6.35.0`)
- Add `lib/ai/openai.ts` — typed client factory + hard-coded `EMBEDDING_MODEL = "text-embedding-3-small"` constant (per `CLAUDE.md`)
- Add `lib/rag/embed.ts` — `embedText(text): Promise<number[]>` returning the 1536-dim vector (strips the SDK's response wrapper so downstream code under `lib/rag/` doesn't depend on OpenAI's internal types)
- Vitest tests:
  - Factory: model constant, `OpenAI` instance, `embeddings` namespace exposed (runs under `node` env because the SDK refuses to instantiate under jsdom)
  - `embedText`: call shape (model + input), return shape (`number[]`, length 1536), error propagation

## Pre-existing scaffolding (no work needed)
- `OPENAI_API_KEY` was already documented in `.env.example` and `docs/env-vars.md` (Epic 1)
- `lib/env.ts` already validates and exports `env.openaiApiKey` (Epic 1)
- `vitest.setup.ts` already stubs the env var so tests load `lib/env.ts` cleanly (#18)

## Drive-by
- Includes `docs/epics/epic4-rag-knowledge-base-tickets.md` — the ticket-breakdown doc that's been sitting untracked since the Epic 4 brainstorming session. Same pattern as Epic 3 #17 folding the breakdown into the first ticket's PR.

## Test plan
- [x] `pnpm test` — 183/183 across 18 files (was 177 — +6 net: 3 factory + 3 embedText)
- [x] `pnpm biome check .` — clean
- [x] `pnpm exec tsc --noEmit` — clean
- [x] `pnpm build` — succeeds

Closes #42. Unblocks the rest of Epic 4 (knowledge chunks insert helper #44, retrieval helper #45, RAG agent #46).

🤖 Generated with [Claude Code](https://claude.com/claude-code)