### PR TITLE
fix(rag): lower similarity threshold to 0.45 + add rag:query helper

### DIFF
--- a/lib/rag/retrieve.test.ts
+++ b/lib/rag/retrieve.test.ts
@@ -22,7 +22,7 @@ describe("retrieveChunks", () => {
     vi.clearAllMocks();
   });
 
-  test("calls match_knowledge_chunks with default threshold 0.75 and count 5", async () => {
+  test("calls match_knowledge_chunks with default threshold 0.45 and count 5", async () => {
     const { supabase, rpc } = mockSupabaseRpc([]);
     const queryEmbedding = Array.from({ length: 1536 }, () => 0.1);
 
@@ -31,7 +31,7 @@ describe("retrieveChunks", () => {
     expect(rpc).toHaveBeenCalledTimes(1);
     expect(rpc).toHaveBeenCalledWith("match_knowledge_chunks", {
       query_embedding: queryEmbedding,
-      match_threshold: 0.75,
+      match_threshold: 0.45,
       match_count: 5,
     });
   });

--- a/lib/rag/retrieve.ts
+++ b/lib/rag/retrieve.ts
@@ -1,7 +1,12 @@
 import type { Database } from "@/types/supabase";
 import type { SupabaseClient } from "@supabase/supabase-js";
 
-const DEFAULT_THRESHOLD = 0.75;
+// Empirically tuned 2026-05-03: text-embedding-3-small produces top-similarity
+// scores of 0.54–0.60 for clearly relevant chunks against this KB's seed (see
+// `scripts/rag-query.ts` for measurement). 0.75 (the original spec) returned
+// zero chunks for every typical health question. 0.45 captures the top 3–5
+// chunks per typical query while excluding the noise tail.
+const DEFAULT_THRESHOLD = 0.45;
 const DEFAULT_COUNT = 5;
 
 export type RetrievedChunk = {
@@ -14,7 +19,7 @@ export type RetrievedChunk = {
 };
 
 export type RetrieveOptions = {
-  /** Cosine similarity floor. Default 0.75 (project spec). */
+  /** Cosine similarity floor. Default 0.45 (empirically tuned — see retrieve.ts comment). */
   threshold?: number;
   /** Max chunks returned. Default 5. */
   count?: number;

--- a/package.json
+++ b/package.json
@@ -13,7 +13,8 @@
     "test": "vitest run",
     "test:watch": "vitest",
     "test:coverage": "vitest run --coverage",
-    "seed:kb": "tsx --env-file=.env.local scripts/seed-knowledge-base.ts"
+    "seed:kb": "tsx --env-file=.env.local scripts/seed-knowledge-base.ts",
+    "rag:query": "tsx --env-file=.env.local scripts/rag-query.ts"
   },
   "dependencies": {
     "@anthropic-ai/sdk": "0.91.1",

--- a/scripts/rag-query.ts
+++ b/scripts/rag-query.ts
@@ -1,0 +1,83 @@
+/**
+ * Inspect RAG retrieval for a query — embeds the query, runs the cosine-
+ * similarity RPC, and prints ranked chunks with similarity scores. Bypasses
+ * `runRagAgent`'s threshold filter so you can see the actual distribution
+ * (run with --threshold to filter, --count to change top-k).
+ *
+ * Run:
+ *   pnpm rag:query "what is hpv?"
+ *   pnpm rag:query "cervical screening age" --threshold 0.5
+ *   pnpm rag:query "vaccine side effects" --count 10
+ *
+ * Requirements:
+ *   - Local Supabase running, env loaded via Node's --env-file flag
+ */
+
+import { embedText } from "@/lib/rag/embed";
+import { retrieveChunks } from "@/lib/rag/retrieve";
+import type { Database } from "@/types/supabase";
+import { createClient } from "@supabase/supabase-js";
+
+function parseArgs() {
+  const args = process.argv.slice(2);
+  const positional: string[] = [];
+  let threshold = 0; // default: no filter, see everything
+  let count = 10;
+
+  for (let i = 0; i < args.length; i++) {
+    if (args[i] === "--threshold") threshold = Number(args[++i]);
+    else if (args[i] === "--count") count = Number(args[++i]);
+    else positional.push(args[i]);
+  }
+
+  const query = positional.join(" ").trim();
+  if (!query) {
+    console.error('Usage: pnpm rag:query "<query>" [--threshold 0.5] [--count 10]');
+    process.exit(1);
+  }
+  return { query, threshold, count };
+}
+
+async function main() {
+  const { query, threshold, count } = parseArgs();
+
+  const url = process.env.SUPABASE_URL ?? process.env.NEXT_PUBLIC_SUPABASE_URL;
+  const key = process.env.SUPABASE_SERVICE_ROLE_KEY;
+  if (!url || !key) {
+    throw new Error(
+      'missing SUPABASE_URL / SUPABASE_SERVICE_ROLE_KEY (run: eval "$(supabase status -o env)")'
+    );
+  }
+
+  const supabase = createClient<Database>(url, key);
+
+  console.log(`🔍 Query: "${query}"`);
+  console.log(`   threshold=${threshold}  count=${count}\n`);
+
+  const embedding = await embedText(query);
+  const chunks = await retrieveChunks(supabase, embedding, { threshold, count });
+
+  if (chunks.length === 0) {
+    console.log("(no chunks retrieved)");
+    return;
+  }
+
+  chunks.forEach((c, i) => {
+    const sim = c.similarityScore.toFixed(3);
+    const preview = c.content.replace(/\s+/g, " ").slice(0, 140);
+    console.log(`#${i + 1}  similarity=${sim}  source=${c.source ?? "(none)"}`);
+    console.log(`    ${preview}…\n`);
+  });
+
+  const min = Math.min(...chunks.map((c) => c.similarityScore));
+  const max = Math.max(...chunks.map((c) => c.similarityScore));
+  const avg = chunks.reduce((s, c) => s + c.similarityScore, 0) / chunks.length;
+  console.log(
+    `Stats: min=${min.toFixed(3)}  max=${max.toFixed(3)}  avg=${avg.toFixed(3)}  count=${chunks.length}`
+  );
+}
+
+main().catch((err) => {
+  console.error("rag-query failed:", err);
+  process.exit(1);
+});


### PR DESCRIPTION
## Problem

Demo regression after #48 merge: \`/api/chat\` "What is HPV?" returned an answer with **no citations**, despite the seeded KB containing 18 chunks of WHO + AU Dept of Health cervical-health content.

Server logs:
\`\`\`
[orchestrator] dispatch: health_question
[orchestrator] health_question returned 0 chunks for query: what is hpv ?
\`\`\`

Intent classifier worked correctly. RAG ran. But every chunk's similarity was below the 0.75 threshold, so retrieval returned empty and the no-match-fallback path (#49) fired.

## Diagnosis

Added \`scripts/rag-query.ts\` (\`pnpm rag:query "<question>"\`) to inspect retrieval directly. Measured 4 representative queries against the seeded KB:

| Query | Top similarity | 5th-rank similarity |
|---|---|---|
| "what is hpv?" | 0.540 | 0.452 |
| "What age should I start cervical screening?" | 0.604 | ~0.50 |
| "How does HPV cause cervical cancer?" | 0.569 | ~0.49 |
| "Is the HPV vaccine safe for my daughter?" | 0.563 | ~0.45 |

OpenAI \`text-embedding-3-small\` produces top-relevant similarities of **0.54–0.60** against this KB style — **none reach 0.75**. The chunks themselves are correct (top 3-5 hits are clearly on-topic).

## Fix

\`DEFAULT_THRESHOLD\` in \`lib/rag/retrieve.ts\`: \`0.75 → 0.45\`. Reasoning:
- Captures top 3-5 chunks per typical query (well within the \`count=5\` cap)
- Slightly conservative buffer below all observed "clearly relevant" tops
- Excludes the noise tail (similarities under 0.40 are weakly related at best)

## Verification

\`\`\`
$ pnpm rag:query "what is hpv?" --threshold 0.45 --count 5
#1  similarity=0.540  source=Australian Department of Health — HPV Immunisation Service
#2  similarity=0.529  source=WHO — HPV Vaccines
#3  similarity=0.506  source=Australian Department of Health — How Cervical Screening Works
#4  similarity=0.498  source=WHO — Cervical Cancer
#5  similarity=0.452  source=WHO — Cervical Cancer
Stats: min=0.452  max=0.540  avg=0.505  count=5
\`\`\`

5 relevant chunks now retrieved. The orchestrator should now thread these into the response agent's \`ragContext\` + \`ragSources\`, lighting up #28's citation chips end-to-end.

## Permanent dev tool

\`scripts/rag-query.ts\` + \`pnpm rag:query\` is committed as a permanent helper. Useful any time:
- Threshold needs re-tuning after KB content changes (e.g., adding PDF guidelines)
- Investigating "why didn't this query return X?"
- Understanding similarity distribution before changing chunking strategy

Default behavior: \`threshold=0\`, \`count=10\` — see everything ranked. Override with \`--threshold 0.5 --count 5\` for production-like cuts. Includes summary stats line.

## Tests
- Updated \`retrieve.test.ts\` to assert the new default
- 234/234 still green
- \`pnpm biome check .\` clean
- \`pnpm exec tsc --noEmit\` clean

## Follow-ups (not in this PR)
- Browser smoke check: log in → ask "What is HPV?" → verify citation chips appear under the assistant message
- Update \`docs/architecture.md\` and the Epic 4 ticket doc which still reference 0.75 (low value, can land in a docs sweep)
- If similarity scores change materially after seeding richer content (e.g., PDF guidelines), re-measure and consider re-tuning

🤖 Generated with [Claude Code](https://claude.com/claude-code)