### PR TITLE
feat(agents): runNewsAgent

### DIFF
--- a/lib/agents/news-agent.test.ts
+++ b/lib/agents/news-agent.test.ts
@@ -1,0 +1,139 @@
+// @vitest-environment node
+
+import type { NewsArticle } from "@/lib/validations/news";
+import { beforeEach, describe, expect, test, vi } from "vitest";
+
+vi.mock("@/lib/tools/news", () => ({
+  fetchHealthNews: vi.fn(),
+}));
+
+import { fetchHealthNews } from "@/lib/tools/news";
+import { runNewsAgent } from "./news-agent";
+
+function article(overrides: Partial<NewsArticle> = {}): NewsArticle {
+  return {
+    title: "HPV vaccine update",
+    source: "BBC Health",
+    url: "https://bbc.example/1",
+    published_at: "2026-04-30T12:00:00Z",
+    description: "summary",
+    ...overrides,
+  };
+}
+
+describe("runNewsAgent", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(fetchHealthNews).mockResolvedValue([]);
+  });
+
+  test("calls fetchHealthNews with userMessage as query and max_results=5", async () => {
+    await runNewsAgent({ userMessage: "any HPV news?" });
+
+    expect(fetchHealthNews).toHaveBeenCalledTimes(1);
+    expect(fetchHealthNews).toHaveBeenCalledWith({
+      query: "any HPV news?",
+      max_results: 5,
+    });
+  });
+
+  test("returns empty newsContext and empty newsSources when tool returns []", async () => {
+    vi.mocked(fetchHealthNews).mockResolvedValue([]);
+
+    const result = await runNewsAgent({ userMessage: "anything" });
+
+    expect(result).toEqual({ newsContext: "", newsSources: [] });
+  });
+
+  test("formats a single article with [1] marker, title, source, date", async () => {
+    vi.mocked(fetchHealthNews).mockResolvedValue([
+      article({
+        title: "HPV vaccine update",
+        source: "BBC Health",
+        url: "https://bbc.example/1",
+        published_at: "2026-04-30T12:00:00Z",
+      }),
+    ]);
+
+    const result = await runNewsAgent({ userMessage: "news?" });
+
+    expect(result.newsContext).toContain("[1]");
+    expect(result.newsContext).toContain("HPV vaccine update");
+    expect(result.newsContext).toContain("BBC Health");
+    expect(result.newsContext).toContain("2026-04-30");
+    expect(result.newsSources).toEqual([
+      {
+        id: "1",
+        title: "HPV vaccine update",
+        url: "https://bbc.example/1",
+        chunkId: "news:https://bbc.example/1",
+      },
+    ]);
+  });
+
+  test("formats multiple articles with sequential markers", async () => {
+    vi.mocked(fetchHealthNews).mockResolvedValue([
+      article({ title: "A", url: "https://a.com", source: "S1" }),
+      article({ title: "B", url: "https://b.com", source: "S2" }),
+      article({ title: "C", url: "https://c.com", source: "S3" }),
+    ]);
+
+    const result = await runNewsAgent({ userMessage: "news" });
+
+    expect(result.newsContext).toMatch(/\[1\][\s\S]*\[2\][\s\S]*\[3\]/);
+    expect(result.newsSources.map((s) => s.id)).toEqual(["1", "2", "3"]);
+    expect(result.newsSources.map((s) => s.title)).toEqual(["A", "B", "C"]);
+  });
+
+  test("separates multiple articles with blank lines for response-agent grounding", async () => {
+    vi.mocked(fetchHealthNews).mockResolvedValue([
+      article({ title: "A", url: "https://a.com" }),
+      article({ title: "B", url: "https://b.com" }),
+    ]);
+
+    const result = await runNewsAgent({ userMessage: "news" });
+
+    expect(result.newsContext).toContain("\n\n");
+  });
+
+  test("never throws when tool resolves with malformed data — degrades to empty", async () => {
+    // Tool itself never throws (per #63), but if it ever does, runNewsAgent must
+    // still return a valid empty result rather than propagating.
+    vi.mocked(fetchHealthNews).mockRejectedValueOnce(new Error("boom"));
+
+    await expect(runNewsAgent({ userMessage: "x" })).resolves.toEqual({
+      newsContext: "",
+      newsSources: [],
+    });
+  });
+
+  test("uses url as the chunkId so citation chips can dedupe across turns", async () => {
+    vi.mocked(fetchHealthNews).mockResolvedValue([
+      article({ url: "https://example.com/article-42" }),
+    ]);
+
+    const result = await runNewsAgent({ userMessage: "x" });
+
+    expect(result.newsSources[0].chunkId).toBe("news:https://example.com/article-42");
+  });
+
+  test("includes article description in context when present", async () => {
+    vi.mocked(fetchHealthNews).mockResolvedValue([
+      article({ title: "T", description: "useful summary line" }),
+    ]);
+
+    const result = await runNewsAgent({ userMessage: "x" });
+
+    expect(result.newsContext).toContain("useful summary line");
+  });
+
+  test("omits description gracefully when null", async () => {
+    vi.mocked(fetchHealthNews).mockResolvedValue([article({ title: "T", description: null })]);
+
+    const result = await runNewsAgent({ userMessage: "x" });
+
+    // No crash, no literal "null" leaking into the prompt
+    expect(result.newsContext).not.toContain("null");
+    expect(result.newsContext).toContain("T");
+  });
+});

--- a/lib/agents/news-agent.ts
+++ b/lib/agents/news-agent.ts
@@ -1,0 +1,70 @@
+import { fetchHealthNews } from "@/lib/tools/news";
+import type { NewsArticle } from "@/lib/validations/news";
+import type { Source } from "@/types/agents";
+
+const MAX_RESULTS = 5;
+
+export type NewsAgentContext = {
+  /** The new user turn — used verbatim as the search hint. */
+  userMessage: string;
+};
+
+export type NewsAgentResult = {
+  /**
+   * Numbered concatenation of news items with `[1]`, `[2]` markers matching
+   * `newsSources`. Empty string when the upstream returns nothing. Consumed
+   * by the response agent under a "Recent news:" header.
+   */
+  newsContext: string;
+  /**
+   * Citation chips for the chat UI. `chunkId` is `news:<url>` so the chip
+   * renderer (which keys on chunkId) can dedupe across turns even though
+   * news items have no DB row.
+   */
+  newsSources: Source[];
+};
+
+/**
+ * News agent — pulls health-domain headlines via `fetchHealthNews` and
+ * shapes them into the same `{ context, sources }` envelope the RAG agent
+ * uses, so the response agent and citation chips treat both paths uniformly.
+ *
+ * Per CLAUDE.md: pure function, never throws. The tool already swallows
+ * upstream errors into `[]`; we still defensively wrap to keep the
+ * orchestrator path graceful if that contract ever drifts.
+ */
+export async function runNewsAgent(ctx: NewsAgentContext): Promise<NewsAgentResult> {
+  let articles: NewsArticle[] = [];
+  try {
+    articles = await fetchHealthNews({
+      query: ctx.userMessage,
+      max_results: MAX_RESULTS,
+    });
+  } catch (err) {
+    console.error(
+      "[news-agent] fetchHealthNews unexpectedly threw:",
+      err instanceof Error ? err.message : err
+    );
+    return { newsContext: "", newsSources: [] };
+  }
+
+  if (articles.length === 0) {
+    return { newsContext: "", newsSources: [] };
+  }
+
+  const newsSources: Source[] = articles.map((a, i) => ({
+    id: String(i + 1),
+    title: a.title,
+    url: a.url,
+    chunkId: `news:${a.url}`,
+  }));
+  const newsContext = articles.map((a, i) => formatArticle(a, i + 1)).join("\n\n");
+
+  return { newsContext, newsSources };
+}
+
+function formatArticle(article: NewsArticle, marker: number): string {
+  const date = article.published_at.slice(0, 10);
+  const head = `[${marker}] ${article.title} — ${article.source} (${date})`;
+  return article.description ? `${head}\n${article.description}` : head;
+}


### PR DESCRIPTION
## Summary
- `lib/agents/news-agent.ts` — pure agent that calls `fetchHealthNews` (#63) and formats results into the same `{ context, sources }` envelope `runRagAgent` returns
- Numbered context: `[N] <title> — <source> (<date>)\n<description?>`
- `Source[]` keyed by URL (`chunkId: "news:<url>"`) so the existing citation chip renderer dedupes across turns without DB rows
- Defensively wraps the tool call so any contract drift returns `{ newsContext: "", newsSources: [] }` instead of throwing

## Test plan
- [x] `pnpm test` — 9 new tests + full suite green (249 passed)
- [x] `pnpm biome check .` clean
- [x] `pnpm build` succeeds
- Tests cover: tool args, empty path, single + multi article formatting, sequential markers, blank-line separator, throw-fallback, chunkId derivation, description present/absent

Closes #64

Next: #66 + #29 to wire the orchestrator.

🤖 Generated with [Claude Code](https://claude.com/claude-code)