### PR TITLE
feat(admin): manual knowledge document manager (add/delete)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -257,6 +257,7 @@ Required external accounts for full local dev: Supabase, Anthropic, OpenAI, Goog
 | File | Contents |
 |---|---|
 | `docs/architecture.md` | Agent pipeline, RAG flow, tool call chain |
+| `docs/discovery-pipeline.md` | Gap-driven knowledge discovery: rag_gap capture, stages, thresholds, triggers |
 | `docs/database.md` | Full schema reference, RLS roles, pgvector setup |
 | `docs/api-routes.md` | All API routes with auth requirements |
 | `docs/env-vars.md` | All environment variables with provider links |

--- a/app/(app)/admin/knowledge/documents/add-document-form.test.tsx
+++ b/app/(app)/admin/knowledge/documents/add-document-form.test.tsx
@@ -17,8 +17,12 @@ describe("AddDocumentForm", () => {
     vi.mocked(addDocument).mockResolvedValue({ chunksCreated: 4 });
     render(<AddDocumentForm />);
 
-    fireEvent.change(screen.getByLabelText(/document name/i), { target: { value: "Cervical basics" } });
-    fireEvent.change(screen.getByLabelText(/document content/i), { target: { value: "Some text" } });
+    fireEvent.change(screen.getByLabelText(/document name/i), {
+      target: { value: "Cervical basics" },
+    });
+    fireEvent.change(screen.getByLabelText(/document content/i), {
+      target: { value: "Some text" },
+    });
     fireEvent.click(screen.getByRole("button", { name: /add to knowledge base/i }));
 
     await waitFor(() => expect(toast.success).toHaveBeenCalled());

--- a/app/(app)/admin/knowledge/documents/add-document-form.test.tsx
+++ b/app/(app)/admin/knowledge/documents/add-document-form.test.tsx
@@ -1,0 +1,38 @@
+// @vitest-environment jsdom
+
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, test, vi } from "vitest";
+
+vi.mock("sonner", () => ({ toast: { success: vi.fn(), error: vi.fn() } }));
+vi.mock("@/lib/rag/document-actions", () => ({ addDocument: vi.fn() }));
+
+import { addDocument } from "@/lib/rag/document-actions";
+import { toast } from "sonner";
+import { AddDocumentForm } from "./add-document-form";
+
+describe("AddDocumentForm", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  test("submits name + content and toasts the chunk count", async () => {
+    vi.mocked(addDocument).mockResolvedValue({ chunksCreated: 4 });
+    render(<AddDocumentForm />);
+
+    fireEvent.change(screen.getByLabelText(/document name/i), { target: { value: "Cervical basics" } });
+    fireEvent.change(screen.getByLabelText(/document content/i), { target: { value: "Some text" } });
+    fireEvent.click(screen.getByRole("button", { name: /add to knowledge base/i }));
+
+    await waitFor(() => expect(toast.success).toHaveBeenCalled());
+    expect(addDocument).toHaveBeenCalledWith({ name: "Cervical basics", content: "Some text" });
+  });
+
+  test("toasts an error when the action rejects", async () => {
+    vi.mocked(addDocument).mockRejectedValue(new Error("fail"));
+    render(<AddDocumentForm />);
+
+    fireEvent.change(screen.getByLabelText(/document name/i), { target: { value: "x" } });
+    fireEvent.change(screen.getByLabelText(/document content/i), { target: { value: "y" } });
+    fireEvent.click(screen.getByRole("button", { name: /add to knowledge base/i }));
+
+    await waitFor(() => expect(toast.error).toHaveBeenCalled());
+  });
+});

--- a/app/(app)/admin/knowledge/documents/add-document-form.tsx
+++ b/app/(app)/admin/knowledge/documents/add-document-form.tsx
@@ -30,7 +30,10 @@ export function AddDocumentForm() {
     "w-full rounded border border-[#eceae4] bg-cream px-3 py-2 text-sm text-charcoal placeholder:text-muted-gray";
 
   return (
-    <form onSubmit={onSubmit} className="space-y-3 rounded-lg border border-[#eceae4] bg-[#fcfbf8] p-5">
+    <form
+      onSubmit={onSubmit}
+      className="space-y-3 rounded-lg border border-[#eceae4] bg-[#fcfbf8] p-5"
+    >
       <h2 className="text-lg font-medium text-charcoal">Add a document</h2>
       <input
         aria-label="Document name"

--- a/app/(app)/admin/knowledge/documents/add-document-form.tsx
+++ b/app/(app)/admin/knowledge/documents/add-document-form.tsx
@@ -1,0 +1,55 @@
+"use client";
+
+import { Button } from "@/components/ui/button";
+import { addDocument } from "@/lib/rag/document-actions";
+import { useState } from "react";
+import { toast } from "sonner";
+
+/** Admin-only form to paste a document into the knowledge base. */
+export function AddDocumentForm() {
+  const [name, setName] = useState("");
+  const [content, setContent] = useState("");
+  const [pending, setPending] = useState(false);
+
+  async function onSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    setPending(true);
+    try {
+      const { chunksCreated } = await addDocument({ name, content });
+      toast.success(`Added “${name}” — ${chunksCreated} chunk${chunksCreated === 1 ? "" : "s"}.`);
+      setName("");
+      setContent("");
+    } catch {
+      toast.error("Could not add the document. Check the inputs and try again.");
+    } finally {
+      setPending(false);
+    }
+  }
+
+  const inputClass =
+    "w-full rounded border border-[#eceae4] bg-cream px-3 py-2 text-sm text-charcoal placeholder:text-muted-gray";
+
+  return (
+    <form onSubmit={onSubmit} className="space-y-3 rounded-lg border border-[#eceae4] bg-[#fcfbf8] p-5">
+      <h2 className="text-lg font-medium text-charcoal">Add a document</h2>
+      <input
+        aria-label="Document name"
+        placeholder="Document name (source)"
+        value={name}
+        onChange={(e) => setName(e.target.value)}
+        className={inputClass}
+      />
+      <textarea
+        aria-label="Document content"
+        placeholder="Paste the document text…"
+        value={content}
+        onChange={(e) => setContent(e.target.value)}
+        rows={8}
+        className={inputClass}
+      />
+      <Button type="submit" disabled={pending || !name.trim() || !content.trim()}>
+        {pending ? "Adding…" : "Add to knowledge base"}
+      </Button>
+    </form>
+  );
+}

--- a/app/(app)/admin/knowledge/documents/document-row.test.tsx
+++ b/app/(app)/admin/knowledge/documents/document-row.test.tsx
@@ -1,0 +1,38 @@
+// @vitest-environment jsdom
+
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+
+vi.mock("sonner", () => ({ toast: { success: vi.fn(), error: vi.fn() } }));
+vi.mock("@/lib/rag/document-actions", () => ({ deleteDocument: vi.fn() }));
+
+import { deleteDocument } from "@/lib/rag/document-actions";
+import { toast } from "sonner";
+import { DocumentRow } from "./document-row";
+
+const doc = { source: "who.int/hpv", title: "HPV", chunkCount: 8, createdAt: "2026-05-01T00:00:00.000Z" };
+
+describe("DocumentRow", () => {
+  beforeEach(() => vi.clearAllMocks());
+  afterEach(() => vi.restoreAllMocks());
+
+  test("deletes after confirm and toasts success", async () => {
+    vi.spyOn(window, "confirm").mockReturnValue(true);
+    vi.mocked(deleteDocument).mockResolvedValue();
+    render(<DocumentRow doc={doc} />);
+
+    fireEvent.click(screen.getByRole("button", { name: /delete/i }));
+
+    await waitFor(() => expect(toast.success).toHaveBeenCalled());
+    expect(deleteDocument).toHaveBeenCalledWith("who.int/hpv");
+  });
+
+  test("does nothing when confirm is cancelled", async () => {
+    vi.spyOn(window, "confirm").mockReturnValue(false);
+    render(<DocumentRow doc={doc} />);
+
+    fireEvent.click(screen.getByRole("button", { name: /delete/i }));
+
+    expect(deleteDocument).not.toHaveBeenCalled();
+  });
+});

--- a/app/(app)/admin/knowledge/documents/document-row.test.tsx
+++ b/app/(app)/admin/knowledge/documents/document-row.test.tsx
@@ -10,7 +10,12 @@ import { deleteDocument } from "@/lib/rag/document-actions";
 import { toast } from "sonner";
 import { DocumentRow } from "./document-row";
 
-const doc = { source: "who.int/hpv", title: "HPV", chunkCount: 8, createdAt: "2026-05-01T00:00:00.000Z" };
+const doc = {
+  source: "who.int/hpv",
+  title: "HPV",
+  chunkCount: 8,
+  createdAt: "2026-05-01T00:00:00.000Z",
+};
 
 describe("DocumentRow", () => {
   beforeEach(() => vi.clearAllMocks());

--- a/app/(app)/admin/knowledge/documents/document-row.tsx
+++ b/app/(app)/admin/knowledge/documents/document-row.tsx
@@ -33,7 +33,7 @@ export function DocumentRow({ doc }: { doc: KnowledgeDocument }) {
         <p className="truncate text-sm font-medium text-charcoal">{label}</p>
         <p className="truncate text-xs text-muted-gray">
           {doc.source ?? "(no source)"} · {doc.chunkCount} chunk{doc.chunkCount === 1 ? "" : "s"} ·{" "}
-          {new Date(doc.createdAt).toLocaleDateString()}
+          {doc.createdAt.slice(0, 10)}
         </p>
       </div>
       <Button type="button" variant="outline" disabled={pending} onClick={onDelete}>

--- a/app/(app)/admin/knowledge/documents/document-row.tsx
+++ b/app/(app)/admin/knowledge/documents/document-row.tsx
@@ -1,0 +1,44 @@
+"use client";
+
+import { Button } from "@/components/ui/button";
+import { deleteDocument } from "@/lib/rag/document-actions";
+import type { KnowledgeDocument } from "@/lib/rag/documents";
+import { useState } from "react";
+import { toast } from "sonner";
+
+/** One row in the document list, with a confirm-gated delete. */
+export function DocumentRow({ doc }: { doc: KnowledgeDocument }) {
+  const [pending, setPending] = useState(false);
+  const label = doc.title ?? doc.source ?? "(no source)";
+
+  async function onDelete() {
+    const ok = window.confirm(
+      `Delete “${label}” and all ${doc.chunkCount} of its chunks? This cannot be undone.`
+    );
+    if (!ok) return;
+    setPending(true);
+    try {
+      await deleteDocument(doc.source);
+      toast.success(`Deleted “${label}”.`);
+    } catch {
+      toast.error("Could not delete the document. Please try again.");
+    } finally {
+      setPending(false);
+    }
+  }
+
+  return (
+    <li className="flex items-center justify-between gap-4 rounded-lg border border-[#eceae4] bg-[#fcfbf8] p-4">
+      <div className="min-w-0">
+        <p className="truncate text-sm font-medium text-charcoal">{label}</p>
+        <p className="truncate text-xs text-muted-gray">
+          {doc.source ?? "(no source)"} · {doc.chunkCount} chunk{doc.chunkCount === 1 ? "" : "s"} ·{" "}
+          {new Date(doc.createdAt).toLocaleDateString()}
+        </p>
+      </div>
+      <Button type="button" variant="outline" disabled={pending} onClick={onDelete}>
+        {pending ? "Deleting…" : "Delete"}
+      </Button>
+    </li>
+  );
+}

--- a/app/(app)/admin/knowledge/documents/page.tsx
+++ b/app/(app)/admin/knowledge/documents/page.tsx
@@ -1,0 +1,45 @@
+import { requireAdmin } from "@/lib/auth/require-admin";
+import { listKnowledgeDocuments } from "@/lib/rag/documents";
+import Link from "next/link";
+import { AddDocumentForm } from "./add-document-form";
+import { DocumentRow } from "./document-row";
+
+// Always render fresh — the list changes as documents are added/deleted.
+export const dynamic = "force-dynamic";
+
+export default async function KnowledgeDocumentsPage() {
+  const { supabase } = await requireAdmin();
+  const documents = await listKnowledgeDocuments(supabase);
+
+  return (
+    <main className="min-h-screen bg-cream px-6 py-10">
+      <div className="mx-auto max-w-3xl space-y-8">
+        <header className="flex items-center justify-between gap-4">
+          <div>
+            <h1 className="text-2xl font-medium text-charcoal">Knowledge documents</h1>
+            <p className="mt-1 text-sm text-muted-gray">
+              {documents.length} document{documents.length === 1 ? "" : "s"} in the knowledge base
+            </p>
+          </div>
+          <Link href="/admin/knowledge" className="text-sm text-charcoal underline">
+            ← Review queue
+          </Link>
+        </header>
+
+        <AddDocumentForm />
+
+        {documents.length === 0 ? (
+          <p className="rounded-lg border border-[#eceae4] bg-[#fcfbf8] p-8 text-center text-sm text-muted-gray">
+            No documents yet. Add one above, or approve discovered candidates from the review queue.
+          </p>
+        ) : (
+          <ul className="space-y-3">
+            {documents.map((doc) => (
+              <DocumentRow key={doc.source ?? "__null__"} doc={doc} />
+            ))}
+          </ul>
+        )}
+      </div>
+    </main>
+  );
+}

--- a/app/(app)/admin/knowledge/page.tsx
+++ b/app/(app)/admin/knowledge/page.tsx
@@ -1,5 +1,6 @@
 import { requireAdmin } from "@/lib/auth/require-admin";
 import { listPendingCandidates } from "@/lib/discovery/candidates";
+import Link from "next/link";
 import { CandidateCard } from "./candidate-card";
 import { RunDiscoveryButton } from "./run-discovery-button";
 
@@ -20,7 +21,12 @@ export default async function KnowledgeReviewPage() {
               {candidates.length} pending candidate{candidates.length === 1 ? "" : "s"}
             </p>
           </div>
-          <RunDiscoveryButton />
+          <div className="flex items-center gap-3">
+            <Link href="/admin/knowledge/documents" className="text-sm text-charcoal underline">
+              Manage documents →
+            </Link>
+            <RunDiscoveryButton />
+          </div>
         </header>
 
         {candidates.length === 0 ? (

--- a/docs/api-routes.md
+++ b/docs/api-routes.md
@@ -80,6 +80,11 @@ All route handlers are in `app/api/` using Next.js App Router conventions (`rout
 **Auth:** `admin` role (server-side gate via `requireAdmin`, enforced in `app/(app)/admin/layout.tsx`).  
 **Purpose:** Review queue for pending `knowledge_candidates`. **Approve** → server action `approveCandidate` ingests the content into `knowledge_chunks` via `ingestDocument` and marks the row `approved`. **Reject** → `rejectCandidate` marks it `rejected`. **Run discovery now** → calls `GET /api/embeddings/discover`.
 
+### `/admin/knowledge/documents` (page, not an API route)
+
+**Auth:** `admin` role (server-side gate via `requireAdmin`, enforced in `app/(app)/admin/layout.tsx`).
+**Purpose:** Manage the documents in `knowledge_chunks` directly. **Lists** every document (one row per `source`, via the `list_knowledge_documents()` RPC). **Add** — server action `addDocument` chunks + embeds pasted text via `ingestDocument` (`source` = the typed name, `metadata.origin = "manual"`). **Delete** — server action `deleteDocument` hard-deletes all chunks for a `source`. Covers seed, discovery-approved, and manually-added documents alike.
+
 ### `POST /api/analytics/event`
 
 **Auth:** `user` role  

--- a/docs/discovery-pipeline.md
+++ b/docs/discovery-pipeline.md
@@ -1,0 +1,183 @@
+# Knowledge Discovery Pipeline
+
+An offline pipeline that **automatically fills gaps in the RAG knowledge base** by
+discovering authoritative women's / cervical / HPV-vaccine content, scoring it, and
+staging it for admin review before it enters `knowledge_chunks`.
+
+It is **demand-driven**: it only goes looking for content when real users ask
+questions the knowledge base answers poorly. There is no hard-coded keyword list.
+
+---
+
+## The core idea: gap-driven, not keyword-driven
+
+```
+① A signed-in user asks a health question in chat
+        │
+        ▼
+② RAG retrieves from knowledge_chunks, but the best chunk's
+   cosine similarity is below 0.52 (weak / no coverage)
+        │   orchestrator logs a `rag_gap` analytics event
+        │   (event_type='rag_gap', payload={ question, top_score })
+        ▼
+③ Cron (every 3 days) or an admin clicks "Run discovery now"
+        │
+        ▼
+④ mineGaps        read rag_gap events (last 30 days), drop ones already
+                  addressed, LLM-cluster the rest → top 5 gap themes
+        ▼
+⑤ synthesizeQueries  per theme, LLM generates 1–2 search queries
+                     (off-domain themes are dropped here)
+        ▼
+⑥ searchWeb       SerpAPI google → candidate URLs
+        ▼
+⑦ scoreAuthority  allowlist floor / denylist drop / LLM judge
+        ▼
+⑧ fetchAndExtract cheerio main-text extraction
+        ▼
+⑨ checkDuplicate  embed snippet → KB similarity ≥ 0.90 = skip
+        ▼
+⑩ stageCandidate  LLM summary + tags → insert into knowledge_candidates
+                  (status='pending')
+        ▼
+⑪ Admin reviews at /admin/knowledge → Approve (ingest) or Reject
+```
+
+**Key consequence:** if there are no fresh `rag_gap` events, `mineGaps` returns
+`[]` and the run stages **nothing**. The pipeline is reactive — it never invents
+work. A freshly deployed instance with no traffic will discover nothing until
+real users hit coverage gaps. (`rag_gap` logging only began when this feature
+shipped; historical gaps were never recorded.)
+
+---
+
+## What counts as a "gap"
+
+A `rag_gap` event is logged (see `lib/ai/rag-gap.ts`, called from
+`lib/agents/orchestrator.ts`) when **all** of these hold for a chat turn:
+
+- the user is signed in (the event is written via the audit-scoped service-role
+  client set up in the chat route),
+- the orchestrator classified the message as `health_question`,
+- the top retrieved chunk's similarity `topScore < 0.52` (`GAP_THRESHOLD`),
+  which includes the zero-result case (`topScore = 0`).
+
+### The two-thresholds principle
+
+These are deliberately different numbers, answering different questions:
+
+| Threshold | Where | Question it answers |
+|---|---|---|
+| **0.45** | `lib/rag/retrieve.ts` | "Is this chunk good enough to *cite* in an answer?" |
+| **0.52** | `lib/ai/rag-gap.ts` (`GAP_THRESHOLD`) | "Is our *coverage* of this question good enough?" |
+
+The gap threshold is stricter than the retrieval floor so it catches
+*weak-coverage* answers (a chunk came back but only scored, say, 0.47), not just
+zero-result ones. The 0.45 retrieval floor is tuned for `text-embedding-3-small`
+(whose "clearly relevant" pairs score ~0.54–0.60) and is **out of scope** to
+change here.
+
+---
+
+## Triggers
+
+`GET /api/embeddings/discover` runs the pipeline. It authenticates **either**:
+
+- a **Vercel Cron** request — `Authorization: Bearer ${CRON_SECRET}` → trigger `cron`
+- an **admin session** — the "Run discovery now" button on `/admin/knowledge` → trigger `manual`
+
+401 if neither; 403 for a non-admin session. The route is a **GET** because
+Vercel Cron only issues GET requests. It runs inside `auditContext` with a
+service-role client so LLM calls are audited and inserts bypass RLS on the
+admin-only staging tables.
+
+Schedule: **every 3 days** — `0 3 */3 * *` (UTC), see `vercel.json`.
+`CRON_SECRET` must be set in the Vercel project env (it also gates the eager
+validation in `lib/env.ts`, so a missing value breaks the build).
+
+---
+
+## Bounds (so one run can't run away)
+
+A run is capped on three axes (constants in `lib/discovery/constants.ts`):
+
+| Constant | Default | Purpose |
+|---|---|---|
+| `MAX_GAP_CLUSTERS` | 5 | gap themes processed per run |
+| `MAX_RESULTS_PER_QUERY` | 5 | search results pulled per query |
+| `MAX_CANDIDATES_PER_RUN` | 15 | hard cap on candidates staged per run |
+| `RUN_BUDGET_MS` | 240_000 | wall-clock budget (guards the 300s function limit) |
+| `GAP_LOOKBACK_DAYS` | 30 | how far back `mineGaps` reads `rag_gap` events |
+
+Per-candidate failures (a bad URL, an LLM hiccup) are swallowed and logged so one
+bad source never aborts the batch. A thrown stage (e.g. `mineGaps`) fails the
+whole run and marks the `discovery_runs` row `failed`.
+
+---
+
+## Quality gates
+
+| Gate | Where | Rule |
+|---|---|---|
+| Domain relevance #1 | `synthesizeQueries` | off-domain themes → no queries |
+| Authority allowlist | `scoreAuthority` | who.int, cdc.gov, nhs.uk, acog.org, cancer.gov, cancer.org(.au), cancercouncil.com.au, healthdirect.gov.au, mayoclinic.org → authority floored to 0.95 |
+| Authority denylist | `scoreAuthority` | reddit, quora, pinterest, facebook, x/twitter, tiktok, medium → authority 0, dropped |
+| Authority/relevance floor | `runDiscovery` | drop if `authorityScore < 0.6` or `relevanceScore < 0.6` |
+| Dedup vs KB | `checkDuplicate` | skip if an existing chunk matches at similarity ≥ 0.90 |
+| Dedup vs prior candidates | `stageCandidate` | `content_hash` unique constraint → duplicate insert returns null |
+| **Human review** | `/admin/knowledge` | nothing reaches `knowledge_chunks` without an admin clicking Approve |
+
+Review state lives **only** in the admin/staging surface — never in the
+learn/chat product UI. Approved chunks flow into `knowledge_chunks` like any
+other document.
+
+---
+
+## File map
+
+```
+lib/ai/rag-gap.ts            recordRagGap + GAP_THRESHOLD (gap capture)
+lib/discovery/
+  types.ts                   shared types
+  constants.ts               allowlist/denylist, thresholds, batch budgets
+  prompts.ts                 4 LLM prompt definitions
+  llm.ts                     runDiscoveryLlm (audited Claude call helper)
+  mine-gaps.ts               read rag_gap events → LLM cluster
+  synthesize-queries.ts      theme → search queries
+  search.ts                  SerpAPI google search
+  score-authority.ts         allowlist/denylist + LLM judge
+  fetch-extract.ts           cheerio main-text extraction
+  dedup.ts                   KB similarity + content hash
+  stage-candidate.ts         summarize + insert pending row
+  run.ts                     runDiscovery coordinator (bounded batch)
+app/api/embeddings/discover/route.ts    cron + manual trigger
+app/(app)/admin/knowledge/              review queue UI
+lib/discovery/review-actions.ts         approveCandidate / rejectCandidate
+lib/auth/require-admin.ts               server-side admin gate
+```
+
+Tables: `knowledge_candidates` (staging), `discovery_runs` (run log), and
+`analytics_events` (reused for `rag_gap`). All Claude calls use
+`claude-sonnet-4-6`; embeddings use OpenAI `text-embedding-3-small`.
+
+---
+
+## Operating it
+
+- **Exercise it manually:** ask the prod chat a few health questions the KB can't
+  answer well (creates `rag_gap` events), then click **"Run discovery now"** on
+  `/admin/knowledge`. Without gaps, a run stages nothing — that's expected.
+- **Seeding the initial KB** is separate from discovery: `pnpm seed:kb` (or the
+  same script pointed at prod via an env file) re-ingests the curated source
+  docs in `supabase/seeds/knowledge/` straight into `knowledge_chunks`.
+- **Tuning:** all knobs live in `lib/discovery/constants.ts` and
+  `lib/ai/rag-gap.ts` (`GAP_THRESHOLD`). Lower `GAP_THRESHOLD` = stricter gap
+  detection (fewer gaps); raise it = more.
+
+## Not built (possible future work)
+
+- **Topic-driven mode:** proactively cover a curated topic list even with no user
+  gaps. Today the pipeline is purely reactive to `rag_gap` events.
+- **Background-job UX:** "Run discovery now" currently blocks until the run
+  finishes (up to `RUN_BUDGET_MS`).
+- **`discovery_runs` history view** in the admin section.

--- a/docs/discovery-pipeline.md
+++ b/docs/discovery-pipeline.md
@@ -173,6 +173,10 @@ Tables: `knowledge_candidates` (staging), `discovery_runs` (run log), and
 - **Tuning:** all knobs live in `lib/discovery/constants.ts` and
   `lib/ai/rag-gap.ts` (`GAP_THRESHOLD`). Lower `GAP_THRESHOLD` = stricter gap
   detection (fewer gaps); raise it = more.
+- **Deleting a discovered document** (via `/admin/knowledge/documents`) removes
+  its chunks but leaves the `knowledge_candidates` row `approved`. Because the
+  content is gone from the KB, the 0.90 dedup no longer matches it, so a future
+  run may re-discover and re-queue it. That is expected.
 
 ## Not built (possible future work)
 

--- a/lib/rag/document-actions.test.ts
+++ b/lib/rag/document-actions.test.ts
@@ -1,0 +1,76 @@
+// @vitest-environment node
+
+import { beforeEach, describe, expect, test, vi } from "vitest";
+
+vi.mock("@/lib/auth/require-admin", () => ({ requireAdmin: vi.fn() }));
+vi.mock("@/lib/rag/store", () => ({ ingestDocument: vi.fn() }));
+vi.mock("@/lib/rag/documents", () => ({ deleteKnowledgeDocument: vi.fn() }));
+vi.mock("next/cache", () => ({ revalidatePath: vi.fn() }));
+
+import { requireAdmin } from "@/lib/auth/require-admin";
+import { deleteKnowledgeDocument } from "@/lib/rag/documents";
+import { ingestDocument } from "@/lib/rag/store";
+import { revalidatePath } from "next/cache";
+import { addDocument, deleteDocument } from "./document-actions";
+
+const client = { from: vi.fn() };
+
+function asAdmin() {
+  vi.mocked(requireAdmin).mockResolvedValue({
+    supabase: client as never,
+    user: { id: "admin1" } as never,
+  });
+}
+
+describe("addDocument", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  test("ingests with source=name and manual metadata, returns chunk count", async () => {
+    asAdmin();
+    vi.mocked(ingestDocument).mockResolvedValue({ chunkIds: ["a", "b", "c"] });
+
+    const result = await addDocument({ name: "My doc", content: "Hello world" });
+
+    expect(ingestDocument).toHaveBeenCalledWith(client, {
+      source: "My doc",
+      content: "Hello world",
+      metadata: { title: "My doc", origin: "manual" },
+    });
+    expect(result).toEqual({ chunksCreated: 3 });
+    expect(revalidatePath).toHaveBeenCalledWith("/admin/knowledge/documents");
+  });
+
+  test("rejects empty content before any admin/DB work", async () => {
+    await expect(addDocument({ name: "x", content: "   " })).rejects.toThrow();
+    expect(requireAdmin).not.toHaveBeenCalled();
+    expect(ingestDocument).not.toHaveBeenCalled();
+  });
+
+  test("rejects empty name", async () => {
+    await expect(addDocument({ name: "  ", content: "real content" })).rejects.toThrow();
+    expect(requireAdmin).not.toHaveBeenCalled();
+  });
+
+  test("rejects content over 512KB", async () => {
+    const tooBig = "a".repeat(512_001);
+    await expect(addDocument({ name: "big", content: tooBig })).rejects.toThrow();
+    expect(ingestDocument).not.toHaveBeenCalled();
+  });
+});
+
+describe("deleteDocument", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  test("deletes the named document and revalidates", async () => {
+    asAdmin();
+    await deleteDocument("who.int/hpv");
+    expect(deleteKnowledgeDocument).toHaveBeenCalledWith(client, "who.int/hpv");
+    expect(revalidatePath).toHaveBeenCalledWith("/admin/knowledge/documents");
+  });
+
+  test("accepts null (the unsourced group)", async () => {
+    asAdmin();
+    await deleteDocument(null);
+    expect(deleteKnowledgeDocument).toHaveBeenCalledWith(client, null);
+  });
+});

--- a/lib/rag/document-actions.ts
+++ b/lib/rag/document-actions.ts
@@ -1,0 +1,54 @@
+"use server";
+
+import { requireAdmin } from "@/lib/auth/require-admin";
+import { deleteKnowledgeDocument } from "@/lib/rag/documents";
+import { ingestDocument } from "@/lib/rag/store";
+import { revalidatePath } from "next/cache";
+import { z } from "zod";
+
+const DOCUMENTS_PATH = "/admin/knowledge/documents";
+const MAX_CONTENT_BYTES = 512_000; // 500KB — matches /api/embeddings/ingest
+
+const addDocumentSchema = z.object({
+  name: z.string().trim().min(1, "name must not be empty").max(500),
+  content: z
+    .string()
+    .trim()
+    .min(1, "content must not be empty")
+    .refine((c) => Buffer.byteLength(c, "utf8") <= MAX_CONTENT_BYTES, "content too large"),
+});
+
+const sourceSchema = z.string().nullable();
+
+/**
+ * Manually add a document to the knowledge base. Validates first, then chunks +
+ * embeds + inserts via the shared ingest pipeline. `source` is the typed name;
+ * metadata records the title and a `manual` origin. Admin-only.
+ */
+export async function addDocument(input: {
+  name: string;
+  content: string;
+}): Promise<{ chunksCreated: number }> {
+  const { name, content } = addDocumentSchema.parse(input);
+  const { supabase } = await requireAdmin();
+
+  const { chunkIds } = await ingestDocument(supabase, {
+    source: name,
+    content,
+    metadata: { title: name, origin: "manual" },
+  });
+
+  revalidatePath(DOCUMENTS_PATH);
+  return { chunksCreated: chunkIds.length };
+}
+
+/**
+ * Delete a document (all chunks for a `source`; `null` = the unsourced group).
+ * Hard delete. Admin-only.
+ */
+export async function deleteDocument(source: string | null): Promise<void> {
+  const validSource = sourceSchema.parse(source);
+  const { supabase } = await requireAdmin();
+  await deleteKnowledgeDocument(supabase, validSource);
+  revalidatePath(DOCUMENTS_PATH);
+}

--- a/lib/rag/documents.test.ts
+++ b/lib/rag/documents.test.ts
@@ -8,7 +8,12 @@ describe("listKnowledgeDocuments", () => {
 
   test("calls the RPC and maps rows to KnowledgeDocument", async () => {
     const rows = [
-      { source: "who.int/hpv", title: "HPV", chunk_count: 8, created_at: "2026-05-01T00:00:00.000Z" },
+      {
+        source: "who.int/hpv",
+        title: "HPV",
+        chunk_count: 8,
+        created_at: "2026-05-01T00:00:00.000Z",
+      },
       { source: null, title: null, chunk_count: 2, created_at: "2026-04-01T00:00:00.000Z" },
     ];
     const rpc = vi.fn().mockResolvedValue({ data: rows, error: null });

--- a/lib/rag/documents.test.ts
+++ b/lib/rag/documents.test.ts
@@ -1,0 +1,60 @@
+// @vitest-environment node
+
+import { beforeEach, describe, expect, test, vi } from "vitest";
+import { deleteKnowledgeDocument, listKnowledgeDocuments } from "./documents";
+
+describe("listKnowledgeDocuments", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  test("calls the RPC and maps rows to KnowledgeDocument", async () => {
+    const rows = [
+      { source: "who.int/hpv", title: "HPV", chunk_count: 8, created_at: "2026-05-01T00:00:00.000Z" },
+      { source: null, title: null, chunk_count: 2, created_at: "2026-04-01T00:00:00.000Z" },
+    ];
+    const rpc = vi.fn().mockResolvedValue({ data: rows, error: null });
+    const client = { rpc };
+
+    const out = await listKnowledgeDocuments(client as never);
+
+    expect(rpc).toHaveBeenCalledWith("list_knowledge_documents");
+    expect(out).toEqual([
+      { source: "who.int/hpv", title: "HPV", chunkCount: 8, createdAt: "2026-05-01T00:00:00.000Z" },
+      { source: null, title: null, chunkCount: 2, createdAt: "2026-04-01T00:00:00.000Z" },
+    ]);
+  });
+
+  test("throws on a query error", async () => {
+    const client = { rpc: vi.fn().mockResolvedValue({ data: null, error: { message: "boom" } }) };
+    await expect(listKnowledgeDocuments(client as never)).rejects.toThrow("boom");
+  });
+});
+
+describe("deleteKnowledgeDocument", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  function fakeDelete(error: unknown = null) {
+    const eq = vi.fn().mockResolvedValue({ error });
+    const is = vi.fn().mockResolvedValue({ error });
+    const del = vi.fn().mockReturnValue({ eq, is });
+    const from = vi.fn().mockReturnValue({ delete: del });
+    return { client: { from }, from, eq, is };
+  }
+
+  test("deletes by source via .eq when source is a string", async () => {
+    const { client, from, eq } = fakeDelete();
+    await deleteKnowledgeDocument(client as never, "who.int/hpv");
+    expect(from).toHaveBeenCalledWith("knowledge_chunks");
+    expect(eq).toHaveBeenCalledWith("source", "who.int/hpv");
+  });
+
+  test("deletes the unsourced group via .is when source is null", async () => {
+    const { client, is } = fakeDelete();
+    await deleteKnowledgeDocument(client as never, null);
+    expect(is).toHaveBeenCalledWith("source", null);
+  });
+
+  test("throws on a delete error", async () => {
+    const { client } = fakeDelete({ message: "nope" });
+    await expect(deleteKnowledgeDocument(client as never, "x")).rejects.toThrow("nope");
+  });
+});

--- a/lib/rag/documents.ts
+++ b/lib/rag/documents.ts
@@ -1,0 +1,45 @@
+import type { Database } from "@/types/supabase";
+import type { SupabaseClient } from "@supabase/supabase-js";
+
+export type KnowledgeDocument = {
+  /** Grouping key; null for chunks with no source. */
+  source: string | null;
+  /** Representative metadata.title, or null. */
+  title: string | null;
+  chunkCount: number;
+  /** Earliest created_at across the document's chunks (ISO string). */
+  createdAt: string;
+};
+
+/**
+ * List every document in the knowledge base (one row per distinct `source`),
+ * newest first. Backed by the list_knowledge_documents() RPC so embeddings are
+ * never pulled into the app layer. Admin-gated at the caller; RLS allows
+ * authenticated SELECT on knowledge_chunks.
+ */
+export async function listKnowledgeDocuments(
+  supabase: SupabaseClient<Database>
+): Promise<KnowledgeDocument[]> {
+  const { data, error } = await supabase.rpc("list_knowledge_documents");
+  if (error) throw new Error(error.message);
+  return (data ?? []).map((row) => ({
+    source: row.source,
+    title: row.title,
+    chunkCount: Number(row.chunk_count),
+    createdAt: row.created_at,
+  }));
+}
+
+/**
+ * Delete every chunk for a document. `null` targets the "(no source)" group
+ * via `.is`, otherwise an exact `.eq` match. Hard delete — no soft delete in v1.
+ * Caller must be on an admin-bound client (RLS gates the delete).
+ */
+export async function deleteKnowledgeDocument(
+  supabase: SupabaseClient<Database>,
+  source: string | null
+): Promise<void> {
+  const base = supabase.from("knowledge_chunks").delete();
+  const { error } = await (source === null ? base.is("source", null) : base.eq("source", source));
+  if (error) throw new Error(error.message);
+}

--- a/supabase/migrations/20260607004727_list_knowledge_documents.sql
+++ b/supabase/migrations/20260607004727_list_knowledge_documents.sql
@@ -1,0 +1,27 @@
+-- Read-only aggregate over knowledge_chunks for the admin document manager.
+-- A "document" = all chunks sharing one `source`. Grouping happens in the DB so
+-- the 1536-dim embedding column is never pulled into the app layer.
+--
+-- SECURITY INVOKER (default): runs as the caller, so the knowledge_chunks SELECT
+-- RLS policy applies. Any authenticated user may already SELECT chunks (needed
+-- for RAG), and source names are not sensitive; the admin-only surface is
+-- enforced at the page/action layer. Same exposure model as match_knowledge_chunks.
+create or replace function public.list_knowledge_documents()
+returns table (
+  source      text,
+  title       text,
+  chunk_count bigint,
+  created_at  timestamptz
+)
+language sql
+stable
+as $$
+  select
+    source,
+    min(metadata->>'title') as title,
+    count(*)                as chunk_count,
+    min(created_at)         as created_at
+  from public.knowledge_chunks
+  group by source
+  order by min(created_at) desc;
+$$;

--- a/types/supabase.ts
+++ b/types/supabase.ts
@@ -429,6 +429,15 @@ export type Database = {
     }
     Functions: {
       is_admin: { Args: never; Returns: boolean }
+      list_knowledge_documents: {
+        Args: never
+        Returns: {
+          chunk_count: number
+          created_at: string
+          source: string
+          title: string
+        }[]
+      }
       match_knowledge_chunks: {
         Args: {
           match_count: number


### PR DESCRIPTION
## Summary
- New admin page `/admin/knowledge/documents` to **view, add, and delete** the documents backing the RAG knowledge base — complements the existing discovery review queue with direct manual control over `knowledge_chunks`.
- A "document" = all chunks sharing one `source` (no new tables). New read-only aggregate RPC `list_knowledge_documents()` groups in Postgres so the 1536-dim `embedding` column never hits the app layer.
- **Add** reuses `ingestDocument` (paste plain text; `source` = typed name, `metadata.origin = "manual"`). **Delete** hard-deletes all chunks for a `source` (confirm-gated). Covers seed, discovery-approved, and manual docs alike.
- Server actions `addDocument` / `deleteDocument` (admin-gated via `requireAdmin`, Zod-validated, 512KB cap). No new RLS — reuses existing `knowledge_chunks` admin policies.
- Fixes a date hydration mismatch by rendering a locale-independent ISO date slice.
- Docs updated (`docs/api-routes.md`, `docs/discovery-pipeline.md`).

## Test Plan
- [x] `pnpm test` — full suite green (490 passed, 30 skipped); 15 new tests across query helpers, server actions, and the two client components
- [x] `pnpm build` — succeeds; `/admin/knowledge/documents` present in route list
- [x] `pnpm biome check` — clean
- [ ] Manual smoke: sign in as admin → `/admin/knowledge` → "Manage documents →" → add a short doc (appears with chunk count) → delete it (confirm → disappears)

🤖 Generated with [Claude Code](https://claude.com/claude-code)