### PR TITLE
feat(orchestrator): wire news_request and events_request dispatch

### DIFF
--- a/app/api/chat/route.ts
+++ b/app/api/chat/route.ts
@@ -55,6 +55,16 @@ export async function POST(request: Request) {
     return Response.json({ error: "history_load_failed" }, { status: 500 });
   }
 
+  // 4a. Best-effort locale lookup for the events agent's location hint. A
+  //     missing or failed read is fine — the agent gracefully prompts the
+  //     user for a city.
+  const { data: profile } = await supabase
+    .from("profiles")
+    .select("locale")
+    .eq("id", user.id)
+    .maybeSingle();
+  const locale = profile?.locale ?? null;
+
   // 5. Persist the user message BEFORE calling Claude — durability over speed.
   //    The chat_sessions.updated_at trigger from #24 fires here so the
   //    sidebar reflects activity even if Claude fails.
@@ -90,6 +100,7 @@ export async function POST(request: Request) {
         for await (const chunk of runOrchestrator(supabase, {
           userMessage,
           history,
+          locale,
         })) {
           if (chunk.type === "text") {
             assistantText += chunk.text;

--- a/docs/api-routes.md
+++ b/docs/api-routes.md
@@ -8,7 +8,7 @@ All route handlers are in `app/api/` using Next.js App Router conventions (`rout
 |---|---|---|---|
 | `/api/chat` | POST | `user` | Main agent orchestration entry point. Streams token-by-token. |
 | `/api/chat/[sessionId]` | GET | `user` | Fetch message history for a session. |
-| `/api/clinics/search` | GET | None (public) | Proxy to Google Places Text Search API. |
+| `/api/clinics/search` | GET | None (public) | Proxy to Google Places API (New) — Text Search endpoint. |
 | `/api/news` | GET | None (public) | Proxy to NewsAPI. Keeps `NEWS_API_KEY` server-side. |
 | `/api/events` | GET | None (public) | Proxy to SerpAPI Google Events. Keeps `SERPAPI_KEY` server-side. |
 | `/api/embeddings/ingest` | POST | `admin` | Ingest a knowledge document into pgvector. |
@@ -23,8 +23,13 @@ All route handlers are in `app/api/` using Next.js App Router conventions (`rout
 
 **Auth:** `user` role required  
 **Body:** `{ sessionId: string, message: string }`  
-**Response:** Streamed text (token-by-token)  
-**Notes:** Entry point for the full agent pipeline. Orchestrator classifies intent and routes to RAG, News, or Events Agent. Response Agent streams the final reply.
+**Response:** Streamed NDJSON of `start` / `text` / `sources` / `done` / `error` events.  
+**Notes:** Entry point for the full agent pipeline. The orchestrator classifies intent and dispatches:
+
+- `health_question` → RAG agent → response agent (RAG chunks injected as grounding context)
+- `news_request` → news agent → response agent (news headlines injected as grounding context). Static fallback text when NewsAPI returns nothing.
+- `events_request` → events agent → response agent (events injected as grounding context). The route reads `profiles.locale` and threads it as a location hint. Static fallback text when (a) no location can be resolved, or (b) SerpAPI returns nothing.
+- `general_chat` → response agent directly
 
 ### `GET /api/chat/[sessionId]`
 
@@ -35,7 +40,7 @@ All route handlers are in `app/api/` using Next.js App Router conventions (`rout
 
 **Auth:** None  
 **Query params:** `location: string`, `keyword?: string`  
-**Proxied to:** Google Places Text Search API (`NEXT_PUBLIC_GOOGLE_MAPS_KEY` injected server-side)  
+**Proxied to:** Google Places API (New) — Text Search (`POST https://places.googleapis.com/v1/places:searchText`). `NEXT_PUBLIC_GOOGLE_MAPS_KEY` injected server-side via `X-Goog-Api-Key` header. Field mask set via `X-Goog-FieldMask` header.  
 **Response:** `{ clinics: ClinicResult[] }`  
 **Notes:** The `/clinics` UI page calls this directly — no agent involvement.
 
@@ -83,4 +88,4 @@ All external API keys are server-side only. Never expose them in the response bo
 Browser → /api/<service> → External API (key injected server-side only)
 ```
 
-Services using this pattern: Google Places, NewsAPI, SerpAPI.
+Services using this pattern: Google Places API (New), NewsAPI, SerpAPI.

--- a/lib/agents/orchestrator.test.ts
+++ b/lib/agents/orchestrator.test.ts
@@ -143,6 +143,8 @@ describe("classifyIntent", () => {
   });
 });
 
+import { runEventsAgent } from "@/lib/agents/events-agent";
+import { runNewsAgent } from "@/lib/agents/news-agent";
 import { runRagAgent } from "@/lib/agents/rag-agent";
 import { type AgentChunk, runResponseAgent } from "@/lib/agents/response-agent";
 import type { ChatHistoryMessage } from "@/lib/ai/context-window";
@@ -153,6 +155,14 @@ vi.mock("@/lib/agents/response-agent", () => ({
 
 vi.mock("@/lib/agents/rag-agent", () => ({
   runRagAgent: vi.fn(),
+}));
+
+vi.mock("@/lib/agents/news-agent", () => ({
+  runNewsAgent: vi.fn(),
+}));
+
+vi.mock("@/lib/agents/events-agent", () => ({
+  runEventsAgent: vi.fn(),
 }));
 
 import { type OrchestratorContext, runOrchestrator } from "./orchestrator";
@@ -206,7 +216,7 @@ describe("runOrchestrator", () => {
 
   // ───── health_question ─────────────────────────────────────────────────
 
-  test("health_question: calls runRagAgent and threads ragContext + ragSources into the response agent", async () => {
+  test("health_question: calls runRagAgent and threads grounding fields into the response agent", async () => {
     vi.mocked(getAnthropicClient).mockReturnValue(mockAnthropicCreate("health_question") as never);
     const ragContext = "[1] (Source A) HPV is a common virus.";
     const ragSources = [{ id: "1", title: "Source A", chunkId: "uuid-1" }];
@@ -228,8 +238,8 @@ describe("runOrchestrator", () => {
     expect(runResponseAgent).toHaveBeenCalledWith({
       userMessage: baseCtx.userMessage,
       history: baseCtx.history,
-      ragContext,
-      ragSources,
+      groundingContext: ragContext,
+      groundingSources: ragSources,
     });
     expect(chunks).toEqual([
       { type: "text", text: "HPV is..." },
@@ -237,7 +247,7 @@ describe("runOrchestrator", () => {
     ]);
   });
 
-  test("health_question with empty RAG result: still calls response agent (with empty ragContext/ragSources)", async () => {
+  test("health_question with empty RAG result: still calls response agent with empty grounding fields", async () => {
     vi.mocked(getAnthropicClient).mockReturnValue(mockAnthropicCreate("health_question") as never);
     vi.mocked(runRagAgent).mockResolvedValue({ ragContext: "", ragSources: [] });
     vi.mocked(runResponseAgent).mockReturnValue(
@@ -249,8 +259,8 @@ describe("runOrchestrator", () => {
     expect(runResponseAgent).toHaveBeenCalledWith({
       userMessage: baseCtx.userMessage,
       history: baseCtx.history,
-      ragContext: "",
-      ragSources: [],
+      groundingContext: "",
+      groundingSources: [],
     });
   });
 
@@ -291,34 +301,144 @@ describe("runOrchestrator", () => {
     consoleInfoSpy.mockRestore();
   });
 
-  // ───── news_request / events_request stubs ─────────────────────────────
+  // ───── news_request ───────────────────────────────────────────────────
 
-  test("news_request: yields a stub text chunk; never calls RAG or response agent", async () => {
+  test("news_request with results: calls runNewsAgent and threads grounding fields into response agent", async () => {
     vi.mocked(getAnthropicClient).mockReturnValue(mockAnthropicCreate("news_request") as never);
+    const newsContext = "[1] HPV vaccine update — BBC Health (2026-04-30)";
+    const newsSources = [
+      {
+        id: "1",
+        title: "HPV vaccine update",
+        url: "https://bbc.example/1",
+        chunkId: "news:https://bbc.example/1",
+      },
+    ];
+    vi.mocked(runNewsAgent).mockResolvedValue({ newsContext, newsSources });
+    vi.mocked(runResponseAgent).mockReturnValue(
+      fakeAgentStream([
+        { type: "text", text: "Here is what's recent..." },
+        { type: "sources", sources: newsSources },
+      ]) as never
+    );
 
     const chunks = await collectOrchestrator(baseCtx);
 
-    expect(runRagAgent).not.toHaveBeenCalled();
-    expect(runResponseAgent).not.toHaveBeenCalled();
-    expect(chunks).toHaveLength(1);
-    expect(chunks[0]).toEqual({
-      type: "text",
-      text: expect.stringContaining("news"),
-    });
+    expect(runNewsAgent).toHaveBeenCalledTimes(1);
+    expect(runNewsAgent).toHaveBeenCalledWith({ userMessage: baseCtx.userMessage });
+    expect(runResponseAgent).toHaveBeenCalledTimes(1);
+    const callArg = vi.mocked(runResponseAgent).mock.calls[0][0];
+    expect(callArg.userMessage).toBe(baseCtx.userMessage);
+    expect(callArg.history).toBe(baseCtx.history);
+    expect(callArg.groundingContext).toContain("Recent news");
+    expect(callArg.groundingContext).toContain(newsContext);
+    expect(callArg.groundingSources).toEqual(newsSources);
+    expect(chunks).toEqual([
+      { type: "text", text: "Here is what's recent..." },
+      { type: "sources", sources: newsSources },
+    ]);
   });
 
-  test("events_request: yields a stub text chunk; never calls RAG or response agent", async () => {
-    vi.mocked(getAnthropicClient).mockReturnValue(mockAnthropicCreate("events_request") as never);
+  test("news_request with empty results: yields a fallback text chunk; skips response agent", async () => {
+    vi.mocked(getAnthropicClient).mockReturnValue(mockAnthropicCreate("news_request") as never);
+    vi.mocked(runNewsAgent).mockResolvedValue({ newsContext: "", newsSources: [] });
 
     const chunks = await collectOrchestrator(baseCtx);
 
-    expect(runRagAgent).not.toHaveBeenCalled();
     expect(runResponseAgent).not.toHaveBeenCalled();
     expect(chunks).toHaveLength(1);
-    expect(chunks[0]).toEqual({
-      type: "text",
-      text: expect.stringContaining("events"),
+    expect(chunks[0].type).toBe("text");
+    if (chunks[0].type === "text") {
+      expect(chunks[0].text.toLowerCase()).toContain("news");
+    }
+  });
+
+  test("news_request never calls runRagAgent", async () => {
+    vi.mocked(getAnthropicClient).mockReturnValue(mockAnthropicCreate("news_request") as never);
+    vi.mocked(runNewsAgent).mockResolvedValue({ newsContext: "", newsSources: [] });
+
+    await collectOrchestrator(baseCtx);
+
+    expect(runRagAgent).not.toHaveBeenCalled();
+  });
+
+  // ───── events_request ─────────────────────────────────────────────────
+
+  test("events_request with results: calls runEventsAgent and threads grounding fields into response agent", async () => {
+    vi.mocked(getAnthropicClient).mockReturnValue(mockAnthropicCreate("events_request") as never);
+    const eventsContext = "[1] Women's Health Fair — Sat, May 10, 2026 (Town Hall, Sydney NSW)";
+    const eventsSources = [
+      {
+        id: "1",
+        title: "Women's Health Fair",
+        url: "https://example.com/1",
+        chunkId: "events:https://example.com/1",
+      },
+    ];
+    vi.mocked(runEventsAgent).mockResolvedValue({ eventsContext, eventsSources });
+    vi.mocked(runResponseAgent).mockReturnValue(
+      fakeAgentStream([
+        { type: "text", text: "Upcoming nearby..." },
+        { type: "sources", sources: eventsSources },
+      ]) as never
+    );
+
+    const ctx: OrchestratorContext = { ...baseCtx, locale: "Sydney" };
+    const chunks = await collectOrchestrator(ctx);
+
+    expect(runEventsAgent).toHaveBeenCalledTimes(1);
+    expect(runEventsAgent).toHaveBeenCalledWith({
+      userMessage: ctx.userMessage,
+      locale: "Sydney",
     });
+    expect(runResponseAgent).toHaveBeenCalledTimes(1);
+    const callArg = vi.mocked(runResponseAgent).mock.calls[0][0];
+    expect(callArg.groundingContext).toContain("Upcoming events");
+    expect(callArg.groundingContext).toContain(eventsContext);
+    expect(callArg.groundingSources).toEqual(eventsSources);
+    expect(chunks).toEqual([
+      { type: "text", text: "Upcoming nearby..." },
+      { type: "sources", sources: eventsSources },
+    ]);
+  });
+
+  test("events_request with needsLocation: yields a 'which city?' fallback; skips response agent", async () => {
+    vi.mocked(getAnthropicClient).mockReturnValue(mockAnthropicCreate("events_request") as never);
+    vi.mocked(runEventsAgent).mockResolvedValue({
+      eventsContext: "",
+      eventsSources: [],
+      needsLocation: true,
+    });
+
+    const chunks = await collectOrchestrator(baseCtx);
+
+    expect(runResponseAgent).not.toHaveBeenCalled();
+    expect(chunks).toHaveLength(1);
+    if (chunks[0].type === "text") {
+      expect(chunks[0].text.toLowerCase()).toContain("city");
+    }
+  });
+
+  test("events_request with empty results (location was used): yields a fallback text chunk; skips response agent", async () => {
+    vi.mocked(getAnthropicClient).mockReturnValue(mockAnthropicCreate("events_request") as never);
+    vi.mocked(runEventsAgent).mockResolvedValue({ eventsContext: "", eventsSources: [] });
+
+    const chunks = await collectOrchestrator({ ...baseCtx, locale: "Sydney" });
+
+    expect(runResponseAgent).not.toHaveBeenCalled();
+    expect(chunks).toHaveLength(1);
+    if (chunks[0].type === "text") {
+      expect(chunks[0].text.toLowerCase()).toContain("events");
+    }
+  });
+
+  test("events_request never calls runRagAgent", async () => {
+    vi.mocked(getAnthropicClient).mockReturnValue(mockAnthropicCreate("events_request") as never);
+    vi.mocked(runEventsAgent).mockResolvedValue({ eventsContext: "", eventsSources: [] });
+
+    await collectOrchestrator({ ...baseCtx, locale: "Sydney" });
+
+    expect(runRagAgent).not.toHaveBeenCalled();
   });
 
   // ───── error propagation ───────────────────────────────────────────────

--- a/lib/agents/orchestrator.ts
+++ b/lib/agents/orchestrator.ts
@@ -77,31 +77,41 @@ function fallbackIntent(message: string): Intent {
   return "general_chat";
 }
 
+import { runEventsAgent } from "@/lib/agents/events-agent";
+import { runNewsAgent } from "@/lib/agents/news-agent";
 import { runRagAgent } from "@/lib/agents/rag-agent";
 import { type AgentChunk, runResponseAgent } from "@/lib/agents/response-agent";
 import type { ChatHistoryMessage } from "@/lib/ai/context-window";
 import type { Database } from "@/types/supabase";
 import type { SupabaseClient } from "@supabase/supabase-js";
 
-const NEWS_STUB =
-  "Latest health news support is coming soon. For now I can answer general questions about cervical health — what would you like to know?";
-const EVENTS_STUB =
-  "Health events support is coming soon. For now I can answer general questions about cervical health — what would you like to know?";
+const NEWS_EMPTY_FALLBACK =
+  "I couldn't find any recent health news right now. Try again in a bit, or ask me about cervical health topics directly.";
+const EVENTS_NEEDS_LOCATION_FALLBACK =
+  "Which city are you in? I can look up cervical health events near you.";
+const EVENTS_EMPTY_FALLBACK =
+  "I couldn't find any upcoming health events for that location right now. Try a nearby city, or check back later.";
 
 export type OrchestratorContext = {
   /** The new user turn. Same shape as the response agent's ctx. */
   userMessage: string;
   /** Prior conversation, oldest first. Does NOT include `userMessage`. */
   history: ChatHistoryMessage[];
+  /**
+   * Optional `profiles.locale` for the signed-in user. Currently only used by
+   * the events agent as a location hint; the orchestrator threads it through
+   * but does not require it.
+   */
+  locale?: string | null;
 };
 
 /**
  * Multi-agent orchestrator. Classifies the user's intent and dispatches:
  *
- * - `health_question` → `runRagAgent` → `runResponseAgent` (with ragContext + ragSources)
+ * - `health_question` → `runRagAgent` → `runResponseAgent` (with grounding fields)
+ * - `news_request`    → `runNewsAgent` → `runResponseAgent` (or static fallback when empty)
+ * - `events_request`  → `runEventsAgent` → `runResponseAgent` (or static fallback when empty / needsLocation)
  * - `general_chat`    → `runResponseAgent` directly
- * - `news_request`    → static stub text (real agent lands in #29)
- * - `events_request`  → static stub text (real agent lands in #29)
  *
  * Returns an `AsyncIterable<AgentChunk>` with the same wire shape as
  * `runResponseAgent` so the route doesn't need to know about dispatch.
@@ -131,19 +141,46 @@ export async function* runOrchestrator(
     yield* runResponseAgent({
       userMessage: ctx.userMessage,
       history: ctx.history,
-      ragContext,
-      ragSources,
+      groundingContext: ragContext,
+      groundingSources: ragSources,
     });
     return;
   }
 
   if (intent === "news_request") {
-    yield { type: "text", text: NEWS_STUB };
+    const { newsContext, newsSources } = await runNewsAgent({ userMessage: ctx.userMessage });
+    if (newsSources.length === 0) {
+      yield { type: "text", text: NEWS_EMPTY_FALLBACK };
+      return;
+    }
+    yield* runResponseAgent({
+      userMessage: ctx.userMessage,
+      history: ctx.history,
+      groundingContext: `Recent news (last 7 days):\n${newsContext}`,
+      groundingSources: newsSources,
+    });
     return;
   }
 
   if (intent === "events_request") {
-    yield { type: "text", text: EVENTS_STUB };
+    const { eventsContext, eventsSources, needsLocation } = await runEventsAgent({
+      userMessage: ctx.userMessage,
+      locale: ctx.locale,
+    });
+    if (needsLocation) {
+      yield { type: "text", text: EVENTS_NEEDS_LOCATION_FALLBACK };
+      return;
+    }
+    if (eventsSources.length === 0) {
+      yield { type: "text", text: EVENTS_EMPTY_FALLBACK };
+      return;
+    }
+    yield* runResponseAgent({
+      userMessage: ctx.userMessage,
+      history: ctx.history,
+      groundingContext: `Upcoming events:\n${eventsContext}`,
+      groundingSources: eventsSources,
+    });
     return;
   }
 

--- a/lib/agents/response-agent.test.ts
+++ b/lib/agents/response-agent.test.ts
@@ -154,7 +154,7 @@ describe("runResponseAgent", () => {
     expect(args[0].system).toBe("You are a custom assistant.");
   });
 
-  test("appends ragContext to the system prompt when provided", async () => {
+  test("appends groundingContext to the system prompt when provided", async () => {
     const anthropic = mockAnthropic({ events: [] });
     vi.mocked(getAnthropicClient).mockReturnValue(anthropic as never);
 
@@ -162,7 +162,7 @@ describe("runResponseAgent", () => {
       runResponseAgent({
         userMessage: "Hi",
         history: [],
-        ragContext: "Source 1: HPV is...",
+        groundingContext: "Source 1: HPV is...",
       })
     );
 
@@ -174,7 +174,7 @@ describe("runResponseAgent", () => {
     expect(args[0].system).toContain("Source 1: HPV is...");
   });
 
-  test("treats empty-string ragContext the same as no ragContext (no 'Retrieved context:' header)", async () => {
+  test("treats empty-string groundingContext the same as absent (no 'Retrieved context:' header)", async () => {
     const anthropic = mockAnthropic({ events: [] });
     vi.mocked(getAnthropicClient).mockReturnValue(anthropic as never);
 
@@ -182,7 +182,7 @@ describe("runResponseAgent", () => {
       runResponseAgent({
         userMessage: "Hi",
         history: [],
-        ragContext: "", // explicit empty string — the no-match-fallback case from runRagAgent
+        groundingContext: "", // explicit empty — the no-match case from runRagAgent
       })
     );
 
@@ -205,7 +205,7 @@ describe("runResponseAgent", () => {
     );
   });
 
-  test("emits a sources chunk after text when ctx.ragSources is non-empty", async () => {
+  test("emits a sources chunk after text when ctx.groundingSources is non-empty", async () => {
     const anthropic = mockAnthropic({
       events: [{ type: "content_block_delta", delta: { type: "text_delta", text: "Hi" } }],
     });
@@ -215,7 +215,7 @@ describe("runResponseAgent", () => {
       runResponseAgent({
         userMessage: "What is HPV?",
         history: [],
-        ragSources: [
+        groundingSources: [
           { id: "1", title: "Cancer Council", url: "https://example.com", chunkId: "c1" },
         ],
       })
@@ -229,19 +229,19 @@ describe("runResponseAgent", () => {
     ]);
   });
 
-  test("does not emit a sources chunk when ctx.ragSources is empty or absent", async () => {
+  test("does not emit a sources chunk when ctx.groundingSources is empty or absent", async () => {
     const anthropic = mockAnthropic({
       events: [{ type: "content_block_delta", delta: { type: "text_delta", text: "Hi" } }],
     });
     vi.mocked(getAnthropicClient).mockReturnValue(anthropic as never);
 
-    // ragSources omitted entirely
+    // groundingSources omitted entirely
     const chunksNoField = await collect(runResponseAgent({ userMessage: "Hi", history: [] }));
     expect(chunksNoField).toEqual([{ type: "text", text: "Hi" }]);
 
-    // ragSources present but empty
+    // groundingSources present but empty
     const chunksEmpty = await collect(
-      runResponseAgent({ userMessage: "Hi", history: [], ragSources: [] })
+      runResponseAgent({ userMessage: "Hi", history: [], groundingSources: [] })
     );
     expect(chunksEmpty).toEqual([{ type: "text", text: "Hi" }]);
   });

--- a/lib/agents/response-agent.ts
+++ b/lib/agents/response-agent.ts
@@ -10,13 +10,18 @@ export type ResponseAgentContext = {
   userMessage: string;
   /** Prior conversation, oldest first. Does NOT include `userMessage`. */
   history: ChatHistoryMessage[];
-  /** Optional retrieved-context block. When present, appended to the system prompt. */
-  ragContext?: string;
   /**
-   * Optional structured citations from the RAG agent. When non-empty, the
-   * agent yields one `sources` chunk after all text chunks. Wired by #27.
+   * Optional grounding block — RAG chunks, news headlines, or upcoming
+   * events. The orchestrator builds the body (including any sub-header
+   * like "Recent news (last 7 days):"). Appended to the system prompt
+   * under "Retrieved context:" when non-empty.
    */
-  ragSources?: Source[];
+  groundingContext?: string;
+  /**
+   * Citations matching `groundingContext`. Yielded as a single `sources`
+   * chunk after the text chunks so the chat UI can render citation chips.
+   */
+  groundingSources?: Source[];
   /** Optional system-prompt override. Defaults to `DEFAULT_SYSTEM_PROMPT`. */
   systemPrompt?: string;
 };
@@ -26,15 +31,15 @@ export type AgentChunk = { type: "text"; text: string } | { type: "sources"; sou
 /**
  * Pure response-agent function. Yields each text delta from Claude as it
  * arrives, then optionally a single `sources` chunk at the end if
- * `ctx.ragSources` is non-empty.
+ * `ctx.groundingSources` is non-empty.
  *
  * Per CLAUDE.md: agents are pure functions with no DB / HTTP awareness, and
  * the model string is hard-coded (never from env).
  */
 export async function* runResponseAgent(ctx: ResponseAgentContext): AsyncIterable<AgentChunk> {
   const baseSystem = ctx.systemPrompt ?? DEFAULT_SYSTEM_PROMPT;
-  const system = ctx.ragContext
-    ? `${baseSystem}\n\nRetrieved context:\n${ctx.ragContext}`
+  const system = ctx.groundingContext
+    ? `${baseSystem}\n\nRetrieved context:\n${ctx.groundingContext}`
     : baseSystem;
 
   const messages = [...ctx.history, { role: "user" as const, content: ctx.userMessage }];
@@ -53,7 +58,7 @@ export async function* runResponseAgent(ctx: ResponseAgentContext): AsyncIterabl
     }
   }
 
-  if (ctx.ragSources && ctx.ragSources.length > 0) {
-    yield { type: "sources", sources: ctx.ragSources };
+  if (ctx.groundingSources && ctx.groundingSources.length > 0) {
+    yield { type: "sources", sources: ctx.groundingSources };
   }
 }

--- a/tests/api/chat.test.ts
+++ b/tests/api/chat.test.ts
@@ -22,6 +22,7 @@ type SupabaseFromMock = {
   sessionSingle: ReturnType<typeof vi.fn>;
   messageInsert: ReturnType<typeof vi.fn>;
   historyOrder: ReturnType<typeof vi.fn>;
+  profileMaybeSingle: ReturnType<typeof vi.fn>;
 };
 
 type SupabaseChainOpts = {
@@ -57,13 +58,21 @@ function mockSupabaseChain(opts: SupabaseChainOpts = {}): SupabaseFromMock {
   const historyEq = vi.fn().mockReturnValue({ order: historyOrder });
   const messageSelect = vi.fn().mockReturnValue({ eq: historyEq });
 
+  // `profiles` lookup is best-effort: route reads `locale` to thread into the
+  // events agent. Default mock returns no profile row — tests don't care
+  // about locale unless they specifically simulate an events_request flow.
+  const profileMaybeSingle = vi.fn().mockResolvedValue({ data: null, error: null });
+  const profileEq = vi.fn().mockReturnValue({ maybeSingle: profileMaybeSingle });
+  const profileSelect = vi.fn().mockReturnValue({ eq: profileEq });
+
   const from = vi.fn((table: string) => {
     if (table === "chat_sessions") return { insert: sessionInsert };
     if (table === "chat_messages") return { insert: messageInsert, select: messageSelect };
+    if (table === "profiles") return { select: profileSelect };
     throw new Error(`Unmocked table: ${table}`);
   });
 
-  return { from, sessionInsert, sessionSingle, messageInsert, historyOrder };
+  return { from, sessionInsert, sessionSingle, messageInsert, historyOrder, profileMaybeSingle };
 }
 
 function mockSupabase(
@@ -239,7 +248,7 @@ describe("POST /api/chat", () => {
     // Orchestrator was called with the supabase client + userMessage + (empty) history
     expect(runOrchestrator).toHaveBeenCalledTimes(1);
     const [, ctxArg] = vi.mocked(runOrchestrator).mock.calls[0];
-    expect(ctxArg).toEqual({ userMessage: "Hi", history: [] });
+    expect(ctxArg).toEqual({ userMessage: "Hi", history: [], locale: null });
   });
 
   test("passes prior session history through to the orchestrator on a follow-up turn", async () => {
@@ -268,6 +277,7 @@ describe("POST /api/chat", () => {
         { role: "user", content: "What is HPV?" },
         { role: "assistant", content: "HPV stands for human papillomavirus..." },
       ],
+      locale: null,
     });
   });
 


### PR DESCRIPTION
## Summary
Replaces the static stub branches in the orchestrator with real dispatch to the News and Events agents (#64, #66). Completes the Epic 3 intent dispatch table.

- **news_request** → `runNewsAgent` → `runResponseAgent` with the news context injected under \`Recent news (last 7 days):\`. Static fallback text when NewsAPI returns nothing.
- **events_request** → `runEventsAgent` → `runResponseAgent` with the events context injected under \`Upcoming events:\`. Two static fallback paths: \`needsLocation\` (asks the user for a city) and empty-result.

## Refactor: response-agent grounding fields
Renamed \`ragContext\` / \`ragSources\` → \`groundingContext\` / \`groundingSources\` in \`ResponseAgentContext\`. The field semantically holds any retrieved grounding (RAG chunks, news headlines, events), so the rag-prefix was misleading after this PR.

\`runRagAgent\`'s own output keeps its rag-prefixed names — those remain RAG-specific, and the orchestrator maps them through.

## Chat route: locale plumbing
The chat route now does a best-effort \`profiles.locale\` lookup and threads it into the orchestrator so the events agent can use it as a location hint. Failure is non-fatal — the agent gracefully prompts the user for a city.

## Test plan
- [x] \`pnpm test\` — full suite green (289 passed)
  - 7 new orchestrator tests cover news/events dispatch with results, empty results, needsLocation, and that runRagAgent is never called for non-health intents
  - response-agent tests updated for the field rename (still 11 passing)
  - chat route tests updated for the new \`profiles\` table read and the \`locale\` field on the orchestrator ctx
- [x] \`pnpm biome check .\` clean
- [x] \`pnpm build\` succeeds
- [x] \`docs/api-routes.md\` updated to describe the four-way dispatch and the locale-from-profiles behavior

Closes #29

🤖 Generated with [Claude Code](https://claude.com/claude-code)