### PR TITLE
feat(agents): runEventsAgent

### DIFF
--- a/lib/agents/events-agent.test.ts
+++ b/lib/agents/events-agent.test.ts
@@ -1,0 +1,165 @@
+// @vitest-environment node
+
+import type { HealthEvent } from "@/lib/validations/events";
+import { beforeEach, describe, expect, test, vi } from "vitest";
+
+vi.mock("@/lib/tools/events", () => ({
+  findHealthEvents: vi.fn(),
+}));
+
+import { findHealthEvents } from "@/lib/tools/events";
+import { runEventsAgent } from "./events-agent";
+
+function ev(overrides: Partial<HealthEvent> = {}): HealthEvent {
+  return {
+    name: "Women's Health Fair",
+    date: "Sat, May 10, 2026",
+    location: "Sydney NSW",
+    url: "https://example.com/event-1",
+    description: "Free screenings",
+    ...overrides,
+  };
+}
+
+describe("runEventsAgent", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(findHealthEvents).mockResolvedValue([]);
+  });
+
+  test("calls findHealthEvents with caller-provided locale as location", async () => {
+    await runEventsAgent({ userMessage: "any health events?", locale: "Sydney" });
+
+    expect(findHealthEvents).toHaveBeenCalledTimes(1);
+    expect(findHealthEvents).toHaveBeenCalledWith({
+      location: "Sydney",
+      query: "any health events?",
+      max_results: 5,
+    });
+  });
+
+  test("extracts location from userMessage when locale not provided", async () => {
+    await runEventsAgent({ userMessage: "screening events in Melbourne next week?" });
+
+    expect(findHealthEvents).toHaveBeenCalledWith(
+      expect.objectContaining({ location: "Melbourne" })
+    );
+  });
+
+  test("supports 'near <Place>' phrasing", async () => {
+    await runEventsAgent({ userMessage: "any HPV events near Brisbane this month" });
+
+    expect(findHealthEvents).toHaveBeenCalledWith(
+      expect.objectContaining({ location: "Brisbane" })
+    );
+  });
+
+  test("prefers locale over a location mentioned in userMessage", async () => {
+    await runEventsAgent({
+      userMessage: "events in Melbourne?",
+      locale: "Sydney",
+    });
+
+    expect(findHealthEvents).toHaveBeenCalledWith(expect.objectContaining({ location: "Sydney" }));
+  });
+
+  test("returns needsLocation=true and empty result when neither locale nor extractable location", async () => {
+    const result = await runEventsAgent({ userMessage: "any health events soon?" });
+
+    expect(findHealthEvents).not.toHaveBeenCalled();
+    expect(result).toEqual({
+      eventsContext: "",
+      eventsSources: [],
+      needsLocation: true,
+    });
+  });
+
+  test("returns empty result when tool returns []", async () => {
+    vi.mocked(findHealthEvents).mockResolvedValue([]);
+
+    const result = await runEventsAgent({ userMessage: "x", locale: "Sydney" });
+
+    expect(result).toEqual({ eventsContext: "", eventsSources: [] });
+    expect(result).not.toHaveProperty("needsLocation", true);
+  });
+
+  test("formats a single event with [1] marker, name, date, location", async () => {
+    vi.mocked(findHealthEvents).mockResolvedValue([
+      ev({
+        name: "Women's Health Fair",
+        date: "Sat, May 10, 2026",
+        location: "Town Hall, Sydney NSW",
+        url: "https://example.com/1",
+      }),
+    ]);
+
+    const result = await runEventsAgent({ userMessage: "x", locale: "Sydney" });
+
+    expect(result.eventsContext).toContain("[1]");
+    expect(result.eventsContext).toContain("Women's Health Fair");
+    expect(result.eventsContext).toContain("Sat, May 10, 2026");
+    expect(result.eventsContext).toContain("Town Hall, Sydney NSW");
+    expect(result.eventsSources).toEqual([
+      {
+        id: "1",
+        title: "Women's Health Fair",
+        url: "https://example.com/1",
+        chunkId: "events:https://example.com/1",
+      },
+    ]);
+  });
+
+  test("formats multiple events with sequential markers and blank-line separators", async () => {
+    vi.mocked(findHealthEvents).mockResolvedValue([
+      ev({ name: "A", url: "https://a.com" }),
+      ev({ name: "B", url: "https://b.com" }),
+      ev({ name: "C", url: "https://c.com" }),
+    ]);
+
+    const result = await runEventsAgent({ userMessage: "x", locale: "Sydney" });
+
+    expect(result.eventsContext).toMatch(/\[1\][\s\S]*\[2\][\s\S]*\[3\]/);
+    expect(result.eventsContext).toContain("\n\n");
+    expect(result.eventsSources.map((s) => s.id)).toEqual(["1", "2", "3"]);
+  });
+
+  test("includes description when present", async () => {
+    vi.mocked(findHealthEvents).mockResolvedValue([ev({ description: "Free screenings and Q&A" })]);
+
+    const result = await runEventsAgent({ userMessage: "x", locale: "Sydney" });
+
+    expect(result.eventsContext).toContain("Free screenings and Q&A");
+  });
+
+  test("omits description gracefully when null", async () => {
+    vi.mocked(findHealthEvents).mockResolvedValue([ev({ description: null, name: "T" })]);
+
+    const result = await runEventsAgent({ userMessage: "x", locale: "Sydney" });
+
+    expect(result.eventsContext).not.toContain("null");
+    expect(result.eventsContext).toContain("T");
+  });
+
+  test("uses url-keyed chunkId for citation deduplication", async () => {
+    vi.mocked(findHealthEvents).mockResolvedValue([ev({ url: "https://x.com/event-42" })]);
+
+    const result = await runEventsAgent({ userMessage: "x", locale: "Sydney" });
+
+    expect(result.eventsSources[0].chunkId).toBe("events:https://x.com/event-42");
+  });
+
+  test("never throws — degrades to empty when tool unexpectedly throws", async () => {
+    vi.mocked(findHealthEvents).mockRejectedValueOnce(new Error("boom"));
+
+    await expect(runEventsAgent({ userMessage: "x", locale: "Sydney" })).resolves.toEqual({
+      eventsContext: "",
+      eventsSources: [],
+    });
+  });
+
+  test("trims whitespace-only locale and falls back to extraction", async () => {
+    await runEventsAgent({ userMessage: "events in Perth", locale: "   " });
+
+    expect(findHealthEvents).toHaveBeenCalledWith(expect.objectContaining({ location: "Perth" }));
+  });
+});

--- a/lib/agents/events-agent.ts
+++ b/lib/agents/events-agent.ts
@@ -1,0 +1,95 @@
+import { findHealthEvents } from "@/lib/tools/events";
+import type { HealthEvent } from "@/lib/validations/events";
+import type { Source } from "@/types/agents";
+
+const MAX_RESULTS = 5;
+
+// Dumb v1 location extractor: pulls a Capitalized place after "in/near/around/at".
+// Stops at end of string or sentence punctuation. Good enough for the common
+// phrasings ("events in Sydney", "near Brisbane?"); intentionally not trying
+// NER. The orchestrator can ask for clarification when this misses.
+const LOCATION_HINT_RE = /\b(?:in|near|around|at)\s+([A-Z][A-Za-z]+(?:\s+[A-Z][A-Za-z]+)*)/;
+
+export type EventsAgentContext = {
+  /** The new user turn — also used as the search query and for location extraction. */
+  userMessage: string;
+  /** `profiles.locale`. Preferred over location extracted from the message. */
+  locale?: string | null;
+};
+
+export type EventsAgentResult = {
+  /**
+   * Numbered concatenation of events with `[1]`, `[2]` markers matching
+   * `eventsSources`. Empty string when no events were returned or the agent
+   * could not resolve a location. Consumed by the response agent under an
+   * "Upcoming events:" header.
+   */
+  eventsContext: string;
+  /**
+   * Citation chips. `chunkId` is `events:<url>` so the chip renderer dedupes
+   * across turns even though events have no DB row.
+   */
+  eventsSources: Source[];
+  /**
+   * Set when the agent could not resolve a location at all. The orchestrator
+   * uses this to swap in a "what city are you in?" follow-up rather than the
+   * generic "no events found" line.
+   */
+  needsLocation?: boolean;
+};
+
+/**
+ * Events agent — resolves a location, calls `findHealthEvents`, and shapes
+ * results into the same `{ context, sources }` envelope the RAG and News
+ * agents return so downstream code is uniform.
+ *
+ * Location precedence: caller-provided `locale` (from `profiles.locale`) →
+ * naive extraction from `userMessage` → `needsLocation: true` (empty result).
+ */
+export async function runEventsAgent(ctx: EventsAgentContext): Promise<EventsAgentResult> {
+  const location = resolveLocation(ctx);
+  if (!location) {
+    return { eventsContext: "", eventsSources: [], needsLocation: true };
+  }
+
+  let events: HealthEvent[] = [];
+  try {
+    events = await findHealthEvents({
+      location,
+      query: ctx.userMessage,
+      max_results: MAX_RESULTS,
+    });
+  } catch (err) {
+    console.error(
+      "[events-agent] findHealthEvents unexpectedly threw:",
+      err instanceof Error ? err.message : err
+    );
+    return { eventsContext: "", eventsSources: [] };
+  }
+
+  if (events.length === 0) {
+    return { eventsContext: "", eventsSources: [] };
+  }
+
+  const eventsSources: Source[] = events.map((e, i) => ({
+    id: String(i + 1),
+    title: e.name,
+    url: e.url,
+    chunkId: `events:${e.url}`,
+  }));
+  const eventsContext = events.map((e, i) => formatEvent(e, i + 1)).join("\n\n");
+
+  return { eventsContext, eventsSources };
+}
+
+function resolveLocation(ctx: EventsAgentContext): string | null {
+  const fromLocale = ctx.locale?.trim();
+  if (fromLocale) return fromLocale;
+  const match = ctx.userMessage.match(LOCATION_HINT_RE);
+  return match ? match[1].trim() : null;
+}
+
+function formatEvent(event: HealthEvent, marker: number): string {
+  const head = `[${marker}] ${event.name} — ${event.date} (${event.location})`;
+  return event.description ? `${head}\n${event.description}` : head;
+}


### PR DESCRIPTION
## Summary
- `lib/agents/events-agent.ts` — pure agent that resolves a location, calls `findHealthEvents` (#65), and shapes results into the `{ context, sources }` envelope used by the RAG and News agents
- Location precedence: caller-provided `locale` → naive `\\b(?:in|near|around|at)\\s+<Capitalized Place>` extraction from `userMessage` → empty result with `needsLocation: true`
- `Source[]` keyed by URL (`chunkId: "events:<url>"`) so the existing citation chip renderer dedupes across turns without DB rows
- Defensively wraps the tool call so a contract drift returns `{ eventsContext: "", eventsSources: [] }` instead of throwing

## Design notes
- **`needsLocation` flag**: distinguishes "I couldn't ask the upstream" from "the upstream returned nothing". The orchestrator (#29) will use it to swap in a "what city are you in?" follow-up rather than the generic "no events found" line.
- **Naive location extractor**: intentionally not full NER. Catches the common phrasings ("events in Sydney", "near Brisbane") and lets the orchestrator ask for clarification when it misses. Easy to swap out later if needed.
- **`locale` precedence over message**: matches the AC. If a user has set their location in their profile, that's a stronger signal than a passing mention in the current turn.

## Test plan
- [x] `pnpm test` — 13 new tests + full suite green (284 passed)
- [x] `pnpm biome check .` clean
- [x] `pnpm build` succeeds
- Tests cover: locale wins over message extraction; "in/near" extraction; needsLocation when neither; whitespace-only locale; tool-empty path; throw-fallback; single + multi event formatting; description present/absent; chunkId derivation

Closes #66

Next: #29 to wire the orchestrator.

🤖 Generated with [Claude Code](https://claude.com/claude-code)