### PR TITLE
feat(news): NewsAPI proxy + fetchHealthNews tool

### DIFF
--- a/app/api/news/route.test.ts
+++ b/app/api/news/route.test.ts
@@ -1,0 +1,89 @@
+import { server } from "@/test-utils/server";
+import { http, HttpResponse } from "msw";
+import { describe, expect, it } from "vitest";
+import { GET } from "./route";
+
+const NEWSAPI_URL = "https://newsapi.org/v2/everything";
+
+function makeRequest(path: string): Request {
+  return new Request(`http://localhost${path}`);
+}
+
+describe("GET /api/news", () => {
+  it("returns 200 with articles array", async () => {
+    server.use(
+      http.get(NEWSAPI_URL, () =>
+        HttpResponse.json({
+          status: "ok",
+          articles: [
+            {
+              title: "x",
+              source: { name: "Y" },
+              url: "https://example.com/x",
+              publishedAt: "2026-04-30T12:00:00Z",
+              description: null,
+            },
+          ],
+        })
+      )
+    );
+    const res = await GET(makeRequest("/api/news"));
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { articles: unknown[] };
+    expect(Array.isArray(body.articles)).toBe(true);
+    expect(body.articles).toHaveLength(1);
+  });
+
+  it("clamps max above 10 to a 400", async () => {
+    const res = await GET(makeRequest("/api/news?max=999"));
+    expect(res.status).toBe(400);
+  });
+
+  it("rejects non-numeric max", async () => {
+    const res = await GET(makeRequest("/api/news?max=abc"));
+    expect(res.status).toBe(400);
+  });
+
+  it("returns empty articles + error flag on upstream 500", async () => {
+    server.use(http.get(NEWSAPI_URL, () => new HttpResponse(null, { status: 500 })));
+    const res = await GET(makeRequest("/api/news"));
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { articles: unknown[]; error?: string };
+    expect(body.articles).toEqual([]);
+    expect(body.error).toBe("unavailable");
+  });
+
+  it("never echoes the NewsAPI key in the response", async () => {
+    server.use(
+      http.get(NEWSAPI_URL, () =>
+        HttpResponse.json({
+          status: "ok",
+          articles: [
+            {
+              title: "x",
+              source: { name: "Y" },
+              url: "https://example.com/x",
+              publishedAt: "2026-04-30T12:00:00Z",
+              description: null,
+            },
+          ],
+        })
+      )
+    );
+    const res = await GET(makeRequest("/api/news?q=hpv"));
+    const text = await res.text();
+    expect(text).not.toContain("test-news-api-key");
+  });
+
+  it("forwards user query to upstream q param", async () => {
+    let captured = "";
+    server.use(
+      http.get(NEWSAPI_URL, ({ request }) => {
+        captured = request.url;
+        return HttpResponse.json({ status: "ok", articles: [] });
+      })
+    );
+    await GET(makeRequest("/api/news?q=screening"));
+    expect(captured).toContain("screening");
+  });
+});

--- a/app/api/news/route.ts
+++ b/app/api/news/route.ts
@@ -1,0 +1,24 @@
+import { searchNewsApi } from "@/lib/news/search-news";
+import { newsQuerySchema } from "@/lib/validations/news";
+
+export async function GET(request: Request) {
+  const { searchParams } = new URL(request.url);
+  const parsed = newsQuerySchema.safeParse({
+    q: searchParams.get("q") ?? undefined,
+    max: searchParams.get("max") ?? undefined,
+  });
+
+  if (!parsed.success) {
+    return Response.json({ error: "invalid_request" }, { status: 400 });
+  }
+
+  const articles = await searchNewsApi({
+    query: parsed.data.q,
+    max_results: parsed.data.max,
+  });
+
+  if (articles.length === 0) {
+    return Response.json({ articles: [], error: "unavailable" });
+  }
+  return Response.json({ articles });
+}

--- a/lib/news/search-news.test.ts
+++ b/lib/news/search-news.test.ts
@@ -1,0 +1,201 @@
+import { server } from "@/test-utils/server";
+import { http, HttpResponse } from "msw";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { searchNewsApi } from "./search-news";
+
+const NEWSAPI_URL = "https://newsapi.org/v2/everything";
+
+describe("searchNewsApi", () => {
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("returns up to max_results articles, normalized", async () => {
+    server.use(
+      http.get(NEWSAPI_URL, () => {
+        return HttpResponse.json({
+          status: "ok",
+          articles: [
+            {
+              title: "HPV vaccine update",
+              source: { id: null, name: "BBC Health" },
+              url: "https://bbc.example/1",
+              publishedAt: "2026-04-30T12:00:00Z",
+              description: "summary",
+            },
+            {
+              title: "Cervical screening reaches more women",
+              source: { id: null, name: "Reuters" },
+              url: "https://reuters.example/2",
+              publishedAt: "2026-04-29T08:00:00Z",
+              description: null,
+            },
+          ],
+        });
+      })
+    );
+
+    const articles = await searchNewsApi({ query: "vaccine", max_results: 5 });
+    expect(articles).toHaveLength(2);
+    expect(articles[0]).toEqual({
+      title: "HPV vaccine update",
+      source: "BBC Health",
+      url: "https://bbc.example/1",
+      published_at: "2026-04-30T12:00:00Z",
+      description: "summary",
+    });
+    expect(articles[1].description).toBeNull();
+  });
+
+  it("respects max_results when upstream returns more", async () => {
+    server.use(
+      http.get(NEWSAPI_URL, () => {
+        return HttpResponse.json({
+          status: "ok",
+          articles: Array.from({ length: 10 }, (_, i) => ({
+            title: `headline ${i}`,
+            source: { name: "X" },
+            url: `https://example.com/${i}`,
+            publishedAt: "2026-04-30T12:00:00Z",
+            description: null,
+          })),
+        });
+      })
+    );
+
+    const articles = await searchNewsApi({ max_results: 3 });
+    expect(articles).toHaveLength(3);
+  });
+
+  it("returns empty array on empty upstream result", async () => {
+    server.use(http.get(NEWSAPI_URL, () => HttpResponse.json({ status: "ok", articles: [] })));
+    const articles = await searchNewsApi({});
+    expect(articles).toEqual([]);
+  });
+
+  it("returns empty array on upstream 500", async () => {
+    server.use(http.get(NEWSAPI_URL, () => new HttpResponse(null, { status: 500 })));
+    const articles = await searchNewsApi({});
+    expect(articles).toEqual([]);
+  });
+
+  it("returns empty array on network failure", async () => {
+    server.use(http.get(NEWSAPI_URL, () => HttpResponse.error()));
+    const articles = await searchNewsApi({});
+    expect(articles).toEqual([]);
+  });
+
+  it("appends fixed health-domain query base when user query is provided", async () => {
+    let capturedUrl = "";
+    server.use(
+      http.get(NEWSAPI_URL, ({ request }) => {
+        capturedUrl = request.url;
+        return HttpResponse.json({ status: "ok", articles: [] });
+      })
+    );
+    await searchNewsApi({ query: "vaccine" });
+    const params = new URL(capturedUrl).searchParams;
+    const q = params.get("q") ?? "";
+    expect(q).toContain("vaccine");
+    expect(q.toLowerCase()).toContain("cervical health");
+    expect(q.toLowerCase()).toContain("hpv");
+  });
+
+  it("uses base health terms when no user query is provided", async () => {
+    let capturedUrl = "";
+    server.use(
+      http.get(NEWSAPI_URL, ({ request }) => {
+        capturedUrl = request.url;
+        return HttpResponse.json({ status: "ok", articles: [] });
+      })
+    );
+    await searchNewsApi({});
+    const q = new URL(capturedUrl).searchParams.get("q") ?? "";
+    expect(q.toLowerCase()).toContain("cervical health");
+  });
+
+  it("constrains the date window to the last 7 days", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-05-04T00:00:00Z"));
+    let capturedUrl = "";
+    server.use(
+      http.get(NEWSAPI_URL, ({ request }) => {
+        capturedUrl = request.url;
+        return HttpResponse.json({ status: "ok", articles: [] });
+      })
+    );
+    await searchNewsApi({});
+    const from = new URL(capturedUrl).searchParams.get("from");
+    expect(from).toBe("2026-04-27");
+  });
+
+  it("requests articles sorted by publishedAt", async () => {
+    let capturedUrl = "";
+    server.use(
+      http.get(NEWSAPI_URL, ({ request }) => {
+        capturedUrl = request.url;
+        return HttpResponse.json({ status: "ok", articles: [] });
+      })
+    );
+    await searchNewsApi({});
+    expect(new URL(capturedUrl).searchParams.get("sortBy")).toBe("publishedAt");
+  });
+
+  it("never includes the API key in returned data", async () => {
+    server.use(
+      http.get(NEWSAPI_URL, () =>
+        HttpResponse.json({
+          status: "ok",
+          articles: [
+            {
+              title: "x",
+              source: { name: "y" },
+              url: "https://example.com",
+              publishedAt: "2026-04-30T12:00:00Z",
+              description: null,
+            },
+          ],
+        })
+      )
+    );
+    const articles = await searchNewsApi({});
+    const serialized = JSON.stringify(articles);
+    expect(serialized).not.toContain("test-news-api-key");
+  });
+
+  it("skips upstream items missing required fields", async () => {
+    server.use(
+      http.get(NEWSAPI_URL, () =>
+        HttpResponse.json({
+          status: "ok",
+          articles: [
+            {
+              title: "ok",
+              source: { name: "X" },
+              url: "https://a.com",
+              publishedAt: "2026-04-30T12:00:00Z",
+              description: null,
+            },
+            {
+              title: "no-url",
+              source: { name: "X" },
+              url: null,
+              publishedAt: "2026-04-30T12:00:00Z",
+              description: null,
+            },
+            {
+              title: "no-source",
+              source: null,
+              url: "https://b.com",
+              publishedAt: "2026-04-30T12:00:00Z",
+              description: null,
+            },
+          ],
+        })
+      )
+    );
+    const articles = await searchNewsApi({});
+    expect(articles).toHaveLength(1);
+    expect(articles[0].title).toBe("ok");
+  });
+});

--- a/lib/news/search-news.ts
+++ b/lib/news/search-news.ts
@@ -1,0 +1,94 @@
+import { env } from "@/lib/env";
+import type { NewsArticle } from "@/lib/validations/news";
+
+const NEWSAPI_ENDPOINT = "https://newsapi.org/v2/everything";
+const HEALTH_DOMAIN_BASE = "cervical health OR HPV OR women's health";
+const WINDOW_DAYS = 7;
+
+export type SearchNewsInput = {
+  query?: string;
+  max_results?: number;
+};
+
+type UpstreamArticle = {
+  title?: string | null;
+  url?: string | null;
+  publishedAt?: string | null;
+  description?: string | null;
+  source?: { name?: string | null } | null;
+};
+
+type UpstreamResponse = {
+  status?: string;
+  articles?: UpstreamArticle[];
+};
+
+/**
+ * Single source of truth for the NewsAPI call.
+ * Used directly by the news agent's tool wrapper and by the `/api/news` proxy.
+ * Never throws — always resolves to an array (empty on any failure) so callers
+ * can degrade gracefully without try/catch boilerplate.
+ */
+export async function searchNewsApi({
+  query = "",
+  max_results = 5,
+}: SearchNewsInput): Promise<NewsArticle[]> {
+  const max = Math.min(Math.max(max_results, 1), 10);
+  const userQuery = query.trim();
+  const q = userQuery ? `(${userQuery}) AND (${HEALTH_DOMAIN_BASE})` : HEALTH_DOMAIN_BASE;
+
+  const from = isoDateNDaysAgo(WINDOW_DAYS);
+
+  const url = new URL(NEWSAPI_ENDPOINT);
+  url.searchParams.set("q", q);
+  url.searchParams.set("from", from);
+  url.searchParams.set("sortBy", "publishedAt");
+  url.searchParams.set("pageSize", String(max));
+  url.searchParams.set("language", "en");
+  url.searchParams.set("apiKey", env.newsApiKey);
+
+  let upstream: Response;
+  try {
+    upstream = await fetch(url, { headers: { Accept: "application/json" } });
+  } catch (err) {
+    console.error("[news] upstream fetch failed:", err instanceof Error ? err.message : err);
+    return [];
+  }
+
+  if (!upstream.ok) {
+    console.error(`[news] upstream non-2xx: ${upstream.status}`);
+    return [];
+  }
+
+  let data: UpstreamResponse;
+  try {
+    data = (await upstream.json()) as UpstreamResponse;
+  } catch {
+    return [];
+  }
+
+  if (!Array.isArray(data.articles)) return [];
+
+  const normalized: NewsArticle[] = [];
+  for (const a of data.articles) {
+    const title = a.title?.trim();
+    const url = a.url?.trim();
+    const sourceName = a.source?.name?.trim();
+    const publishedAt = a.publishedAt?.trim();
+    if (!title || !url || !sourceName || !publishedAt) continue;
+    normalized.push({
+      title,
+      source: sourceName,
+      url,
+      published_at: publishedAt,
+      description: a.description ?? null,
+    });
+    if (normalized.length >= max) break;
+  }
+  return normalized;
+}
+
+function isoDateNDaysAgo(days: number): string {
+  const d = new Date(Date.now() - days * 24 * 60 * 60 * 1000);
+  return d.toISOString().slice(0, 10);
+}

--- a/lib/tools/news.test.ts
+++ b/lib/tools/news.test.ts
@@ -1,0 +1,59 @@
+import { server } from "@/test-utils/server";
+import { http, HttpResponse } from "msw";
+import { describe, expect, it } from "vitest";
+import { fetchHealthNews } from "./news";
+
+const NEWSAPI_URL = "https://newsapi.org/v2/everything";
+
+describe("fetchHealthNews", () => {
+  it("returns parsed articles on success", async () => {
+    server.use(
+      http.get(NEWSAPI_URL, () =>
+        HttpResponse.json({
+          status: "ok",
+          articles: [
+            {
+              title: "HPV vaccine update",
+              source: { name: "BBC Health" },
+              url: "https://bbc.example/1",
+              publishedAt: "2026-04-30T12:00:00Z",
+              description: "summary",
+            },
+          ],
+        })
+      )
+    );
+    const articles = await fetchHealthNews({ query: "vaccine" });
+    expect(articles).toHaveLength(1);
+    expect(articles[0].source).toBe("BBC Health");
+  });
+
+  it("returns empty array on upstream failure (does not throw)", async () => {
+    server.use(http.get(NEWSAPI_URL, () => new HttpResponse(null, { status: 500 })));
+    await expect(fetchHealthNews({})).resolves.toEqual([]);
+  });
+
+  it("returns empty array on empty upstream", async () => {
+    server.use(http.get(NEWSAPI_URL, () => HttpResponse.json({ status: "ok", articles: [] })));
+    await expect(fetchHealthNews({})).resolves.toEqual([]);
+  });
+
+  it("defaults max_results to 5", async () => {
+    server.use(
+      http.get(NEWSAPI_URL, () =>
+        HttpResponse.json({
+          status: "ok",
+          articles: Array.from({ length: 10 }, (_, i) => ({
+            title: `h${i}`,
+            source: { name: "X" },
+            url: `https://example.com/${i}`,
+            publishedAt: "2026-04-30T12:00:00Z",
+            description: null,
+          })),
+        })
+      )
+    );
+    const articles = await fetchHealthNews({});
+    expect(articles).toHaveLength(5);
+  });
+});

--- a/lib/tools/news.ts
+++ b/lib/tools/news.ts
@@ -1,0 +1,16 @@
+import { searchNewsApi } from "@/lib/news/search-news";
+import type { NewsArticle } from "@/lib/validations/news";
+
+export type FetchHealthNewsInput = {
+  query?: string;
+  max_results?: number;
+};
+
+/**
+ * News Agent's tool wrapper. Surfaces the same data the `/api/news` proxy
+ * returns — both share `searchNewsApi` so the upstream call has a single
+ * implementation. Never throws; returns `[]` on any failure.
+ */
+export async function fetchHealthNews(input: FetchHealthNewsInput = {}): Promise<NewsArticle[]> {
+  return searchNewsApi(input);
+}

--- a/lib/validations/news.ts
+++ b/lib/validations/news.ts
@@ -1,0 +1,18 @@
+import { z } from "zod";
+
+export const newsQuerySchema = z.object({
+  q: z.string().trim().max(200).optional().default(""),
+  max: z.coerce.number().int().min(1).max(10).optional().default(5),
+});
+
+export type NewsQuery = z.infer<typeof newsQuerySchema>;
+
+export const newsArticleSchema = z.object({
+  title: z.string(),
+  source: z.string(),
+  url: z.string().url(),
+  published_at: z.string(),
+  description: z.string().nullable(),
+});
+
+export type NewsArticle = z.infer<typeof newsArticleSchema>;


### PR DESCRIPTION
## Summary
- `lib/news/search-news.ts` — single shared NewsAPI caller with the fixed health-domain query base (`cervical health OR HPV OR women's health`), 7-day window, and graceful empty-array fallback on upstream errors
- `app/api/news/route.ts` — GET handler with Zod-validated `q?` and `max?` params (1-10)
- `lib/tools/news.ts` — `fetchHealthNews` tool wrapper for the upcoming News Agent (#64)
- `lib/validations/news.ts` — Zod schemas for `NewsArticle` + query params

## Design note
The tool calls `searchNewsApi` directly rather than self-fetching `/api/news`. Both run server-side, so the proxy hop adds latency without further protecting the API key. The route still exists for future browser callers and is end-to-end tested.

## Test plan
- [x] `pnpm test` — 21 new tests + full suite green (240 passed)
- [x] `pnpm biome check .` clean
- [x] `pnpm build` succeeds
- [x] Tests cover: success, empty upstream, upstream 5xx, network failure, query base appended, 7-day window, sortBy, max clamp, key non-leakage, malformed-item filtering, route Zod validation

Closes #63

🤖 Generated with [Claude Code](https://claude.com/claude-code)