### PR TITLE
feat(events): SerpAPI proxy + findHealthEvents tool

### DIFF
--- a/app/api/events/route.test.ts
+++ b/app/api/events/route.test.ts
@@ -1,0 +1,85 @@
+import { server } from "@/test-utils/server";
+import { http, HttpResponse } from "msw";
+import { describe, expect, it } from "vitest";
+import { GET } from "./route";
+
+const SERPAPI_URL = "https://serpapi.com/search";
+
+function makeRequest(path: string): Request {
+  return new Request(`http://localhost${path}`);
+}
+
+describe("GET /api/events", () => {
+  it("returns 200 with events array", async () => {
+    server.use(
+      http.get(SERPAPI_URL, () =>
+        HttpResponse.json({
+          events_results: [
+            {
+              title: "Women's Health Fair",
+              date: { when: "May 10, 2026" },
+              address: ["Sydney"],
+              link: "https://example.com/1",
+              description: null,
+            },
+          ],
+        })
+      )
+    );
+    const res = await GET(makeRequest("/api/events?location=Sydney"));
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { events: unknown[] };
+    expect(Array.isArray(body.events)).toBe(true);
+    expect(body.events).toHaveLength(1);
+  });
+
+  it("returns 400 when location is missing", async () => {
+    const res = await GET(makeRequest("/api/events"));
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 400 when location is empty string", async () => {
+    const res = await GET(makeRequest("/api/events?location="));
+    expect(res.status).toBe(400);
+  });
+
+  it("rejects max above 10 with 400", async () => {
+    const res = await GET(makeRequest("/api/events?location=Sydney&max=999"));
+    expect(res.status).toBe(400);
+  });
+
+  it("rejects non-numeric max with 400", async () => {
+    const res = await GET(makeRequest("/api/events?location=Sydney&max=abc"));
+    expect(res.status).toBe(400);
+  });
+
+  it("returns empty events + error flag on upstream 500", async () => {
+    server.use(http.get(SERPAPI_URL, () => new HttpResponse(null, { status: 500 })));
+    const res = await GET(makeRequest("/api/events?location=Sydney"));
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { events: unknown[]; error?: string };
+    expect(body.events).toEqual([]);
+    expect(body.error).toBe("unavailable");
+  });
+
+  it("never echoes the SerpAPI key in the response", async () => {
+    server.use(
+      http.get(SERPAPI_URL, () =>
+        HttpResponse.json({
+          events_results: [
+            {
+              title: "T",
+              date: { when: "May 10" },
+              address: ["X"],
+              link: "https://example.com/x",
+              description: null,
+            },
+          ],
+        })
+      )
+    );
+    const res = await GET(makeRequest("/api/events?location=Sydney"));
+    const text = await res.text();
+    expect(text).not.toContain("test-serpapi-key");
+  });
+});

--- a/app/api/events/route.ts
+++ b/app/api/events/route.ts
@@ -1,0 +1,26 @@
+import { searchEventsApi } from "@/lib/events/search-events";
+import { eventsQuerySchema } from "@/lib/validations/events";
+
+export async function GET(request: Request) {
+  const { searchParams } = new URL(request.url);
+  const parsed = eventsQuerySchema.safeParse({
+    location: searchParams.get("location") ?? undefined,
+    q: searchParams.get("q") ?? undefined,
+    max: searchParams.get("max") ?? undefined,
+  });
+
+  if (!parsed.success) {
+    return Response.json({ error: "invalid_request" }, { status: 400 });
+  }
+
+  const events = await searchEventsApi({
+    location: parsed.data.location,
+    query: parsed.data.q,
+    max_results: parsed.data.max,
+  });
+
+  if (events.length === 0) {
+    return Response.json({ events: [], error: "unavailable" });
+  }
+  return Response.json({ events });
+}

--- a/lib/events/search-events.test.ts
+++ b/lib/events/search-events.test.ts
@@ -1,0 +1,199 @@
+import { server } from "@/test-utils/server";
+import { http, HttpResponse } from "msw";
+import { describe, expect, it } from "vitest";
+import { searchEventsApi } from "./search-events";
+
+const SERPAPI_URL = "https://serpapi.com/search";
+
+describe("searchEventsApi", () => {
+  it("returns up to max_results events, normalized", async () => {
+    server.use(
+      http.get(SERPAPI_URL, () =>
+        HttpResponse.json({
+          events_results: [
+            {
+              title: "Women's Health Fair",
+              date: { when: "Sat, May 10, 2026" },
+              address: ["123 Main St", "Sydney NSW"],
+              link: "https://example.com/event-1",
+              description: "Free screenings and Q&A",
+            },
+            {
+              title: "HPV Awareness Talk",
+              date: { when: "Sun, May 11, 2026" },
+              address: ["Town Hall", "Sydney NSW"],
+              link: "https://example.com/event-2",
+              description: null,
+            },
+          ],
+        })
+      )
+    );
+
+    const events = await searchEventsApi({ location: "Sydney", max_results: 5 });
+    expect(events).toHaveLength(2);
+    expect(events[0]).toEqual({
+      name: "Women's Health Fair",
+      date: "Sat, May 10, 2026",
+      location: "123 Main St, Sydney NSW",
+      url: "https://example.com/event-1",
+      description: "Free screenings and Q&A",
+    });
+    expect(events[1].description).toBeNull();
+  });
+
+  it("respects max_results when upstream returns more", async () => {
+    server.use(
+      http.get(SERPAPI_URL, () =>
+        HttpResponse.json({
+          events_results: Array.from({ length: 8 }, (_, i) => ({
+            title: `Event ${i}`,
+            date: { when: "May 10" },
+            address: ["X"],
+            link: `https://example.com/${i}`,
+            description: null,
+          })),
+        })
+      )
+    );
+    const events = await searchEventsApi({ location: "Sydney", max_results: 3 });
+    expect(events).toHaveLength(3);
+  });
+
+  it("returns empty array on empty upstream", async () => {
+    server.use(http.get(SERPAPI_URL, () => HttpResponse.json({ events_results: [] })));
+    const events = await searchEventsApi({ location: "Sydney" });
+    expect(events).toEqual([]);
+  });
+
+  it("returns empty array when upstream omits events_results", async () => {
+    server.use(http.get(SERPAPI_URL, () => HttpResponse.json({})));
+    const events = await searchEventsApi({ location: "Sydney" });
+    expect(events).toEqual([]);
+  });
+
+  it("returns empty array on upstream 500", async () => {
+    server.use(http.get(SERPAPI_URL, () => new HttpResponse(null, { status: 500 })));
+    const events = await searchEventsApi({ location: "Sydney" });
+    expect(events).toEqual([]);
+  });
+
+  it("returns empty array on network failure", async () => {
+    server.use(http.get(SERPAPI_URL, () => HttpResponse.error()));
+    const events = await searchEventsApi({ location: "Sydney" });
+    expect(events).toEqual([]);
+  });
+
+  it("returns empty array when location is missing", async () => {
+    let called = false;
+    server.use(
+      http.get(SERPAPI_URL, () => {
+        called = true;
+        return HttpResponse.json({ events_results: [] });
+      })
+    );
+    const events = await searchEventsApi({ location: "" });
+    expect(events).toEqual([]);
+    expect(called).toBe(false);
+  });
+
+  it("forwards location and adds health-domain keywords to upstream q", async () => {
+    let captured = "";
+    server.use(
+      http.get(SERPAPI_URL, ({ request }) => {
+        captured = request.url;
+        return HttpResponse.json({ events_results: [] });
+      })
+    );
+    await searchEventsApi({ location: "Sydney NSW", query: "cancer" });
+    const params = new URL(captured).searchParams;
+    expect(params.get("location")).toBe("Sydney NSW");
+    expect(params.get("engine")).toBe("google_events");
+    const q = params.get("q") ?? "";
+    expect(q.toLowerCase()).toContain("cancer");
+    expect(q.toLowerCase()).toContain("women's health");
+  });
+
+  it("never echoes the SerpAPI key in returned data", async () => {
+    server.use(
+      http.get(SERPAPI_URL, () =>
+        HttpResponse.json({
+          events_results: [
+            {
+              title: "x",
+              date: { when: "x" },
+              address: ["x"],
+              link: "https://example.com/x",
+              description: null,
+            },
+          ],
+        })
+      )
+    );
+    const events = await searchEventsApi({ location: "Sydney" });
+    expect(JSON.stringify(events)).not.toContain("test-serpapi-key");
+  });
+
+  it("skips items missing required fields (title/link/date/address)", async () => {
+    server.use(
+      http.get(SERPAPI_URL, () =>
+        HttpResponse.json({
+          events_results: [
+            {
+              title: "ok",
+              date: { when: "May 10" },
+              address: ["A"],
+              link: "https://a.com",
+              description: null,
+            },
+            {
+              title: "no-link",
+              date: { when: "May 10" },
+              address: ["A"],
+              link: null,
+              description: null,
+            },
+            {
+              title: "no-date",
+              date: null,
+              address: ["A"],
+              link: "https://b.com",
+              description: null,
+            },
+            {
+              title: null,
+              date: { when: "May 10" },
+              address: ["A"],
+              link: "https://c.com",
+              description: null,
+            },
+          ],
+        })
+      )
+    );
+    const events = await searchEventsApi({ location: "Sydney" });
+    expect(events).toHaveLength(1);
+    expect(events[0].name).toBe("ok");
+  });
+
+  it("falls back to empty location string when address array missing", async () => {
+    server.use(
+      http.get(SERPAPI_URL, () =>
+        HttpResponse.json({
+          events_results: [
+            {
+              title: "T",
+              date: { when: "May 10" },
+              address: null,
+              link: "https://a.com",
+              description: null,
+            },
+          ],
+        })
+      )
+    );
+    const events = await searchEventsApi({ location: "Sydney" });
+    expect(events).toHaveLength(1);
+    expect(events[0].location).toBe("");
+  });
+});

--- a/lib/events/search-events.ts
+++ b/lib/events/search-events.ts
@@ -1,0 +1,93 @@
+import { env } from "@/lib/env";
+import type { HealthEvent } from "@/lib/validations/events";
+
+const SERPAPI_ENDPOINT = "https://serpapi.com/search";
+const HEALTH_DOMAIN_BASE = "women's health OR cervical screening OR HPV";
+
+export type SearchEventsInput = {
+  location: string;
+  query?: string;
+  max_results?: number;
+};
+
+type UpstreamEvent = {
+  title?: string | null;
+  date?: { when?: string | null } | null;
+  address?: string[] | null;
+  link?: string | null;
+  description?: string | null;
+};
+
+type UpstreamResponse = {
+  events_results?: UpstreamEvent[];
+};
+
+/**
+ * Single source of truth for the SerpAPI Google Events call.
+ * Used directly by the events agent's tool wrapper and by the `/api/events`
+ * proxy. Never throws — always resolves to an array (empty on any failure)
+ * so callers can degrade gracefully without try/catch boilerplate.
+ *
+ * Returns `[]` immediately when `location` is empty: SerpAPI requires it,
+ * and we'd rather skip the round-trip than burn quota on a guaranteed-empty
+ * search.
+ */
+export async function searchEventsApi({
+  location,
+  query = "",
+  max_results = 5,
+}: SearchEventsInput): Promise<HealthEvent[]> {
+  const trimmedLocation = location.trim();
+  if (!trimmedLocation) return [];
+
+  const max = Math.min(Math.max(max_results, 1), 10);
+  const userQuery = query.trim();
+  const q = userQuery ? `(${userQuery}) AND (${HEALTH_DOMAIN_BASE})` : HEALTH_DOMAIN_BASE;
+
+  const url = new URL(SERPAPI_ENDPOINT);
+  url.searchParams.set("engine", "google_events");
+  url.searchParams.set("q", q);
+  url.searchParams.set("location", trimmedLocation);
+  url.searchParams.set("num", String(max));
+  url.searchParams.set("api_key", env.serpapiKey);
+
+  let upstream: Response;
+  try {
+    upstream = await fetch(url, { headers: { Accept: "application/json" } });
+  } catch (err) {
+    console.error("[events] upstream fetch failed:", err instanceof Error ? err.message : err);
+    return [];
+  }
+
+  if (!upstream.ok) {
+    console.error(`[events] upstream non-2xx: ${upstream.status}`);
+    return [];
+  }
+
+  let data: UpstreamResponse;
+  try {
+    data = (await upstream.json()) as UpstreamResponse;
+  } catch {
+    return [];
+  }
+
+  if (!Array.isArray(data.events_results)) return [];
+
+  const normalized: HealthEvent[] = [];
+  for (const e of data.events_results) {
+    const name = e.title?.trim();
+    const url = e.link?.trim();
+    const date = e.date?.when?.trim();
+    if (!name || !url || !date) continue;
+    const address = Array.isArray(e.address) ? e.address.filter(Boolean).join(", ") : "";
+    normalized.push({
+      name,
+      date,
+      location: address,
+      url,
+      description: e.description ?? null,
+    });
+    if (normalized.length >= max) break;
+  }
+  return normalized;
+}

--- a/lib/tools/events.test.ts
+++ b/lib/tools/events.test.ts
@@ -1,0 +1,56 @@
+import { server } from "@/test-utils/server";
+import { http, HttpResponse } from "msw";
+import { describe, expect, it } from "vitest";
+import { findHealthEvents } from "./events";
+
+const SERPAPI_URL = "https://serpapi.com/search";
+
+describe("findHealthEvents", () => {
+  it("returns parsed events on success", async () => {
+    server.use(
+      http.get(SERPAPI_URL, () =>
+        HttpResponse.json({
+          events_results: [
+            {
+              title: "Women's Health Fair",
+              date: { when: "May 10, 2026" },
+              address: ["Town Hall", "Sydney"],
+              link: "https://example.com/1",
+              description: "summary",
+            },
+          ],
+        })
+      )
+    );
+    const events = await findHealthEvents({ location: "Sydney" });
+    expect(events).toHaveLength(1);
+    expect(events[0].name).toBe("Women's Health Fair");
+  });
+
+  it("returns empty array on upstream failure (does not throw)", async () => {
+    server.use(http.get(SERPAPI_URL, () => new HttpResponse(null, { status: 500 })));
+    await expect(findHealthEvents({ location: "Sydney" })).resolves.toEqual([]);
+  });
+
+  it("returns empty array when location missing", async () => {
+    await expect(findHealthEvents({ location: "" })).resolves.toEqual([]);
+  });
+
+  it("defaults max_results to 5", async () => {
+    server.use(
+      http.get(SERPAPI_URL, () =>
+        HttpResponse.json({
+          events_results: Array.from({ length: 8 }, (_, i) => ({
+            title: `E${i}`,
+            date: { when: "May 10" },
+            address: ["X"],
+            link: `https://example.com/${i}`,
+            description: null,
+          })),
+        })
+      )
+    );
+    const events = await findHealthEvents({ location: "Sydney" });
+    expect(events).toHaveLength(5);
+  });
+});

--- a/lib/tools/events.ts
+++ b/lib/tools/events.ts
@@ -1,0 +1,17 @@
+import { searchEventsApi } from "@/lib/events/search-events";
+import type { HealthEvent } from "@/lib/validations/events";
+
+export type FindHealthEventsInput = {
+  location: string;
+  query?: string;
+  max_results?: number;
+};
+
+/**
+ * Events Agent's tool wrapper. Surfaces the same data the `/api/events` proxy
+ * returns — both share `searchEventsApi`. Never throws; returns `[]` on any
+ * failure (including missing location).
+ */
+export async function findHealthEvents(input: FindHealthEventsInput): Promise<HealthEvent[]> {
+  return searchEventsApi(input);
+}

--- a/lib/validations/events.ts
+++ b/lib/validations/events.ts
@@ -1,0 +1,19 @@
+import { z } from "zod";
+
+export const eventsQuerySchema = z.object({
+  location: z.string().trim().min(1, "location is required").max(200),
+  q: z.string().trim().max(200).optional().default(""),
+  max: z.coerce.number().int().min(1).max(10).optional().default(5),
+});
+
+export type EventsQuery = z.infer<typeof eventsQuerySchema>;
+
+export const healthEventSchema = z.object({
+  name: z.string(),
+  date: z.string(),
+  location: z.string(),
+  url: z.string().url(),
+  description: z.string().nullable(),
+});
+
+export type HealthEvent = z.infer<typeof healthEventSchema>;


### PR DESCRIPTION
## Summary
- `lib/events/search-events.ts` — single shared SerpAPI Google Events caller with the fixed health-domain keyword base, location short-circuit, and graceful empty-array fallback on all upstream errors
- `app/api/events/route.ts` — GET handler with Zod-validated `location` (required), `q?`, `max?` (1-10)
- `lib/tools/events.ts` — `findHealthEvents` tool wrapper for the upcoming Events Agent (#66)
- `lib/validations/events.ts` — Zod schemas for `HealthEvent` + query params

## Design note
Same architecture as the news pair (#63/#67): tool calls `searchEventsApi` directly rather than self-fetching `/api/events`. Both run server-side, so the proxy hop adds latency without further protecting the API key. The route still exists for future browser callers.

`searchEventsApi` short-circuits to `[]` when `location` is empty — SerpAPI requires it, and we'd rather skip the round-trip than burn quota on a guaranteed-empty search.

## Test plan
- [x] `pnpm test` — 22 new tests + full suite green (271 passed)
- [x] `pnpm biome check .` clean
- [x] `pnpm build` succeeds
- Tests cover: success, empty upstream, missing `events_results`, upstream 5xx, network failure, missing location (no upstream call), keyword base appended, key non-leakage, malformed-item filtering, address join, route Zod validation (missing/empty location, max bounds, non-numeric max)

Closes #65

🤖 Generated with [Claude Code](https://claude.com/claude-code)