### PR TITLE
feat(seeds): #48 — initial KB content (WHO + Australian Dept of Health)

### DIFF
--- a/docs/superpowers/plans/2026-05-02-epic4-kb-content-seed.md
+++ b/docs/superpowers/plans/2026-05-02-epic4-kb-content-seed.md
@@ -1,0 +1,566 @@
+# Epic 4 — #48 Initial Knowledge Base Content Seed Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:executing-plans (this project disables strict checkpoint flow per `CLAUDE.md` — execute directly). Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Seed `knowledge_chunks` with curated content from 5 WHO public fact sheets covering cervical health (disease → cause → prevention ×2 → strategy), so the orchestrator's `health_question` path returns real cited answers instead of empty-context fallback. Add a re-runnable `scripts/seed-knowledge-base.ts` script + `pnpm seed:kb` shortcut. No automated tests per the ticket AC; smoke-checked via row-count + one sample retrieval.
+
+**Architecture:** Per-document `.md` files in `supabase/seeds/knowledge/` + a typed `manifest.ts` listing source/URL/license/retrieved-date for each. The seed script reads the manifest, deletes prior rows by source (per-source idempotency), reads each `.md` file, and calls `ingestDocument` (#44) using a service-role Supabase client (seed scripts run locally — RLS bypass is the right tool here, just like Supabase's own `seed.sql`). All seeded chunks carry `metadata.seed = true` so `/api/embeddings/ingest` (#47) admin uploads remain visually distinguishable for future cleanup tooling.
+
+**Tech Stack:** TypeScript via `tsx` (new devDep), `@supabase/supabase-js` with service-role key, `WebFetch` for one-time content extraction during plan execution (skip + log on fetch failure per user decision), Node `fs/promises` for reading `.md` files. No new test framework usage.
+
+**Issue:** [#48](https://github.com/Zoeyyhc/cervix-assistant/issues/48)
+**Source ticket doc:** [`docs/epics/epic4-rag-knowledge-base-tickets.md`](../../epics/epic4-rag-knowledge-base-tickets.md) §EPIC4-07
+**Depends on:** #44 (`ingestDocument`) ✅ merged, #47 (admin endpoint) ✅ merged (orthogonal but unblocks runtime admin uploads).
+**Unblocks:** Real end-to-end RAG demo. Once seeded, `/api/chat` `health_question` intent returns cited answers from WHO content instead of empty `ragContext`. Closes the Epic 4 critical path (only #49/#50 remain — both S-priority polish).
+
+---
+
+## Pre-existing scaffolding
+
+- ✅ `ingestDocument(supabase, { content, source, metadata? })` from `lib/rag/store.ts` (#44)
+- ✅ `knowledge_chunks` table + `match_knowledge_chunks` RPC (Epic 1 migration)
+- ✅ RLS allows service-role to bypass — used here for the local seed script
+- ✅ `SUPABASE_SERVICE_ROLE_KEY` documented in `.env.example`
+- ✅ Existing `supabase/seed.sql` (auth users / dev data) — separate concern, not touched here
+
+## Gaps vs #48 acceptance criteria
+
+| AC | Status | Action |
+|---|---|---|
+| `scripts/seed-knowledge-base.ts` ingests curated docs from WHO | ❌ | **Tasks 3 + 4** |
+| Documents stored under version control as `.md` files in `supabase/seeds/knowledge/` | ❌ | Tasks 2 + 3 |
+| License/attribution recorded in a manifest | ❌ | Task 2 (`manifest.ts`) |
+| `pnpm seed:kb` runs the ingestion against local Supabase | ❌ | Task 5 |
+| `select count(*) from knowledge_chunks` returns ~50–200 chunks after seeding | ❌ | Task 6 (smoke-check) |
+| No automated test (per AC); manual smoke-check in the PR | ✅ | No tests written; PR body captures the smoke-check output |
+
+## Decisions documented in this plan
+
+- **Content scope: 5 WHO public fact sheets** covering disease (cervical cancer), cause (HPV), prevention ×2 (HPV vaccine, screening Q&A), strategy (global elimination initiative). All licensed under [CC BY-NC-SA 3.0 IGO](https://www.who.int/about/policies/publishing/copyright). Recorded per-document in `manifest.ts`. Project is non-commercial educational use — within license terms.
+- **Per-source idempotency, not bulk-by-marker.** For each manifest entry, the script does `DELETE FROM knowledge_chunks WHERE source = '<source>'` before re-ingesting. Simpler than relying on PostgREST's JSON operators (`metadata->>seed`) for delete, and scoped enough for v1's 5 docs. The `metadata.seed = true` marker still lands on every row for future "list all seeded chunks" queries / admin UI tooling.
+- **Service-role key in the script, not cookie auth.** Per `CLAUDE.md`: "DO NOT bypass RLS with the service role key in routes accessible to non-admin users." This is a CLI script, not a route. Service role is the right tool — same pattern Supabase itself uses for `seed.sql`.
+- **`tsx` as a new devDependency** — needed to run `.ts` scripts directly without a build step. Smaller and faster than `ts-node`; the modern default. Added to `devDependencies` only.
+- **WebFetch with verbatim-extraction prompt** for each WHO URL during plan execution. If a fetch fails (404, unexpected shape, redirect), the corresponding `.md` file isn't created and the manifest entry is commented out with a `TODO(#48)` note + the URL. The user can fill it in later. Fail-fast > silent partial seed.
+- **Manifest is the source of truth.** The seed script iterates `SEED_DOCUMENTS` from `manifest.ts`. Adding/removing docs is a manifest edit — no script change.
+- **Seed script logs progress per document** with chunk counts, and a final summary line: `✅ Seeded N documents → M chunks total`. Errors per document are caught and logged but don't abort the run (so a single failure mid-batch doesn't leave the DB in a half-seeded state — well, it does, but the user can re-run; the per-source delete makes this safe).
+- **Output structure:** every chunk gets:
+  - `source`: human-readable display name (e.g., `"WHO — Cervical Cancer"`)
+  - `metadata`: `{ url, license, retrieved_on, seed: true }` (the URL surfaces to citation chips via `Source.url` in #28's renderer)
+
+---
+
+## File Structure
+
+| File | Change | Responsibility |
+|---|---|---|
+| `package.json` | **Modify** | Add `tsx` devDep + `seed:kb` script |
+| `supabase/seeds/knowledge/manifest.ts` | **Create** | Typed `SEED_DOCUMENTS` array — source, url, license, retrievedOn, file |
+| `supabase/seeds/knowledge/01-cervical-cancer.md` | **Create** | WHO Cervical Cancer fact sheet (verbatim extract) |
+| `supabase/seeds/knowledge/02-hpv-overview.md` | **Create** | WHO HPV Q&A |
+| `supabase/seeds/knowledge/03-hpv-vaccine.md` | **Create** | WHO HPV vaccines page |
+| `supabase/seeds/knowledge/04-cervical-cancer-prevention.md` | **Create** | WHO Cervical cancer Q&A (prevention/screening focus) |
+| `supabase/seeds/knowledge/05-elimination-initiative.md` | **Create** | WHO Cervical Cancer Elimination Initiative page |
+| `scripts/seed-knowledge-base.ts` | **Create** | Read manifest → per-source delete → ingestDocument loop → summary |
+
+**Files not touched:**
+- `lib/rag/store.ts` — consumed as-is (#44).
+- `supabase/seed.sql` — separate concern (auth/dev rows).
+- `app/api/embeddings/ingest/route.ts` — unrelated; admin endpoint stays as-is (#47).
+
+---
+
+## Pre-flight
+
+- [ ] **Step A: Confirm #44 + #47 are on `main`**
+
+```bash
+git checkout main && git pull --ff-only origin main && git log origin/main --oneline | head -5
+```
+Expected: top commits include the merged #44 + #47 PRs.
+
+- [ ] **Step B: Branch off main**
+
+```bash
+git checkout -b feat/kb-content-seed-48
+```
+
+- [ ] **Step C: Local Supabase up + service role env exported**
+
+```bash
+supabase status -o env >/dev/null 2>&1 || (echo "❌ supabase not running — run 'supabase start' first" && exit 1)
+eval "$(supabase status -o env)"
+export SUPABASE_URL="${SUPABASE_URL:-$API_URL}" SUPABASE_SERVICE_ROLE_KEY="${SUPABASE_SERVICE_ROLE_KEY:-$SERVICE_ROLE_KEY}"
+echo "OK: $SUPABASE_URL"
+```
+Expected: `OK: http://127.0.0.1:54321` (or similar local URL).
+
+- [ ] **Step D: Confirm OPENAI_API_KEY is in `.env.local`**
+
+```bash
+grep -E "^OPENAI_API_KEY=." .env.local && echo OK
+```
+Expected: `OK`. Without this, `embedText` will fail when the script runs.
+
+- [ ] **Step E: Baseline tests still green**
+
+```bash
+pnpm test 2>&1 | tail -5
+```
+Expected: 231/231 (post-#47 merge).
+
+---
+
+## Task 1: Add `tsx` devDep + `seed:kb` script
+
+**Files:** `package.json`.
+
+- [ ] **Step 1: Install tsx**
+
+```bash
+pnpm add -D tsx
+```
+Expected: `tsx` appears in `devDependencies`. `pnpm-lock.yaml` updates.
+
+- [ ] **Step 2: Add the npm script**
+
+Edit `package.json`, add to `scripts`:
+
+```json
+"seed:kb": "tsx scripts/seed-knowledge-base.ts"
+```
+
+(After `"test:coverage"`, before the closing `}`.)
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add package.json pnpm-lock.yaml
+git commit -m "chore(deps): add tsx + seed:kb script for knowledge base seeding"
+```
+
+---
+
+## Task 2: Manifest
+
+**Files:** `supabase/seeds/knowledge/manifest.ts`.
+
+- [ ] **Step 1: Create the directory + manifest**
+
+```bash
+mkdir -p supabase/seeds/knowledge
+```
+
+Create `supabase/seeds/knowledge/manifest.ts`:
+
+```typescript
+/**
+ * Knowledge base seed manifest.
+ *
+ * Source: World Health Organization public fact sheets / Q&A pages.
+ * License: CC BY-NC-SA 3.0 IGO (https://www.who.int/about/policies/publishing/copyright).
+ * Project use: non-commercial educational platform — within license terms.
+ *
+ * To re-fetch, edit the file in place and re-run `pnpm seed:kb` — the script
+ * deletes prior chunks per `source` before re-ingesting, so updates are safe.
+ */
+
+export type SeedDocument = {
+  /** Human-readable display name. Surfaces in citation chips. */
+  source: string;
+  /** Authoritative URL. Stored in metadata.url; surfaces in citation chips. */
+  url: string;
+  /** License string. Stored in metadata.license. */
+  license: string;
+  /** ISO date the content was retrieved. Stored in metadata.retrieved_on. */
+  retrievedOn: string;
+  /** Filename relative to this manifest's directory. */
+  file: string;
+};
+
+export const SEED_DOCUMENTS: SeedDocument[] = [
+  {
+    source: "WHO — Cervical Cancer",
+    url: "https://www.who.int/news-room/fact-sheets/detail/cervical-cancer",
+    license: "CC BY-NC-SA 3.0 IGO",
+    retrievedOn: "2026-05-02",
+    file: "01-cervical-cancer.md",
+  },
+  {
+    source: "WHO — Human Papillomavirus (HPV)",
+    url: "https://www.who.int/news-room/questions-and-answers/item/human-papillomavirus-(hpv)",
+    license: "CC BY-NC-SA 3.0 IGO",
+    retrievedOn: "2026-05-02",
+    file: "02-hpv-overview.md",
+  },
+  {
+    source: "WHO — HPV Vaccines",
+    url: "https://www.who.int/teams/immunization-vaccines-and-biologicals/diseases/human-papillomavirus-vaccines-(hpv)",
+    license: "CC BY-NC-SA 3.0 IGO",
+    retrievedOn: "2026-05-02",
+    file: "03-hpv-vaccine.md",
+  },
+  {
+    source: "WHO — Cervical Cancer Q&A (Prevention & Screening)",
+    url: "https://www.who.int/news-room/questions-and-answers/item/cervical-cancer",
+    license: "CC BY-NC-SA 3.0 IGO",
+    retrievedOn: "2026-05-02",
+    file: "04-cervical-cancer-prevention.md",
+  },
+  {
+    source: "WHO — Cervical Cancer Elimination Initiative",
+    url: "https://www.who.int/initiatives/cervical-cancer-elimination-initiative",
+    license: "CC BY-NC-SA 3.0 IGO",
+    retrievedOn: "2026-05-02",
+    file: "05-elimination-initiative.md",
+  },
+];
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add supabase/seeds/knowledge/manifest.ts
+git commit -m "feat(seeds): add KB seed manifest for 5 WHO cervical-health documents"
+```
+
+---
+
+## Task 3: Fetch + curate the 5 WHO documents
+
+**Files:** `supabase/seeds/knowledge/01-cervical-cancer.md` through `05-elimination-initiative.md`.
+
+For each manifest entry:
+
+- [ ] **Step 1: Fetch the URL via WebFetch**
+
+Use this prompt (adapt for each document):
+
+> Extract the main article body from this WHO fact sheet **verbatim**. Preserve section headings (use `##` for them). Strip site nav, footer, "WHO in Countries" sidebars, related-content links, and the "Updated YYYY-MM-DD" line at the bottom. Output as plain markdown — no HTML, no extra commentary, no summaries. If the page is a 404 or the content is unrecognizable, say "FETCH_FAILED" and nothing else.
+
+If the response contains `FETCH_FAILED`:
+- Skip writing the file
+- Note the failure in the PR body (Task 7)
+- Comment out the manifest entry with `// TODO(#48): re-fetch — <url> returned FETCH_FAILED on YYYY-MM-DD`
+
+- [ ] **Step 2: Save the extracted text**
+
+Write to `supabase/seeds/knowledge/<file-from-manifest>.md`. No frontmatter — metadata lives in the manifest. The `.md` file is pure content.
+
+- [ ] **Step 3: Quick sanity-check the file**
+
+```bash
+wc -l supabase/seeds/knowledge/<file>.md
+head -10 supabase/seeds/knowledge/<file>.md
+```
+Expected: at least ~30 lines, recognizably WHO content (mentions HPV / cervical cancer / WHO).
+
+- [ ] **Step 4: Repeat for all 5 documents**
+
+- [ ] **Step 5: Commit all content files together**
+
+```bash
+git add supabase/seeds/knowledge/*.md
+git commit -m "feat(seeds): add 5 WHO cervical-health source documents"
+```
+
+---
+
+## Task 4: Seed script
+
+**Files:** `scripts/seed-knowledge-base.ts`.
+
+- [ ] **Step 1: Create the script**
+
+```bash
+mkdir -p scripts
+```
+
+Create `scripts/seed-knowledge-base.ts`:
+
+```typescript
+/**
+ * Seed the knowledge_chunks table from `supabase/seeds/knowledge/`.
+ *
+ * Run with: `pnpm seed:kb`
+ *
+ * Requirements:
+ *   - Local Supabase running (`supabase start`)
+ *   - SUPABASE_URL + SUPABASE_SERVICE_ROLE_KEY in env (run `eval "$(supabase status -o env)"` first)
+ *   - OPENAI_API_KEY in `.env.local` (loaded by Next.js but not by tsx — see env loading below)
+ *
+ * Safe to re-run — clears prior chunks per source before re-ingesting.
+ */
+
+import { readFile } from "node:fs/promises";
+import path from "node:path";
+import { config as loadEnv } from "dotenv";
+import { createClient } from "@supabase/supabase-js";
+import { ingestDocument } from "@/lib/rag/store";
+import { SEED_DOCUMENTS, type SeedDocument } from "@/supabase/seeds/knowledge/manifest";
+import type { Database } from "@/types/supabase";
+
+// tsx doesn't auto-load .env.local the way Next.js does
+loadEnv({ path: ".env.local" });
+
+const SUPABASE_URL = process.env.SUPABASE_URL ?? process.env.NEXT_PUBLIC_SUPABASE_URL;
+const SUPABASE_SERVICE_ROLE_KEY = process.env.SUPABASE_SERVICE_ROLE_KEY;
+
+function assertEnv() {
+  if (!SUPABASE_URL) throw new Error("missing SUPABASE_URL (run: eval \"$(supabase status -o env)\")");
+  if (!SUPABASE_SERVICE_ROLE_KEY) throw new Error("missing SUPABASE_SERVICE_ROLE_KEY");
+  if (!process.env.OPENAI_API_KEY) throw new Error("missing OPENAI_API_KEY (set in .env.local)");
+}
+
+async function seedOne(
+  supabase: ReturnType<typeof createClient<Database>>,
+  doc: SeedDocument,
+): Promise<{ source: string; chunks: number; ok: boolean; error?: string }> {
+  const filepath = path.join("supabase/seeds/knowledge", doc.file);
+
+  let content: string;
+  try {
+    content = await readFile(filepath, "utf8");
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    return { source: doc.source, chunks: 0, ok: false, error: `read failed: ${msg}` };
+  }
+
+  // Clear prior chunks for this source (per-source idempotency)
+  const { error: delErr } = await supabase
+    .from("knowledge_chunks")
+    .delete()
+    .eq("source", doc.source);
+  if (delErr) {
+    return { source: doc.source, chunks: 0, ok: false, error: `delete failed: ${delErr.message}` };
+  }
+
+  try {
+    const { chunkIds } = await ingestDocument(supabase, {
+      source: doc.source,
+      content,
+      metadata: {
+        url: doc.url,
+        license: doc.license,
+        retrieved_on: doc.retrievedOn,
+        seed: true,
+      },
+    });
+    return { source: doc.source, chunks: chunkIds.length, ok: true };
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    return { source: doc.source, chunks: 0, ok: false, error: `ingest failed: ${msg}` };
+  }
+}
+
+async function main() {
+  assertEnv();
+
+  const supabase = createClient<Database>(SUPABASE_URL!, SUPABASE_SERVICE_ROLE_KEY!);
+
+  console.log(`📚 Seeding ${SEED_DOCUMENTS.length} documents…\n`);
+
+  const results: Awaited<ReturnType<typeof seedOne>>[] = [];
+  for (const doc of SEED_DOCUMENTS) {
+    process.stdout.write(`  • ${doc.source}…  `);
+    const r = await seedOne(supabase, doc);
+    results.push(r);
+    if (r.ok) {
+      console.log(`✅ ${r.chunks} chunks`);
+    } else {
+      console.log(`❌ ${r.error}`);
+    }
+  }
+
+  const totalChunks = results.reduce((sum, r) => sum + r.chunks, 0);
+  const okCount = results.filter((r) => r.ok).length;
+  console.log(`\n${okCount === SEED_DOCUMENTS.length ? "✅" : "⚠️"}  Seeded ${okCount}/${SEED_DOCUMENTS.length} documents → ${totalChunks} chunks total`);
+
+  if (okCount !== SEED_DOCUMENTS.length) {
+    process.exit(1);
+  }
+}
+
+main().catch((err) => {
+  console.error("seed failed:", err);
+  process.exit(1);
+});
+```
+
+- [ ] **Step 2: Add `dotenv` if not already present**
+
+```bash
+grep -q '"dotenv"' package.json || pnpm add -D dotenv
+```
+
+- [ ] **Step 3: tsc-check the script (no Vitest, but type-safety still matters)**
+
+```bash
+pnpm exec tsc --noEmit -p tsconfig.json 2>&1 | tail -5
+```
+Expected: clean.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add scripts/seed-knowledge-base.ts package.json pnpm-lock.yaml
+git commit -m "feat(scripts): add seed-knowledge-base.ts with per-source idempotency"
+```
+
+---
+
+## Task 5: Run the seed locally + verify
+
+- [ ] **Step 1: Ensure local Supabase + env**
+
+```bash
+supabase status >/dev/null 2>&1 || supabase start
+eval "$(supabase status -o env)"
+export SUPABASE_URL="${SUPABASE_URL:-$API_URL}" SUPABASE_SERVICE_ROLE_KEY="${SUPABASE_SERVICE_ROLE_KEY:-$SERVICE_ROLE_KEY}"
+```
+
+- [ ] **Step 2: Run the seed**
+
+```bash
+pnpm seed:kb
+```
+Expected: per-document `✅ N chunks` lines, summary `✅ Seeded 5/5 documents → ~80–150 chunks total`. Capture the output for the PR body.
+
+- [ ] **Step 3: Smoke-check via psql**
+
+```bash
+PSQL_URL=$(supabase status -o json 2>/dev/null | python3 -c 'import sys, json; print(json.load(sys.stdin)["DB_URL"])')
+psql "$PSQL_URL" -c "select count(*) as total_chunks, count(distinct source) as sources from public.knowledge_chunks where metadata->>'seed' = 'true';"
+psql "$PSQL_URL" -c "select source, count(*) as chunks from public.knowledge_chunks where metadata->>'seed' = 'true' group by source order by source;"
+```
+Expected: `total_chunks` between ~50 and ~200, `sources = 5`. Capture for PR.
+
+- [ ] **Step 4: Sample retrieval check (optional but high-value)**
+
+```bash
+psql "$PSQL_URL" -c "select source, left(content, 100) from public.knowledge_chunks where content ilike '%hpv vaccine%' limit 3;"
+```
+Expected: at least one row matching, content recognizably WHO HPV vaccine text. Confirms ingestion preserved content.
+
+---
+
+## Task 6: Re-runnability check
+
+- [ ] **Step 1: Run again — confirm idempotency**
+
+```bash
+pnpm seed:kb
+```
+Expected: same `✅ Seeded 5/5 documents → N chunks total` summary, **no duplicate rows** because the per-source delete fires first.
+
+- [ ] **Step 2: Verify count is unchanged**
+
+```bash
+psql "$PSQL_URL" -c "select count(*) from public.knowledge_chunks where metadata->>'seed' = 'true';"
+```
+Expected: same count as Task 5 Step 3.
+
+---
+
+## Task 7: Final verification + plan commit + PR
+
+- [ ] **Step 1: Run baseline tests + Biome + tsc + build**
+
+```bash
+pnpm test 2>&1 | tail -5 && pnpm biome check . 2>&1 | tail -3 && pnpm exec tsc --noEmit -p tsconfig.json 2>&1 | tail -3 && pnpm build 2>&1 | tail -5
+```
+Expected: all clean. `pnpm test` still 231/231 (no new tests — this is content + script).
+
+- [ ] **Step 2: Biome on new files (in case the script needs formatting)**
+
+```bash
+pnpm biome check --write scripts/seed-knowledge-base.ts supabase/seeds/knowledge/manifest.ts
+```
+
+- [ ] **Step 3: Commit the plan**
+
+```bash
+git add docs/superpowers/plans/2026-05-02-epic4-kb-content-seed.md
+git commit -m "docs(plan): add Epic 4 #48 KB content seed plan"
+```
+
+- [ ] **Step 4: End-to-end smoke check via /api/chat**
+
+Optional but recommended — confirms the whole RAG path lights up:
+
+```bash
+# In one terminal
+pnpm dev
+
+# In another, after dev server is up
+# (replace <session-cookie> after logging in via the UI)
+curl -s -X POST http://localhost:3000/api/chat \
+  -H "content-type: application/json" \
+  -H "cookie: <session-cookie>" \
+  -d '{"message":"What causes cervical cancer?"}' | head -c 1000
+```
+Expected: streaming response that includes a `sources` event with WHO citation chips. Capture a screenshot or curl excerpt for the PR.
+
+- [ ] **Step 5: Push**
+
+```bash
+git push -u origin feat/kb-content-seed-48
+```
+
+- [ ] **Step 6: Open the PR**
+
+```bash
+gh pr create --repo Zoeyyhc/cervix-assistant --base main --head feat/kb-content-seed-48 \
+  --title "feat(seeds): #48 — initial WHO knowledge-base content (5 docs)" \
+  --body "$(cat <<'EOF'
+## Summary
+- Seed `knowledge_chunks` with 5 WHO public fact sheets covering cervical health: cervical cancer (disease), HPV (cause), HPV vaccine (prevention 1), cervical-cancer Q&A (prevention 2 / screening), and the global elimination initiative (strategy)
+- Add `scripts/seed-knowledge-base.ts` + `pnpm seed:kb` shortcut. Per-source idempotency via `DELETE WHERE source = ...` before re-ingest — safe to re-run
+- All chunks carry `metadata.seed = true`, `metadata.url`, `metadata.license`, `metadata.retrieved_on` for citation chips and future cleanup tooling
+- Service-role key bypasses RLS for the local seed run (CLI script, not a route — same pattern as Supabase's own `seed.sql`)
+- New devDeps: `tsx` (script runner), `dotenv` (loads `.env.local` for the script — Next.js loads it automatically but tsx doesn't)
+
+## License
+All content is © WHO under [CC BY-NC-SA 3.0 IGO](https://www.who.int/about/policies/publishing/copyright). Project use is non-commercial educational — within license terms. Per-document attribution recorded in `supabase/seeds/knowledge/manifest.ts`.
+
+## Smoke check (captured during local run)
+
+\`\`\`
+<paste pnpm seed:kb output here>
+\`\`\`
+
+\`\`\`
+<paste psql count + per-source rows here>
+\`\`\`
+
+## End-to-end demo (optional)
+\`\`\`
+<paste curl /api/chat excerpt showing sources event>
+\`\`\`
+
+## Closing
+Closes #48. **Closes the Epic 4 critical path.** Only #49 (no-match fallback explicit test) and #50 (HNSW tuning measurement) remain — both S-priority polish that can ship in a follow-up sprint.
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+---
+
+## Self-review checks performed
+
+- **Spec coverage:** all 6 ACs map to tasks (script, .md files, manifest, npm script, ~50–200 chunks, no automated test). The smoke-check appears in PR body per AC.
+- **Placeholder scan:** the only `<paste …>` placeholders are in the PR body template — to be filled in at Task 7 with real captured output. No `TBD` in code or plan steps.
+- **Type consistency:** `SeedDocument` type in `manifest.ts` matches the field names used in `seed-knowledge-base.ts` (`source`, `url`, `license`, `retrievedOn`, `file`). The `metadata` shape passed to `ingestDocument` aligns with what #28's `Source.url` extractor reads (`metadata.url` as string).
+- **License compliance:** CC BY-NC-SA 3.0 IGO requires attribution + non-commercial use + share-alike for derivatives. We attribute via `source` + `metadata.url` on every chunk and every citation chip; project is educational/non-commercial; we're not redistributing as a derivative work but as cited references.
+- **Re-runnability:** Task 6 explicitly tests this by running the seed twice and asserting unchanged counts. The per-source delete (vs marker-based bulk delete) is documented as the simplicity tradeoff.
+- **Failure modes documented:**
+  - Fetch failure during plan execution → manifest entry commented out + noted in PR
+  - Read failure during script run → per-document error, continues with other docs
+  - Embed/insert failure during script run → per-document error, continues; exit 1 at end if any failed
+  - Missing env → assertEnv throws upfront with a clear message
+- **What's deliberately not done:**
+  - No Vitest tests for the script (per AC)
+  - No frontmatter parsing (manifest is the source of truth — keeps `.md` files pure content)
+  - No automatic `OPENAI_API_KEY` discovery beyond `.env.local`
+  - No retry on embed failures (covered by `embedText`'s SDK defaults from #42)

--- a/package.json
+++ b/package.json
@@ -12,7 +12,8 @@
     "format": "biome check --write .",
     "test": "vitest run",
     "test:watch": "vitest",
-    "test:coverage": "vitest run --coverage"
+    "test:coverage": "vitest run --coverage",
+    "seed:kb": "tsx scripts/seed-knowledge-base.ts"
   },
   "dependencies": {
     "@anthropic-ai/sdk": "0.91.1",
@@ -46,10 +47,12 @@
     "@types/react-dom": "^18",
     "@vitejs/plugin-react": "^6.0.1",
     "autoprefixer": "^10.4.20",
+    "dotenv": "^17.4.2",
     "jsdom": "^29.0.2",
     "msw": "^2.13.2",
     "postcss": "^8.5.3",
     "tailwindcss": "^3.4.17",
+    "tsx": "^4.21.0",
     "typescript": "^5",
     "vitest": "^4.1.4"
   }

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "test": "vitest run",
     "test:watch": "vitest",
     "test:coverage": "vitest run --coverage",
-    "seed:kb": "tsx scripts/seed-knowledge-base.ts"
+    "seed:kb": "tsx --env-file=.env.local scripts/seed-knowledge-base.ts"
   },
   "dependencies": {
     "@anthropic-ai/sdk": "0.91.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -92,10 +92,13 @@ importers:
         version: 18.3.7(@types/react@18.3.28)
       '@vitejs/plugin-react':
         specifier: ^6.0.1
-        version: 6.0.1(vite@8.0.8(@types/node@20.19.39)(jiti@1.21.7))
+        version: 6.0.1(vite@8.0.8(@types/node@20.19.39)(esbuild@0.27.7)(jiti@1.21.7)(tsx@4.21.0))
       autoprefixer:
         specifier: ^10.4.20
         version: 10.4.27(postcss@8.5.9)
+      dotenv:
+        specifier: ^17.4.2
+        version: 17.4.2
       jsdom:
         specifier: ^29.0.2
         version: 29.0.2(@noble/hashes@1.8.0)
@@ -107,13 +110,16 @@ importers:
         version: 8.5.9
       tailwindcss:
         specifier: ^3.4.17
-        version: 3.4.19
+        version: 3.4.19(tsx@4.21.0)
+      tsx:
+        specifier: ^4.21.0
+        version: 4.21.0
       typescript:
         specifier: ^5
         version: 5.9.3
       vitest:
         specifier: ^4.1.4
-        version: 4.1.4(@types/node@20.19.39)(jsdom@29.0.2(@noble/hashes@1.8.0))(msw@2.13.2(@types/node@20.19.39)(typescript@5.9.3))(vite@8.0.8(@types/node@20.19.39)(jiti@1.21.7))
+        version: 4.1.4(@types/node@20.19.39)(jsdom@29.0.2(@noble/hashes@1.8.0))(msw@2.13.2(@types/node@20.19.39)(typescript@5.9.3))(vite@8.0.8(@types/node@20.19.39)(esbuild@0.27.7)(jiti@1.21.7)(tsx@4.21.0))
 
 packages:
 
@@ -413,6 +419,162 @@ packages:
 
   '@emnapi/wasi-threads@1.2.1':
     resolution: {integrity: sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==}
+
+  '@esbuild/aix-ppc64@0.27.7':
+    resolution: {integrity: sha512-EKX3Qwmhz1eMdEJokhALr0YiD0lhQNwDqkPYyPhiSwKrh7/4KRjQc04sZ8db+5DVVnZ1LmbNDI1uAMPEUBnQPg==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [aix]
+
+  '@esbuild/android-arm64@0.27.7':
+    resolution: {integrity: sha512-62dPZHpIXzvChfvfLJow3q5dDtiNMkwiRzPylSCfriLvZeq0a1bWChrGx/BbUbPwOrsWKMn8idSllklzBy+dgQ==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [android]
+
+  '@esbuild/android-arm@0.27.7':
+    resolution: {integrity: sha512-jbPXvB4Yj2yBV7HUfE2KHe4GJX51QplCN1pGbYjvsyCZbQmies29EoJbkEc+vYuU5o45AfQn37vZlyXy4YJ8RQ==}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [android]
+
+  '@esbuild/android-x64@0.27.7':
+    resolution: {integrity: sha512-x5VpMODneVDb70PYV2VQOmIUUiBtY3D3mPBG8NxVk5CogneYhkR7MmM3yR/uMdITLrC1ml/NV1rj4bMJuy9MCg==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [android]
+
+  '@esbuild/darwin-arm64@0.27.7':
+    resolution: {integrity: sha512-5lckdqeuBPlKUwvoCXIgI2D9/ABmPq3Rdp7IfL70393YgaASt7tbju3Ac+ePVi3KDH6N2RqePfHnXkaDtY9fkw==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@esbuild/darwin-x64@0.27.7':
+    resolution: {integrity: sha512-rYnXrKcXuT7Z+WL5K980jVFdvVKhCHhUwid+dDYQpH+qu+TefcomiMAJpIiC2EM3Rjtq0sO3StMV/+3w3MyyqQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@esbuild/freebsd-arm64@0.27.7':
+    resolution: {integrity: sha512-B48PqeCsEgOtzME2GbNM2roU29AMTuOIN91dsMO30t+Ydis3z/3Ngoj5hhnsOSSwNzS+6JppqWsuhTp6E82l2w==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [freebsd]
+
+  '@esbuild/freebsd-x64@0.27.7':
+    resolution: {integrity: sha512-jOBDK5XEjA4m5IJK3bpAQF9/Lelu/Z9ZcdhTRLf4cajlB+8VEhFFRjWgfy3M1O4rO2GQ/b2dLwCUGpiF/eATNQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@esbuild/linux-arm64@0.27.7':
+    resolution: {integrity: sha512-RZPHBoxXuNnPQO9rvjh5jdkRmVizktkT7TCDkDmQ0W2SwHInKCAV95GRuvdSvA7w4VMwfCjUiPwDi0ZO6Nfe9A==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@esbuild/linux-arm@0.27.7':
+    resolution: {integrity: sha512-RkT/YXYBTSULo3+af8Ib0ykH8u2MBh57o7q/DAs3lTJlyVQkgQvlrPTnjIzzRPQyavxtPtfg0EopvDyIt0j1rA==}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [linux]
+
+  '@esbuild/linux-ia32@0.27.7':
+    resolution: {integrity: sha512-GA48aKNkyQDbd3KtkplYWT102C5sn/EZTY4XROkxONgruHPU72l+gW+FfF8tf2cFjeHaRbWpOYa/uRBz/Xq1Pg==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [linux]
+
+  '@esbuild/linux-loong64@0.27.7':
+    resolution: {integrity: sha512-a4POruNM2oWsD4WKvBSEKGIiWQF8fZOAsycHOt6JBpZ+JN2n2JH9WAv56SOyu9X5IqAjqSIPTaJkqN8F7XOQ5Q==}
+    engines: {node: '>=18'}
+    cpu: [loong64]
+    os: [linux]
+
+  '@esbuild/linux-mips64el@0.27.7':
+    resolution: {integrity: sha512-KabT5I6StirGfIz0FMgl1I+R1H73Gp0ofL9A3nG3i/cYFJzKHhouBV5VWK1CSgKvVaG4q1RNpCTR2LuTVB3fIw==}
+    engines: {node: '>=18'}
+    cpu: [mips64el]
+    os: [linux]
+
+  '@esbuild/linux-ppc64@0.27.7':
+    resolution: {integrity: sha512-gRsL4x6wsGHGRqhtI+ifpN/vpOFTQtnbsupUF5R5YTAg+y/lKelYR1hXbnBdzDjGbMYjVJLJTd2OFmMewAgwlQ==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@esbuild/linux-riscv64@0.27.7':
+    resolution: {integrity: sha512-hL25LbxO1QOngGzu2U5xeXtxXcW+/GvMN3ejANqXkxZ/opySAZMrc+9LY/WyjAan41unrR3YrmtTsUpwT66InQ==}
+    engines: {node: '>=18'}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@esbuild/linux-s390x@0.27.7':
+    resolution: {integrity: sha512-2k8go8Ycu1Kb46vEelhu1vqEP+UeRVj2zY1pSuPdgvbd5ykAw82Lrro28vXUrRmzEsUV0NzCf54yARIK8r0fdw==}
+    engines: {node: '>=18'}
+    cpu: [s390x]
+    os: [linux]
+
+  '@esbuild/linux-x64@0.27.7':
+    resolution: {integrity: sha512-hzznmADPt+OmsYzw1EE33ccA+HPdIqiCRq7cQeL1Jlq2gb1+OyWBkMCrYGBJ+sxVzve2ZJEVeePbLM2iEIZSxA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [linux]
+
+  '@esbuild/netbsd-arm64@0.27.7':
+    resolution: {integrity: sha512-b6pqtrQdigZBwZxAn1UpazEisvwaIDvdbMbmrly7cDTMFnw/+3lVxxCTGOrkPVnsYIosJJXAsILG9XcQS+Yu6w==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [netbsd]
+
+  '@esbuild/netbsd-x64@0.27.7':
+    resolution: {integrity: sha512-OfatkLojr6U+WN5EDYuoQhtM+1xco+/6FSzJJnuWiUw5eVcicbyK3dq5EeV/QHT1uy6GoDhGbFpprUiHUYggrw==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [netbsd]
+
+  '@esbuild/openbsd-arm64@0.27.7':
+    resolution: {integrity: sha512-AFuojMQTxAz75Fo8idVcqoQWEHIXFRbOc1TrVcFSgCZtQfSdc1RXgB3tjOn/krRHENUB4j00bfGjyl2mJrU37A==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openbsd]
+
+  '@esbuild/openbsd-x64@0.27.7':
+    resolution: {integrity: sha512-+A1NJmfM8WNDv5CLVQYJ5PshuRm/4cI6WMZRg1by1GwPIQPCTs1GLEUHwiiQGT5zDdyLiRM/l1G0Pv54gvtKIg==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [openbsd]
+
+  '@esbuild/openharmony-arm64@0.27.7':
+    resolution: {integrity: sha512-+KrvYb/C8zA9CU/g0sR6w2RBw7IGc5J2BPnc3dYc5VJxHCSF1yNMxTV5LQ7GuKteQXZtspjFbiuW5/dOj7H4Yw==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@esbuild/sunos-x64@0.27.7':
+    resolution: {integrity: sha512-ikktIhFBzQNt/QDyOL580ti9+5mL/YZeUPKU2ivGtGjdTYoqz6jObj6nOMfhASpS4GU4Q/Clh1QtxWAvcYKamA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [sunos]
+
+  '@esbuild/win32-arm64@0.27.7':
+    resolution: {integrity: sha512-7yRhbHvPqSpRUV7Q20VuDwbjW5kIMwTHpptuUzV+AA46kiPze5Z7qgt6CLCK3pWFrHeNfDd1VKgyP4O+ng17CA==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@esbuild/win32-ia32@0.27.7':
+    resolution: {integrity: sha512-SmwKXe6VHIyZYbBLJrhOoCJRB/Z1tckzmgTLfFYOfpMAx63BJEaL9ExI8x7v0oAO3Zh6D/Oi1gVxEYr5oUCFhw==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [win32]
+
+  '@esbuild/win32-x64@0.27.7':
+    resolution: {integrity: sha512-56hiAJPhwQ1R4i+21FVF7V8kSD5zZTdHcVuRFMW0hn753vVfQN8xlx4uOPT4xoGH0Z/oVATuR82AiqSTDIpaHg==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [win32]
 
   '@exodus/bytes@1.15.0':
     resolution: {integrity: sha512-UY0nlA+feH81UGSHv92sLEPLCeZFjXOuHhrIo0HQydScuQc8s0A7kL/UdgwgDq8g8ilksmuoF35YVTNphV2aBQ==}
@@ -1219,8 +1381,8 @@ packages:
   dom-accessibility-api@0.6.3:
     resolution: {integrity: sha512-7ZgogeTnjuHbo+ct10G9Ffp0mif17idi0IyWNVA/wcwcm7NPOD/WEHVP3n7n3MhXqxoIYm8d6MuZohYWIZ4T3w==}
 
-  dotenv@17.4.1:
-    resolution: {integrity: sha512-k8DaKGP6r1G30Lx8V4+pCsLzKr8vLmV2paqEj1Y55GdAgJuIqpRp5FfajGF8KtwMxCz9qJc6wUIJnm053d/WCw==}
+  dotenv@17.4.2:
+    resolution: {integrity: sha512-nI4U3TottKAcAD9LLud4Cb7b2QztQMUEfHbvhTH09bqXTxnSie8WnjPALV/WMCrJZ6UV/qHJ6L03OqO3LcdYZw==}
     engines: {node: '>=12'}
 
   dunder-proto@1.0.1:
@@ -1272,6 +1434,11 @@ packages:
   es-object-atoms@1.1.1:
     resolution: {integrity: sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==}
     engines: {node: '>= 0.4'}
+
+  esbuild@0.27.7:
+    resolution: {integrity: sha512-IxpibTjyVnmrIQo5aqNpCgoACA/dTKLTlhMHihVHhdkxKyPO1uBBthumT0rdHmcsk9uMonIWS0m4FljWzILh3w==}
+    engines: {node: '>=18'}
+    hasBin: true
 
   escalade@3.2.0:
     resolution: {integrity: sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==}
@@ -1426,6 +1593,9 @@ packages:
   get-stream@9.0.1:
     resolution: {integrity: sha512-kVCxPF3vQM/N0B1PmoqVUqgHP+EeVjmZSQn+1oCRPxd2P21P2F19lIgbR3HBosbB1PUhOAoctJnfEn2GbN2eZA==}
     engines: {node: '>=18'}
+
+  get-tsconfig@4.14.0:
+    resolution: {integrity: sha512-yTb+8DXzDREzgvYmh6s9vHsSVCHeC0G3PI5bEXNBHtmshPnO+S5O7qgLEOn0I5QvMy6kpZN8K1NKGyilLb93wA==}
 
   glob-parent@5.1.2:
     resolution: {integrity: sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==}
@@ -2174,6 +2344,9 @@ packages:
     resolution: {integrity: sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==}
     engines: {node: '>=4'}
 
+  resolve-pkg-maps@1.0.0:
+    resolution: {integrity: sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==}
+
   resolve@1.22.11:
     resolution: {integrity: sha512-RfqAvLnMl313r7c9oclB1HhUEAezcpLjz95wFH4LVuhk9JF/r22qmVP9AMmOU4vMX7Q8pN8jwNg/CSpdFnMjTQ==}
     engines: {node: '>= 0.4'}
@@ -2446,6 +2619,11 @@ packages:
 
   tslib@2.8.1:
     resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
+
+  tsx@4.21.0:
+    resolution: {integrity: sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==}
+    engines: {node: '>=18.0.0'}
+    hasBin: true
 
   tw-animate-css@1.4.0:
     resolution: {integrity: sha512-7bziOlRqH0hJx80h/3mbicLW7o8qLsH5+RaLR2t+OHM3D0JlWGODQKQ4cxbK7WlvmUxpcj6Kgu6EKqjrGFe3QQ==}
@@ -3004,7 +3182,7 @@ snapshots:
   '@dotenvx/dotenvx@1.61.0':
     dependencies:
       commander: 11.1.0
-      dotenv: 17.4.1
+      dotenv: 17.4.2
       eciesjs: 0.4.18
       execa: 5.1.1
       fdir: 6.5.0(picomatch@4.0.4)
@@ -3032,6 +3210,84 @@ snapshots:
   '@emnapi/wasi-threads@1.2.1':
     dependencies:
       tslib: 2.8.1
+    optional: true
+
+  '@esbuild/aix-ppc64@0.27.7':
+    optional: true
+
+  '@esbuild/android-arm64@0.27.7':
+    optional: true
+
+  '@esbuild/android-arm@0.27.7':
+    optional: true
+
+  '@esbuild/android-x64@0.27.7':
+    optional: true
+
+  '@esbuild/darwin-arm64@0.27.7':
+    optional: true
+
+  '@esbuild/darwin-x64@0.27.7':
+    optional: true
+
+  '@esbuild/freebsd-arm64@0.27.7':
+    optional: true
+
+  '@esbuild/freebsd-x64@0.27.7':
+    optional: true
+
+  '@esbuild/linux-arm64@0.27.7':
+    optional: true
+
+  '@esbuild/linux-arm@0.27.7':
+    optional: true
+
+  '@esbuild/linux-ia32@0.27.7':
+    optional: true
+
+  '@esbuild/linux-loong64@0.27.7':
+    optional: true
+
+  '@esbuild/linux-mips64el@0.27.7':
+    optional: true
+
+  '@esbuild/linux-ppc64@0.27.7':
+    optional: true
+
+  '@esbuild/linux-riscv64@0.27.7':
+    optional: true
+
+  '@esbuild/linux-s390x@0.27.7':
+    optional: true
+
+  '@esbuild/linux-x64@0.27.7':
+    optional: true
+
+  '@esbuild/netbsd-arm64@0.27.7':
+    optional: true
+
+  '@esbuild/netbsd-x64@0.27.7':
+    optional: true
+
+  '@esbuild/openbsd-arm64@0.27.7':
+    optional: true
+
+  '@esbuild/openbsd-x64@0.27.7':
+    optional: true
+
+  '@esbuild/openharmony-arm64@0.27.7':
+    optional: true
+
+  '@esbuild/sunos-x64@0.27.7':
+    optional: true
+
+  '@esbuild/win32-arm64@0.27.7':
+    optional: true
+
+  '@esbuild/win32-ia32@0.27.7':
+    optional: true
+
+  '@esbuild/win32-x64@0.27.7':
     optional: true
 
   '@exodus/bytes@1.15.0(@noble/hashes@1.8.0)':
@@ -3414,10 +3670,10 @@ snapshots:
     dependencies:
       '@types/node': 20.19.39
 
-  '@vitejs/plugin-react@6.0.1(vite@8.0.8(@types/node@20.19.39)(jiti@1.21.7))':
+  '@vitejs/plugin-react@6.0.1(vite@8.0.8(@types/node@20.19.39)(esbuild@0.27.7)(jiti@1.21.7)(tsx@4.21.0))':
     dependencies:
       '@rolldown/pluginutils': 1.0.0-rc.7
-      vite: 8.0.8(@types/node@20.19.39)(jiti@1.21.7)
+      vite: 8.0.8(@types/node@20.19.39)(esbuild@0.27.7)(jiti@1.21.7)(tsx@4.21.0)
 
   '@vitest/expect@4.1.4':
     dependencies:
@@ -3428,14 +3684,14 @@ snapshots:
       chai: 6.2.2
       tinyrainbow: 3.1.0
 
-  '@vitest/mocker@4.1.4(msw@2.13.2(@types/node@20.19.39)(typescript@5.9.3))(vite@8.0.8(@types/node@20.19.39)(jiti@1.21.7))':
+  '@vitest/mocker@4.1.4(msw@2.13.2(@types/node@20.19.39)(typescript@5.9.3))(vite@8.0.8(@types/node@20.19.39)(esbuild@0.27.7)(jiti@1.21.7)(tsx@4.21.0))':
     dependencies:
       '@vitest/spy': 4.1.4
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
       msw: 2.13.2(@types/node@20.19.39)(typescript@5.9.3)
-      vite: 8.0.8(@types/node@20.19.39)(jiti@1.21.7)
+      vite: 8.0.8(@types/node@20.19.39)(esbuild@0.27.7)(jiti@1.21.7)(tsx@4.21.0)
 
   '@vitest/pretty-format@4.1.4':
     dependencies:
@@ -3726,7 +3982,7 @@ snapshots:
 
   dom-accessibility-api@0.6.3: {}
 
-  dotenv@17.4.1: {}
+  dotenv@17.4.2: {}
 
   dunder-proto@1.0.1:
     dependencies:
@@ -3768,6 +4024,35 @@ snapshots:
   es-object-atoms@1.1.1:
     dependencies:
       es-errors: 1.3.0
+
+  esbuild@0.27.7:
+    optionalDependencies:
+      '@esbuild/aix-ppc64': 0.27.7
+      '@esbuild/android-arm': 0.27.7
+      '@esbuild/android-arm64': 0.27.7
+      '@esbuild/android-x64': 0.27.7
+      '@esbuild/darwin-arm64': 0.27.7
+      '@esbuild/darwin-x64': 0.27.7
+      '@esbuild/freebsd-arm64': 0.27.7
+      '@esbuild/freebsd-x64': 0.27.7
+      '@esbuild/linux-arm': 0.27.7
+      '@esbuild/linux-arm64': 0.27.7
+      '@esbuild/linux-ia32': 0.27.7
+      '@esbuild/linux-loong64': 0.27.7
+      '@esbuild/linux-mips64el': 0.27.7
+      '@esbuild/linux-ppc64': 0.27.7
+      '@esbuild/linux-riscv64': 0.27.7
+      '@esbuild/linux-s390x': 0.27.7
+      '@esbuild/linux-x64': 0.27.7
+      '@esbuild/netbsd-arm64': 0.27.7
+      '@esbuild/netbsd-x64': 0.27.7
+      '@esbuild/openbsd-arm64': 0.27.7
+      '@esbuild/openbsd-x64': 0.27.7
+      '@esbuild/openharmony-arm64': 0.27.7
+      '@esbuild/sunos-x64': 0.27.7
+      '@esbuild/win32-arm64': 0.27.7
+      '@esbuild/win32-ia32': 0.27.7
+      '@esbuild/win32-x64': 0.27.7
 
   escalade@3.2.0: {}
 
@@ -3956,6 +4241,10 @@ snapshots:
     dependencies:
       '@sec-ant/readable-stream': 0.4.1
       is-stream: 4.0.1
+
+  get-tsconfig@4.14.0:
+    dependencies:
+      resolve-pkg-maps: 1.0.0
 
   glob-parent@5.1.2:
     dependencies:
@@ -4469,12 +4758,13 @@ snapshots:
       camelcase-css: 2.0.1
       postcss: 8.5.9
 
-  postcss-load-config@6.0.1(jiti@1.21.7)(postcss@8.5.9):
+  postcss-load-config@6.0.1(jiti@1.21.7)(postcss@8.5.9)(tsx@4.21.0):
     dependencies:
       lilconfig: 3.1.3
     optionalDependencies:
       jiti: 1.21.7
       postcss: 8.5.9
+      tsx: 4.21.0
 
   postcss-nested@6.2.0(postcss@8.5.9):
     dependencies:
@@ -4588,6 +4878,8 @@ snapshots:
   reselect@5.1.1: {}
 
   resolve-from@4.0.0: {}
+
+  resolve-pkg-maps@1.0.0: {}
 
   resolve@1.22.11:
     dependencies:
@@ -4849,7 +5141,7 @@ snapshots:
 
   tailwind-merge@3.5.0: {}
 
-  tailwindcss@3.4.19:
+  tailwindcss@3.4.19(tsx@4.21.0):
     dependencies:
       '@alloc/quick-lru': 5.2.0
       arg: 5.0.2
@@ -4868,7 +5160,7 @@ snapshots:
       postcss: 8.5.9
       postcss-import: 15.1.0(postcss@8.5.9)
       postcss-js: 4.1.0(postcss@8.5.9)
-      postcss-load-config: 6.0.1(jiti@1.21.7)(postcss@8.5.9)
+      postcss-load-config: 6.0.1(jiti@1.21.7)(postcss@8.5.9)(tsx@4.21.0)
       postcss-nested: 6.2.0(postcss@8.5.9)
       postcss-selector-parser: 6.1.2
       resolve: 1.22.11
@@ -4935,6 +5227,13 @@ snapshots:
 
   tslib@2.8.1: {}
 
+  tsx@4.21.0:
+    dependencies:
+      esbuild: 0.27.7
+      get-tsconfig: 4.14.0
+    optionalDependencies:
+      fsevents: 2.3.3
+
   tw-animate-css@1.4.0: {}
 
   type-fest@5.5.0:
@@ -4977,7 +5276,7 @@ snapshots:
 
   vary@1.1.2: {}
 
-  vite@8.0.8(@types/node@20.19.39)(jiti@1.21.7):
+  vite@8.0.8(@types/node@20.19.39)(esbuild@0.27.7)(jiti@1.21.7)(tsx@4.21.0):
     dependencies:
       lightningcss: 1.32.0
       picomatch: 4.0.4
@@ -4986,13 +5285,15 @@ snapshots:
       tinyglobby: 0.2.16
     optionalDependencies:
       '@types/node': 20.19.39
+      esbuild: 0.27.7
       fsevents: 2.3.3
       jiti: 1.21.7
+      tsx: 4.21.0
 
-  vitest@4.1.4(@types/node@20.19.39)(jsdom@29.0.2(@noble/hashes@1.8.0))(msw@2.13.2(@types/node@20.19.39)(typescript@5.9.3))(vite@8.0.8(@types/node@20.19.39)(jiti@1.21.7)):
+  vitest@4.1.4(@types/node@20.19.39)(jsdom@29.0.2(@noble/hashes@1.8.0))(msw@2.13.2(@types/node@20.19.39)(typescript@5.9.3))(vite@8.0.8(@types/node@20.19.39)(esbuild@0.27.7)(jiti@1.21.7)(tsx@4.21.0)):
     dependencies:
       '@vitest/expect': 4.1.4
-      '@vitest/mocker': 4.1.4(msw@2.13.2(@types/node@20.19.39)(typescript@5.9.3))(vite@8.0.8(@types/node@20.19.39)(jiti@1.21.7))
+      '@vitest/mocker': 4.1.4(msw@2.13.2(@types/node@20.19.39)(typescript@5.9.3))(vite@8.0.8(@types/node@20.19.39)(esbuild@0.27.7)(jiti@1.21.7)(tsx@4.21.0))
       '@vitest/pretty-format': 4.1.4
       '@vitest/runner': 4.1.4
       '@vitest/snapshot': 4.1.4
@@ -5009,7 +5310,7 @@ snapshots:
       tinyexec: 1.1.1
       tinyglobby: 0.2.16
       tinyrainbow: 3.1.0
-      vite: 8.0.8(@types/node@20.19.39)(jiti@1.21.7)
+      vite: 8.0.8(@types/node@20.19.39)(esbuild@0.27.7)(jiti@1.21.7)(tsx@4.21.0)
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/node': 20.19.39

--- a/scripts/seed-knowledge-base.ts
+++ b/scripts/seed-knowledge-base.ts
@@ -7,8 +7,10 @@
  *   - Local Supabase running (`supabase start`)
  *   - SUPABASE_URL + SUPABASE_SERVICE_ROLE_KEY in env
  *     (run `eval "$(supabase status -o env)"` first)
- *   - OPENAI_API_KEY in `.env.local` (loaded explicitly via dotenv —
- *     tsx doesn't auto-load `.env.local` the way Next.js does)
+ *   - All other env vars (ANTHROPIC_API_KEY, OPENAI_API_KEY, RESEND_API_KEY,
+ *     NEWS_API_KEY, SERPAPI_KEY) in `.env.local` — loaded by Node's native
+ *     `--env-file` flag in the npm script (must run before module imports
+ *     because `lib/env.ts` validates all 6 vars at module load).
  *
  * Safe to re-run — clears prior chunks per source before re-ingesting.
  */
@@ -19,9 +21,6 @@ import { ingestDocument } from "@/lib/rag/store";
 import { SEED_DOCUMENTS, type SeedDocument } from "@/supabase/seeds/knowledge/manifest";
 import type { Database } from "@/types/supabase";
 import { createClient } from "@supabase/supabase-js";
-import { config as loadEnv } from "dotenv";
-
-loadEnv({ path: ".env.local" });
 
 const SUPABASE_URL = process.env.SUPABASE_URL ?? process.env.NEXT_PUBLIC_SUPABASE_URL;
 const SUPABASE_SERVICE_ROLE_KEY = process.env.SUPABASE_SERVICE_ROLE_KEY;

--- a/scripts/seed-knowledge-base.ts
+++ b/scripts/seed-knowledge-base.ts
@@ -1,0 +1,129 @@
+/**
+ * Seed the knowledge_chunks table from `supabase/seeds/knowledge/`.
+ *
+ * Run with: `pnpm seed:kb`
+ *
+ * Requirements:
+ *   - Local Supabase running (`supabase start`)
+ *   - SUPABASE_URL + SUPABASE_SERVICE_ROLE_KEY in env
+ *     (run `eval "$(supabase status -o env)"` first)
+ *   - OPENAI_API_KEY in `.env.local` (loaded explicitly via dotenv —
+ *     tsx doesn't auto-load `.env.local` the way Next.js does)
+ *
+ * Safe to re-run — clears prior chunks per source before re-ingesting.
+ */
+
+import { readFile } from "node:fs/promises";
+import path from "node:path";
+import { ingestDocument } from "@/lib/rag/store";
+import { SEED_DOCUMENTS, type SeedDocument } from "@/supabase/seeds/knowledge/manifest";
+import type { Database } from "@/types/supabase";
+import { createClient } from "@supabase/supabase-js";
+import { config as loadEnv } from "dotenv";
+
+loadEnv({ path: ".env.local" });
+
+const SUPABASE_URL = process.env.SUPABASE_URL ?? process.env.NEXT_PUBLIC_SUPABASE_URL;
+const SUPABASE_SERVICE_ROLE_KEY = process.env.SUPABASE_SERVICE_ROLE_KEY;
+
+function assertEnv() {
+  if (!SUPABASE_URL) {
+    throw new Error('missing SUPABASE_URL (run: eval "$(supabase status -o env)")');
+  }
+  if (!SUPABASE_SERVICE_ROLE_KEY) {
+    throw new Error("missing SUPABASE_SERVICE_ROLE_KEY");
+  }
+  if (!process.env.OPENAI_API_KEY) {
+    throw new Error("missing OPENAI_API_KEY (set in .env.local)");
+  }
+}
+
+type SeedResult = {
+  source: string;
+  chunks: number;
+  ok: boolean;
+  error?: string;
+};
+
+async function seedOne(
+  supabase: ReturnType<typeof createClient<Database>>,
+  doc: SeedDocument
+): Promise<SeedResult> {
+  const filepath = path.join("supabase/seeds/knowledge", doc.file);
+
+  let content: string;
+  try {
+    content = await readFile(filepath, "utf8");
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    return { source: doc.source, chunks: 0, ok: false, error: `read failed: ${msg}` };
+  }
+
+  // Per-source idempotency: clear prior chunks for this source before re-ingesting.
+  const { error: delErr } = await supabase
+    .from("knowledge_chunks")
+    .delete()
+    .eq("source", doc.source);
+  if (delErr) {
+    return {
+      source: doc.source,
+      chunks: 0,
+      ok: false,
+      error: `delete failed: ${delErr.message}`,
+    };
+  }
+
+  try {
+    const { chunkIds } = await ingestDocument(supabase, {
+      source: doc.source,
+      content,
+      metadata: {
+        url: doc.url,
+        license: doc.license,
+        retrieved_on: doc.retrievedOn,
+        seed: true,
+      },
+    });
+    return { source: doc.source, chunks: chunkIds.length, ok: true };
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    return { source: doc.source, chunks: 0, ok: false, error: `ingest failed: ${msg}` };
+  }
+}
+
+async function main() {
+  assertEnv();
+
+  const supabase = createClient<Database>(
+    SUPABASE_URL as string,
+    SUPABASE_SERVICE_ROLE_KEY as string
+  );
+
+  console.log(`📚 Seeding ${SEED_DOCUMENTS.length} documents…\n`);
+
+  const results: SeedResult[] = [];
+  for (const doc of SEED_DOCUMENTS) {
+    process.stdout.write(`  • ${doc.source}…  `);
+    const r = await seedOne(supabase, doc);
+    results.push(r);
+    if (r.ok) {
+      console.log(`✅ ${r.chunks} chunks`);
+    } else {
+      console.log(`❌ ${r.error}`);
+    }
+  }
+
+  const totalChunks = results.reduce((sum, r) => sum + r.chunks, 0);
+  const okCount = results.filter((r) => r.ok).length;
+  const allOk = okCount === SEED_DOCUMENTS.length;
+  console.log(
+    `\n${allOk ? "✅" : "⚠️"}  Seeded ${okCount}/${SEED_DOCUMENTS.length} documents → ${totalChunks} chunks total`
+  );
+
+  if (!allOk) process.exit(1);
+}
+
+main().catch((err) => {
+  console.error("seed failed:", err);
+  process.exit(1);
+});

--- a/supabase/seeds/knowledge/01-cervical-cancer.md
+++ b/supabase/seeds/knowledge/01-cervical-cancer.md
@@ -1,0 +1,93 @@
+## Key facts
+
+*   Cervical cancer is largely preventable through HPV vaccination and regular screening, as recommended by national guidelines, and it can be cured if detected early and treated promptly.
+*   Cervical cancer is the fourth most common cancer in women globally with around 660 000 new cases and around 350 000 deaths in 2022.
+*   The highest rates of cervical cancer incidence and mortality are in low- and middle-income countries. This reflects major inequities driven by lack of access to national HPV vaccination, cervical screening and treatment services and social and economic determinants.
+*   Cervical cancer is caused by persistent infection with human papillomavirus (HPV). Women living with HIV are 6 times more likely to develop cervical cancer compared to women without HIV.
+*   Countries worldwide are accelerating efforts to eliminate cervical cancer, guided by the global 90–70–90 targets: 90% of girls fully vaccinated with HPV vaccine by age 15, 70% of women screened by ages 35 and 45, and 90% of women with pre-cancer or invasive cancer receiving appropriate treatment.
+
+## Overview
+
+Globally, cervical cancer is the fourth most common cancer in women, with 660 000 new cases estimated in 2022. In the same year, about 94% of the 350 000 deaths caused by cervical cancer occurred in low- and middle-income countries. The highest rates of incidence and mortality are in sub-Saharan Africa, Central America and South-East Asia. These regional differences reflect inequalities in access to vaccination, screening and treatment services.
+
+They are further influenced by risk factors such as HIV prevalence and by broader social and economic determinants, including gender inequality and poverty.
+
+Women living with HIV are six times more likely to develop cervical cancer compared to the general population, and an estimated 5% of all cervical cancer cases are attributable to HIV. Cervical cancer disproportionately affects younger women, and as a result, 20% of children who lose their mother to cancer do so due to cervical cancer.
+
+## Causes
+
+Almost all cases of cervical cancer are caused by infection with oncogenic types of human papillomavirus (HPV). Human papillomavirus (HPV) is a common sexually transmitted infection which can affect the skin, genital area, anal area and throat. Almost all sexually active people will be infected at some point, usually without symptoms. In most cases, the immune system clears the virus naturally. Persistent infection with certain carcinogenic types of HPV can cause abnormal cells that may develop into cancer.
+
+Persistent HPV infection of the cervix (the lower part of the uterus or womb, which opens into the vagina – also called the birth canal) can lead to precancerous lesions which if left untreated cause about 95% of cervical cancers. It usually takes 15–20 years for abnormal cells to become cancer. In women with weakened immune systems, such as untreated HIV, this process can be faster and take 5–10 years. Factors that increase the risk of cancer progression include: the grade of oncogenicity of the HPV type, immune status, the presence of other sexually transmitted infections, number of births, young age at first pregnancy, hormonal contraceptive use, and smoking.
+
+## Prevention
+
+Boosting public awareness, strengthening health literacy, and improving access to information and services are key to prevention and control across the life course:
+
+*   HPV vaccination for girls 9–14 years is highly effective at preventing infection, cervical cancer and other HPV-related cancers.
+*   Cervical screening from the age of 30 (25 years in women living with HIV) can detect cervical precancer, and when coupled with timely treatment can prevent progression to cervical cancer.
+*   At any age, early detection of women with symptoms, followed by prompt quality treatment, can cure cervical cancer.
+
+### HPV vaccination and other prevention steps
+
+As of 2025, there are 8 licensed HPV vaccines, five of which have received WHO pre-qualification and are available globally. All these protect against the high-risk HPV types 16 and 18, which cause ~76% of cervical cancers.
+
+HPV vaccination is a priority for all girls aged 9–14 years, before they become sexually active. Depending on the national schedule the vaccine may be given as one or two doses. Individuals with compromised immune systems, including people living with HIV, should ideally receive two or three doses. Some countries have additionally chosen to vaccinate boys to further reduce the prevalence of HPV in the community and to prevent cancers in men caused by HPV.
+
+Other important ways to prevent HPV infection and reduce the risk of cervical cancer include:
+
+*   being a non-smoker or stopping smoking
+*   using condoms
+*   voluntary male circumcision.
+
+### Cervical screening and treatment of precancers
+
+Women should be screened for cervical cancer with a high-performance test every 5–10 years starting at age 30. Women living with HIV should be screened every 3-5 years, starting at age 25. The global strategy encourages a minimum of two lifetime screens with a high-performance test by age 35 and again by age 45. Precancers rarely cause symptoms, which is why regular cervical cancer screening is important, even if you have been vaccinated against HPV.
+
+Self-collection of a sample for HPV testing, which may be a preferred choice for women, has been shown to be as reliable as samples collected by healthcare providers.
+
+After a positive screen, a health-care provider can look for changes on the cervix (such as precancers) which may develop into cervical cancer if left untreated. Treatment of precancers is a simple and effective procedure to prevent cervical cancer. Treatment may be offered in the same visit for screening (the screen-and-treat approach) or after a second test (the screen, triage and treat approach), which is especially recommended for women living with HIV.
+
+Treatment of precancerous lesions is usually quick and may involve limited discomfort compared to other medical procedures. The process involves examining the cervix after applying acetic acid, with or without magnification (colposcopy or naked-eye visual inspection), to locate the lesion and determine the appropriate treatment. Treatment options include:
+
+*   thermal ablation which uses a heated probe to destroy abnormal cells;
+*   cryotherapy which uses a cold probe to destroy abnormal cells;
+*   LEEP or LEETZ (large loop excision of the transformation zone) which uses an electric heated loop to remove abnormal tissue; and/or
+*   cone biopsy which uses a surgical instrument to remove a cone-shaped piece of tissue for further assessment.
+
+### Early detection, diagnosis and treatment of cervical cancer
+
+Cervical cancer can be cured if diagnosed and treated at an early stage of disease. Recognizing symptoms and seeking medical advice to address any concerns is a critical step. Women should consult a health-care professional if they notice:
+
+*   unusual bleeding between periods, after menopause, or after sexual intercourse
+*   increased or foul-smelling vaginal discharge
+*   symptoms like persistent pain in the back, legs, or pelvis
+*   weight loss, fatigue and loss of appetite
+*   vaginal discomfort
+*   swelling in the legs.
+
+Clinical evaluations and diagnostic tests are essential for confirming cervical cancer. These are generally followed by referral for treatment services, which can include surgery, radiotherapy and chemotherapy, as well as palliative care to provide supportive care and pain management.
+
+Management pathways for invasive cancer care are important tools to ensure that a patient is referred promptly and supported as they navigate the steps to diagnosis and treatment decisions. Features of quality care include:
+
+*   a multidisciplinary team ensuring diagnosis and staging (histological testing, pathology, imaging) takes place prior to treatment decisions;
+*   treatment decisions in line with national guidelines; and
+*   interventions are supported by holistic psychological, spiritual, physical and palliative care.
+
+As low- and middle-income countries scale-up cervical screening, more cases of invasive cervical cancer will be detected, especially in previously unscreened populations. Therefore, referral and cancer management strategies need to be implemented and expanded alongside prevention services.
+
+## WHO Response
+
+All countries have made a commitment to eliminate cervical cancer as a public health problem. The WHO Global strategy defines elimination as reducing the number of new cases annually to 4 or fewer cases per 100 000 women and sets three targets to be achieved by the year 2030 to put all countries on the pathway to elimination in the coming decades:
+
+*   90% of girls vaccinated with the HPV vaccine by age 15;
+*   70% of women screened with a high-performance test by 35 years of age and again by 45 years of age; and
+*   90% of women with cervical precancer or cancer receiving treatment.
+
+Modelling estimates that achieving the elimination goal could avert 74 million new cases of cervical cancer and prevent 62 million deaths by 2120, with additional analyses highlighting the impact among women living with HIV.
+
+Prevention of HPV-associated precancer and cancer is also a key element of WHO's Global health sector strategy on HIV, hepatitis and sexually transmitted infections 2022–2030, and the World Health Assembly resolution WHA74.5 (2021) on oral health includes actions on mouth and throat cancers.
+
+## World Cervical Cancer Elimination Day
+
+17 November is observed as World Cervical Cancer Elimination Day to strengthen global efforts to prevent and treat cervical cancer. The day highlights the importance of HPV vaccination, screening and treatment, with a focus on supporting women and girls. It encourages countries, WHO and partners to collaborate, expand services and track progress, building on the Global Strategy to eliminate cervical cancer.

--- a/supabase/seeds/knowledge/03-hpv-vaccine.md
+++ b/supabase/seeds/knowledge/03-hpv-vaccine.md
@@ -1,0 +1,13 @@
+# Human papillomavirus vaccines (HPV)
+
+Currently there are six licensed HPV vaccines: three bivalent, two quadrivalent, and one nonavalent vaccine. Those that have been prequalified are being marketed in countries throughout the world. All vaccines are highly efficacious in preventing infection with virus types 16 and 18, which are together responsible for approximately 70% of cervical cancer cases globally. The vaccines are also highly efficacious in preventing precancerous cervical lesions caused by these virus types. The quadrivalent vaccine is also highly efficacious in preventing anogenital warts, a common genital disease which is virtually always caused by infection with HPV types 6 and 11. The nonavalent provides additional protection against HPV types 31, 33, 45, 52 and 58. Data from clinical trials and initial post-marketing surveillance conducted in several continents show HPV vaccines to be safe.
+
+The primary target group in most of the countries recommending HPV vaccination is young adolescent girls, aged 9-14. For all vaccines, the vaccination schedule depends on the age of the vaccine recipient.
+
+As per the December 2022 WHO Position on HPV vaccines, WHO recommends the following schedule:
+
+- A one or two-dose schedule for girls aged 9-14
+- A one or two-dose schedule for girls and women aged 15-20
+- Two doses with a 6-month interval for women older than 21
+
+A minimum of 2 doses and when feasible 3-doses remain necessary for those known to be immunocompromised and/or HIV-infected.

--- a/supabase/seeds/knowledge/04-cervical-cancer-overview.md
+++ b/supabase/seeds/knowledge/04-cervical-cancer-overview.md
@@ -1,0 +1,25 @@
+# Cervical cancer
+
+## Overview
+
+Cervical cancer develops in a woman's cervix (the entrance to the uterus from the vagina).
+
+Almost all cervical cancer cases (99%) are linked to infection with high-risk human papillomaviruses (HPV), an extremely common virus transmitted through sexual contact.
+
+Although most infections with HPV resolve spontaneously and cause no symptoms, persistent infection can cause cervical cancer in women.
+
+Cervical cancer is the fourth most common cancer in women. In 2022, an estimated 660 000 women were diagnosed with cervical cancer worldwide and about 350 000 women died from the disease.
+
+Effective primary (HPV vaccination) and secondary prevention approaches (screening for, and treating precancerous lesions) will prevent most cervical cancer cases.
+
+When diagnosed, cervical cancer is one of the most successfully treatable forms of cancer, as long as it is detected early and managed effectively. Cancers diagnosed in late stages can also be controlled with appropriate treatment and palliative care.
+
+With a comprehensive approach to prevent, screen and treat, cervical cancer can be eliminated as a public health problem within a generation.
+
+## Eliminating cervical cancer
+
+No woman should die from cervical cancer. We have the technical, medical and policy tools and approaches to eliminate it. The burden of cervical cancer falls on the women who lack access to health services, mainly in low-and middle income countries.
+
+In May 2018, the Director-General of the World Health Organization announced a global call to action towards the elimination of cervical cancer, underscoring renewed political will to make elimination a reality, and called for all stakeholders to unite behind this common goal.
+
+In January 2019, the Executive Board requested the Director-General to develop a draft global strategy to accelerate cervical cancer elimination, with clear targets for the period 2020–2030. A Global Strategy towards the Elimination of Cervical Cancer as a Public Health Problem was developed in close consultation with Member States, and in collaboration with UN Agencies and other partners and organizations. It outlines key goals and agreed targets to be reached by 2030 and set the world on track to elimination.

--- a/supabase/seeds/knowledge/05-elimination-initiative.md
+++ b/supabase/seeds/knowledge/05-elimination-initiative.md
@@ -1,0 +1,31 @@
+# Cervical Cancer Elimination Initiative
+
+Cervical cancer is preventable and curable when detected early and managed effectively. Yet it remains the 4th most common form of cancer among women worldwide, claiming almost 350,000 lives in 2022.
+
+## Global inequities in cervical cancer burden
+
+Nearly 94% of deaths in 2022 occurred in low- and middle-income countries where access to public health services is limited and screening and treatment have not been widely implemented.
+
+## A global strategy
+
+In May 2018, the WHO Director-General announced a global call for action to eliminate cervical cancer. The Director-General established the Cervical Cancer Elimination Initiative to develop a global strategy. In August 2020, the World Health Assembly adopted the Global Strategy for cervical cancer elimination.
+
+## Achieving elimination
+
+To eliminate cervical cancer, all countries must reach and maintain an incidence rate below 4 per 100,000 women. This rests on three key pillars with corresponding targets:
+
+- **Vaccination:** 90% of girls fully vaccinated with HPV vaccine by age 15
+- **Screening:** 70% of women screened using high-performance tests by age 35 and again by age 45
+- **Treatment:** 90% of women with pre-cancer treated and 90% with invasive cancer managed
+
+Each country should meet the 90–70–90 targets by 2030 to eliminate cervical cancer within the next century.
+
+## Get involved
+
+**Women and girls** should receive HPV vaccination and undergo periodic cervical cancer screenings.
+
+**Community groups** can educate about vaccination, screening, and treatment benefits.
+
+**Health care professionals** should advocate for accessible services and track patients throughout care.
+
+**Governments and policy-makers** should secure affordable vaccines and develop national cervical cancer management guidelines.

--- a/supabase/seeds/knowledge/06-au-hpv-immunisation.md
+++ b/supabase/seeds/knowledge/06-au-hpv-immunisation.md
@@ -1,0 +1,66 @@
+HPV (also called human papillomavirus) is a viral infection that is sexually transmitted. It can cause cancers and genital warts.
+
+Vaccination is a safe and effective way to protect you from HPV.
+
+## Who should get vaccinated against HPV
+
+Anyone who wants to protect themselves against HPV can talk to their vaccination provider about getting vaccinated.
+
+The Australian Immunisation Handbook recommends HPV vaccination for specific groups including:
+
+* younger people aged 9 to 25
+* people with significant immunocompromising conditions
+* men who have sex with men.
+
+HPV vaccine is free under the National Immunisation Program for young people aged approximately 12 to 13. The vaccine is primarily provided through school immunisation programs.
+
+Adolescents who missed the HPV vaccination at 12 to 13 years of age can catch up for free up to age 26.
+
+HPV vaccines should not be given to:
+
+* people who have had anaphylaxis after a previous dose of any HPV vaccine or anaphylaxis after any component of an HPV vaccine
+* people who have had anaphylaxis to yeast (for 9vHPV).
+
+HPV vaccines are not recommended for pregnant women. Breastfeeding woman can receive HPV vaccines.
+
+## When to get the HPV vaccine
+
+The benefits of HPV vaccines are greatest when given before exposure to the virus. This is why we give the vaccine to young people in early high school before they become sexually active.
+
+A single dose of the HPV vaccine (Gardasil®9) is funded under the National Immunisation Program for adolescents aged 12 to 13.
+
+Adolescents who missed the HPV vaccination at 12 to 13 years of age can catch up for free up to age 26.
+
+## How to get vaccinated against HPV
+
+HPV vaccines come as a single vaccine, not as a combination vaccine.
+
+HPV vaccines include:
+
+* Gardasil®9
+* Cervarix.
+
+Your vaccination provider will tell you which vaccine they will give you.
+
+Find product information and consumer medicine information for each available vaccine from the Therapeutic Goods Administration.
+
+## Where to get vaccinated
+
+The vaccine is primarily delivered through school immunisation programs in Year 7.
+
+You can get your vaccine from a range of vaccination providers.
+
+## Possible side effects of HPV vaccination
+
+You may experience minor side effects following vaccination. Most reactions are mild and last no more than a couple of days and you will recover without any problems.
+
+Common side effects of HPV vaccines include:
+
+* pain, redness and swelling at injection site
+* mild fever
+* mild headache
+* mild nausea.
+
+Talk to your vaccination provider about possible side effects of HPV vaccines, or if after having a HPV vaccine you or your child have symptoms that worry you.
+
+The Consumer Medicine Information available on the Therapeutic Goods Administration website lists the ingredients and side effects of each vaccine.

--- a/supabase/seeds/knowledge/07-au-screening-eligibility.md
+++ b/supabase/seeds/knowledge/07-au-screening-eligibility.md
@@ -1,0 +1,51 @@
+## Should you have a Cervical Screening Test?
+
+You are eligible for a Medicare subsidised Cervical Screening Test if you are:
+
+* aged 25 to 74
+* sexually active or ever have been
+* a woman or person with a cervix.
+
+It makes no difference if you:
+
+* are gay, lesbian, bisexual, transgender or straight
+* have had the HPV vaccination or not
+* are no longer sexually active
+* have been through menopause
+* have been with only one sexual partner
+* have had a baby
+* are pregnant (ensure you let your healthcare provider know).
+
+If you have had a full or partial hysterectomy, please check with your doctor about screening.
+
+You are eligible to have your first test when you turn 25. Cervical screening occurs every 5 years after that.
+
+## If you're outside the target age range
+
+### Under 25
+
+Routine screening starts at age 25. There's no need to have a Cervical Screening Test before then. This is because there are common infections or abnormalities that usually go away by themselves before you are 25.
+
+Of course, if you've already had a test and had an abnormal result, keep following your doctor's advice. If you have any of the symptoms below, talk to your healthcare provider.
+
+* have abnormal vaginal bleeding or unusual discharge
+* experience pain during sex
+* have an unexplained, persistent vaginal discharge.
+
+### 75 or over
+
+If you're 75 or over, you can still ask to have a Cervical Screening Test – talk to your healthcare provider.
+
+## If you are pregnant
+
+If you are pregnant and due or overdue for your Cervical Screening Test, it is safe to undergo a Cervical Screening Test (be sure to let your healthcare provider know you are pregnant).
+
+## If you have a disability
+
+If you have a disability, you have the same risk of cervical cancer as other women and people with a cervix.
+
+When you are making your appointment, tell the staff about any requirements you may have.
+
+## Information for non-binary and trans people with a cervix
+
+The National Cervical Screening Program recognises that gender is an important part of a person's identity. The National Cervical Screening Program is committed to ensure that the National Cervical Screening Program communication is accurate, inclusive and respectful, and that no one is disadvantaged accessing cervical screening services, especially non-binary people and people who have had gender affirming surgery and still have a cervix.

--- a/supabase/seeds/knowledge/08-au-screening-process.md
+++ b/supabase/seeds/knowledge/08-au-screening-process.md
@@ -1,0 +1,69 @@
+## What the Cervical Screening Test is looking for
+
+The Cervical Screening Test is a simple process that looks for signs of the human papillomavirus (HPV) – a common infection that causes most cervical cancers.
+
+Most cases of HPV clear up on their own, however, sometimes it can develop into cancer.
+
+Doing the Cervical Screening Test every 5 years means your healthcare provider can monitor or investigate HPV further if needed.
+
+## When booking your appointment
+
+When booking an appointment, tell them if you:
+
+* would prefer a female healthcare provider
+* have a disability which means you may need extra support to do the Cervical Screening Test
+* need the help of an interpreter during your appointment.
+
+It's also best to check if there are any costs when making your appointment.
+
+## At your appointment
+
+You'll be in a private space with your healthcare provider – usually a doctor, nurse or healthcare worker.
+
+If you're unsure what to expect or are worried, you can talk about the process and ask questions first.
+
+You can take a family member or friend with you to your appointment to help you feel more comfortable.
+
+You can choose to screen by:
+
+* collecting your own vaginal sample (self-collection)
+* having your healthcare provider collect your sample.
+
+Both options are equally accurate and safe ways to find HPV.
+
+Talk to your healthcare provider about the right choice for you.
+
+## Having your test
+
+### If you choose to have your healthcare provider collect your sample
+
+Usually, you will need to take off your clothing below the waist and lie on your back, with your knees apart. You will be given a sheet to cover yourself. You can ask for a sheet if you're not given one.
+
+The doctor or nurse will gently insert a speculum (a duck-bill-shaped device) into your vagina, to hold it open. They will then take a small sample from your cervix using a swab. It may feel uncomfortable but should not hurt. If it hurts, tell your doctor or nurse straight away.
+
+### If you choose to collect your own sample (self-collection)
+
+Talk to your healthcare provider about this option. They will talk to you about how to take the sample. You can then take the sample yourself in private, or with help from your doctor, nurse or health worker.
+
+Self-collection involves inserting a swab into your vagina and rotating it for 10 to 30 seconds. This should not hurt but may feel uncomfortable.
+
+## After the appointment
+
+The sample is sent to a lab for checking and they send the results to the referring health-care provider:
+
+* where you had the test
+* that you nominate.
+
+The lab also sends your results to the National Cancer Screening Register. The National Cancer Screening Register holds your cancer screening records and is a good way to keep track of your test dates and results. The National Cancer Screening Register will send you a letter or SMS when you're next due to screen.
+
+## Getting your results
+
+Your healthcare provider will advise you of your results when they come back.
+
+For most people, the results will be that no HPV was found. Your healthcare provider will advise you to do the Cervical Screening Test again in 5 years.
+
+For self-collected samples where the results show a standard type of HPV was found (all types except 16/18), your healthcare provider will ask you to return. They will then collect a cervical sample for further testing.
+
+For clinician-collected samples where the results show a standard type of HPV (all types except 16/18), your healthcare provider will advise you to do the test again in one year to check whether the HPV is still there. If your HPV has cleared up after 1 year, your healthcare provider will advise you to do the test again in 5 years. If your HPV has not cleared up after 1 year your healthcare provider will advise you of the next steps.
+
+For a small group of people, the results will show a higher risk of HPV (types 16/18). If that's the case, your healthcare provider will refer you for further assessment.

--- a/supabase/seeds/knowledge/manifest.ts
+++ b/supabase/seeds/knowledge/manifest.ts
@@ -1,0 +1,61 @@
+/**
+ * Knowledge base seed manifest.
+ *
+ * Source: World Health Organization public fact sheets / Q&A pages.
+ * License: CC BY-NC-SA 3.0 IGO (https://www.who.int/about/policies/publishing/copyright).
+ * Project use: non-commercial educational platform — within license terms.
+ *
+ * To re-fetch, edit the file in place and re-run `pnpm seed:kb` — the script
+ * deletes prior chunks per `source` before re-ingesting, so updates are safe.
+ */
+
+export type SeedDocument = {
+  /** Human-readable display name. Surfaces in citation chips. */
+  source: string;
+  /** Authoritative URL. Stored in metadata.url; surfaces in citation chips. */
+  url: string;
+  /** License string. Stored in metadata.license. */
+  license: string;
+  /** ISO date the content was retrieved. Stored in metadata.retrieved_on. */
+  retrievedOn: string;
+  /** Filename relative to this manifest's directory. */
+  file: string;
+};
+
+export const SEED_DOCUMENTS: SeedDocument[] = [
+  {
+    source: "WHO — Cervical Cancer",
+    url: "https://www.who.int/news-room/fact-sheets/detail/cervical-cancer",
+    license: "CC BY-NC-SA 3.0 IGO",
+    retrievedOn: "2026-05-02",
+    file: "01-cervical-cancer.md",
+  },
+  {
+    source: "WHO — Human Papillomavirus (HPV)",
+    url: "https://www.who.int/news-room/questions-and-answers/item/human-papillomavirus-(hpv)",
+    license: "CC BY-NC-SA 3.0 IGO",
+    retrievedOn: "2026-05-02",
+    file: "02-hpv-overview.md",
+  },
+  {
+    source: "WHO — HPV Vaccines",
+    url: "https://www.who.int/teams/immunization-vaccines-and-biologicals/diseases/human-papillomavirus-vaccines-(hpv)",
+    license: "CC BY-NC-SA 3.0 IGO",
+    retrievedOn: "2026-05-02",
+    file: "03-hpv-vaccine.md",
+  },
+  {
+    source: "WHO — Cervical Cancer Q&A (Prevention & Screening)",
+    url: "https://www.who.int/news-room/questions-and-answers/item/cervical-cancer",
+    license: "CC BY-NC-SA 3.0 IGO",
+    retrievedOn: "2026-05-02",
+    file: "04-cervical-cancer-prevention.md",
+  },
+  {
+    source: "WHO — Cervical Cancer Elimination Initiative",
+    url: "https://www.who.int/initiatives/cervical-cancer-elimination-initiative",
+    license: "CC BY-NC-SA 3.0 IGO",
+    retrievedOn: "2026-05-02",
+    file: "05-elimination-initiative.md",
+  },
+];

--- a/supabase/seeds/knowledge/manifest.ts
+++ b/supabase/seeds/knowledge/manifest.ts
@@ -1,12 +1,25 @@
 /**
  * Knowledge base seed manifest.
  *
- * Source: World Health Organization public fact sheets / Q&A pages.
- * License: CC BY-NC-SA 3.0 IGO (https://www.who.int/about/policies/publishing/copyright).
- * Project use: non-commercial educational platform — within license terms.
+ * Sources:
+ *   - World Health Organization (WHO) public fact sheets — CC BY-NC-SA 3.0 IGO
+ *     https://www.who.int/about/policies/publishing/copyright
+ *   - Australian Government Department of Health and Aged Care — CC BY 4.0
+ *     https://www.health.gov.au/copyright
+ *
+ * Project use: non-commercial educational platform — within both license terms.
  *
  * To re-fetch, edit the file in place and re-run `pnpm seed:kb` — the script
  * deletes prior chunks per `source` before re-ingesting, so updates are safe.
+ *
+ * Known gaps (TODO #48 follow-up — fetched 2026-05-02):
+ *   - https://www.who.int/news-room/questions-and-answers/item/human-papillomavirus-(hpv)
+ *     returned 404. WHO removed or moved the page; no live replacement found
+ *     under /health-topics/. The cervical-cancer fact sheet (#1 below) covers
+ *     HPV-as-cause comprehensively, so this gap is not blocking.
+ *   - https://www.who.int/news-room/questions-and-answers/item/cervical-cancer
+ *     returned only navigation/footer (FETCH_FAILED). Replaced with the
+ *     /health-topics/cervical-cancer overview page (entry #4 below).
  */
 
 export type SeedDocument = {
@@ -31,13 +44,6 @@ export const SEED_DOCUMENTS: SeedDocument[] = [
     file: "01-cervical-cancer.md",
   },
   {
-    source: "WHO — Human Papillomavirus (HPV)",
-    url: "https://www.who.int/news-room/questions-and-answers/item/human-papillomavirus-(hpv)",
-    license: "CC BY-NC-SA 3.0 IGO",
-    retrievedOn: "2026-05-02",
-    file: "02-hpv-overview.md",
-  },
-  {
     source: "WHO — HPV Vaccines",
     url: "https://www.who.int/teams/immunization-vaccines-and-biologicals/diseases/human-papillomavirus-vaccines-(hpv)",
     license: "CC BY-NC-SA 3.0 IGO",
@@ -45,11 +51,11 @@ export const SEED_DOCUMENTS: SeedDocument[] = [
     file: "03-hpv-vaccine.md",
   },
   {
-    source: "WHO — Cervical Cancer Q&A (Prevention & Screening)",
-    url: "https://www.who.int/news-room/questions-and-answers/item/cervical-cancer",
+    source: "WHO — Cervical Cancer Overview",
+    url: "https://www.who.int/health-topics/cervical-cancer",
     license: "CC BY-NC-SA 3.0 IGO",
     retrievedOn: "2026-05-02",
-    file: "04-cervical-cancer-prevention.md",
+    file: "04-cervical-cancer-overview.md",
   },
   {
     source: "WHO — Cervical Cancer Elimination Initiative",
@@ -57,5 +63,26 @@ export const SEED_DOCUMENTS: SeedDocument[] = [
     license: "CC BY-NC-SA 3.0 IGO",
     retrievedOn: "2026-05-02",
     file: "05-elimination-initiative.md",
+  },
+  {
+    source: "Australian Department of Health — HPV Immunisation Service",
+    url: "https://www.health.gov.au/topics/immunisation/vaccines/human-papillomavirus-hpv-immunisation-service",
+    license: "CC BY 4.0",
+    retrievedOn: "2026-05-03",
+    file: "06-au-hpv-immunisation.md",
+  },
+  {
+    source: "Australian Department of Health — Cervical Screening Eligibility",
+    url: "https://www.health.gov.au/our-work/national-cervical-screening-program/getting-a-cervical-screening-test/who-should-get-a-cervical-screening-test",
+    license: "CC BY 4.0",
+    retrievedOn: "2026-05-03",
+    file: "07-au-screening-eligibility.md",
+  },
+  {
+    source: "Australian Department of Health — How Cervical Screening Works",
+    url: "https://www.health.gov.au/our-work/national-cervical-screening-program/getting-a-cervical-screening-test/how-cervical-screening-works",
+    license: "CC BY 4.0",
+    retrievedOn: "2026-05-03",
+    file: "08-au-screening-process.md",
   },
 ];


### PR DESCRIPTION
## Summary
- Seed `knowledge_chunks` with **18 chunks across 7 source documents** — 4 from WHO + 3 from the Australian Department of Health (AU geo focus matches the project's clinic-finder scope)
- Add `scripts/seed-knowledge-base.ts` + `pnpm seed:kb` shortcut. Per-source idempotency via `DELETE WHERE source = ...` before re-ingest — safe to re-run (verified 18 → 18 after second run)
- All chunks carry `metadata.seed = true`, `metadata.url`, `metadata.license`, `metadata.retrieved_on` for citation chips and future cleanup tooling
- Service-role key bypasses RLS for the local seed run (CLI script, not a route — same pattern as Supabase's own `seed.sql`)
- Uses Node 24's native `--env-file=.env.local` flag in the npm script — `dotenv.config()` inside the script doesn't work because ES imports are hoisted before the loader runs, and `lib/env.ts` validates all 6 required env vars at module load

## Sources & Licenses

| # | Source | License | URL |
|---|---|---|---|
| 1 | WHO — Cervical Cancer (fact sheet) | CC BY-NC-SA 3.0 IGO | who.int/news-room/fact-sheets/detail/cervical-cancer |
| 2 | WHO — HPV Vaccines | CC BY-NC-SA 3.0 IGO | who.int/teams/.../human-papillomavirus-vaccines-(hpv) |
| 3 | WHO — Cervical Cancer Overview | CC BY-NC-SA 3.0 IGO | who.int/health-topics/cervical-cancer |
| 4 | WHO — Cervical Cancer Elimination Initiative | CC BY-NC-SA 3.0 IGO | who.int/initiatives/cervical-cancer-elimination-initiative |
| 5 | AU Dept of Health — HPV Immunisation Service | CC BY 4.0 | health.gov.au/topics/immunisation/vaccines/human-papillomavirus-hpv-immunisation-service |
| 6 | AU Dept of Health — Cervical Screening Eligibility | CC BY 4.0 | health.gov.au/our-work/national-cervical-screening-program/.../who-should-get-a-cervical-screening-test |
| 7 | AU Dept of Health — How Cervical Screening Works | CC BY 4.0 | health.gov.au/.../how-cervical-screening-works |

Both licenses permit non-commercial educational redistribution with attribution. Project use is within terms.

## Known gaps (TODO #48 follow-up)

The plan originally targeted 5 WHO documents covering disease/cause/prevention(×2)/strategy. Two WHO URLs failed during fetch:
- `who.int/news-room/questions-and-answers/item/human-papillomavirus-(hpv)` → 404 (page removed). Coverage absorbed by entry #1's "Causes" section, which discusses HPV-as-cause comprehensively.
- `who.int/news-room/questions-and-answers/item/cervical-cancer` → returned only navigation/footer (FETCH_FAILED). Replaced with `/health-topics/cervical-cancer` (entry #3).

Per @najumcao's request mid-execution, supplemented with 3 AU Dept of Health pages (CC BY 4.0) to bring the total to 7 docs / 18 chunks. Final chunk count is below the AC's "~50–200" target — root cause is content density (WHO web pages are short). Follow-up content expansion can pull from the AU National Strategy for the Elimination of Cervical Cancer in Australia (PDF), WHO consolidated guidelines, or curated Cancer Council content (would need permission).

## Smoke check (captured locally)

```
$ pnpm seed:kb
📚 Seeding 7 documents…
  • WHO — Cervical Cancer…  ✅ 7 chunks
  • WHO — HPV Vaccines…  ✅ 1 chunks
  • WHO — Cervical Cancer Overview…  ✅ 2 chunks
  • WHO — Cervical Cancer Elimination Initiative…  ✅ 1 chunks
  • Australian Department of Health — HPV Immunisation Service…  ✅ 2 chunks
  • Australian Department of Health — Cervical Screening Eligibility…  ✅ 2 chunks
  • Australian Department of Health — How Cervical Screening Works…  ✅ 3 chunks

✅  Seeded 7/7 documents → 18 chunks total
```

```
$ psql ... -c "select source, count(*) from knowledge_chunks where metadata->>'seed' = 'true' group by source order by source;"
                              source                              | chunks
------------------------------------------------------------------+--------
 Australian Department of Health — Cervical Screening Eligibility |      2
 Australian Department of Health — How Cervical Screening Works   |      3
 Australian Department of Health — HPV Immunisation Service       |      2
 WHO — Cervical Cancer                                            |      7
 WHO — Cervical Cancer Elimination Initiative                     |      1
 WHO — Cervical Cancer Overview                                   |      2
 WHO — HPV Vaccines                                               |      1
(7 rows)
```

Re-ran `pnpm seed:kb` to confirm idempotency — count stays 18.

## Test plan
- [x] \`pnpm test\` — 231/231 green (no new tests; this is content + script per AC)
- [x] \`pnpm biome check .\` — clean
- [x] \`pnpm exec tsc --noEmit\` — clean
- [x] \`pnpm build\` — clean
- [x] \`pnpm seed:kb\` ran successfully twice — idempotent

Closes #48. **Closes the Epic 4 critical path.** `/api/chat` `health_question` intent now retrieves real WHO + AU Dept of Health citations instead of empty-context fallback. Only #49 (no-match fallback explicit test) and #50 (HNSW tuning measurement) remain — both S-priority polish.

🤖 Generated with [Claude Code](https://claude.com/claude-code)