### PR TITLE
feat(chat): inline citation markers in assistant responses

### DIFF
--- a/app/(app)/chat/chat-client.tsx
+++ b/app/(app)/chat/chat-client.tsx
@@ -218,7 +218,11 @@ function MessageBubble({ message }: { message: ChatMessage }) {
           {renderBody()}
         </div>
         {message.role === "assistant" && (
-          <CitationChips sources={message.sources} messageId={message.id} />
+          <CitationChips
+            sources={message.sources}
+            messageId={message.id}
+            content={message.content}
+          />
         )}
       </div>
     </div>

--- a/app/(app)/chat/chat-client.tsx
+++ b/app/(app)/chat/chat-client.tsx
@@ -204,7 +204,9 @@ function MessageBubble({ message }: { message: ChatMessage }) {
     if (isUser) {
       return message.content;
     }
-    return <MarkdownMessage content={message.content} />;
+    return (
+      <MarkdownMessage content={message.content} sources={message.sources} messageId={message.id} />
+    );
   };
 
   return (
@@ -215,7 +217,9 @@ function MessageBubble({ message }: { message: ChatMessage }) {
         >
           {renderBody()}
         </div>
-        {message.role === "assistant" && <CitationChips sources={message.sources} />}
+        {message.role === "assistant" && (
+          <CitationChips sources={message.sources} messageId={message.id} />
+        )}
       </div>
     </div>
   );

--- a/app/(app)/chat/citation-chips.test.tsx
+++ b/app/(app)/chat/citation-chips.test.tsx
@@ -1,7 +1,15 @@
 import type { Source } from "@/types/agents";
 import { render, screen } from "@testing-library/react";
 import { describe, expect, it } from "vitest";
-import { CitationChips } from "./citation-chips";
+import { CitationChips, parseCitedMarkers } from "./citation-chips";
+
+const fiveSources: Source[] = [
+  { id: "1", title: "Source A", url: "https://a.com", chunkId: "c1" },
+  { id: "2", title: "Source B", url: "https://b.com", chunkId: "c2" },
+  { id: "3", title: "Source C", url: "https://c.com", chunkId: "c3" },
+  { id: "4", title: "Source D", url: "https://d.com", chunkId: "c4" },
+  { id: "5", title: "Source E", url: "https://e.com", chunkId: "c5" },
+];
 
 describe("CitationChips", () => {
   it("renders nothing for an empty array", () => {
@@ -66,5 +74,44 @@ describe("CitationChips", () => {
     const sources: Source[] = [{ id: "1", title: "Source A", url: "https://a.com", chunkId: "c1" }];
     const { container } = render(<CitationChips sources={sources} />);
     expect(container.querySelector("[id^='cite-']")).toBeNull();
+  });
+
+  describe("content filtering", () => {
+    it("renders only the sources actually cited in the content", () => {
+      render(<CitationChips sources={fiveSources} content="A claim [1][2]. Another [1]." />);
+      expect(screen.getByRole("link", { name: "[1]" })).toHaveAttribute("title", "Source A");
+      expect(screen.getByRole("link", { name: "[2]" })).toHaveAttribute("title", "Source B");
+      expect(screen.queryByRole("link", { name: "[3]" })).toBeNull();
+      expect(screen.queryByRole("link", { name: "[4]" })).toBeNull();
+      expect(screen.queryByRole("link", { name: "[5]" })).toBeNull();
+    });
+
+    it("keeps numbering aligned with the source index (no renumber)", () => {
+      // Only [2] is cited → the single chip shown is [2], mapping to Source B.
+      render(<CitationChips sources={fiveSources} content="Only this one [2]." />);
+      const link = screen.getByRole("link", { name: "[2]" });
+      expect(link).toHaveAttribute("href", "https://b.com");
+      expect(screen.queryByRole("link", { name: "[1]" })).toBeNull();
+    });
+
+    it("falls back to showing all sources when content has no markers", () => {
+      render(<CitationChips sources={fiveSources} content="No markers at all here." />);
+      expect(screen.getAllByRole("link")).toHaveLength(5);
+    });
+
+    it("shows all sources when content prop is absent (back-compat)", () => {
+      render(<CitationChips sources={fiveSources} />);
+      expect(screen.getAllByRole("link")).toHaveLength(5);
+    });
+  });
+
+  describe("parseCitedMarkers", () => {
+    it("extracts the distinct numbers cited in the text", () => {
+      expect(parseCitedMarkers("a [1] b [2][1] c [3]")).toEqual(new Set([1, 2, 3]));
+    });
+
+    it("returns an empty set when nothing is cited", () => {
+      expect(parseCitedMarkers("plain text")).toEqual(new Set());
+    });
   });
 });

--- a/app/(app)/chat/citation-chips.test.tsx
+++ b/app/(app)/chat/citation-chips.test.tsx
@@ -51,4 +51,20 @@ describe("CitationChips", () => {
     // But the chip still appears with the marker
     expect(screen.getByText(/\[1\]/)).toBeInTheDocument();
   });
+
+  it("sets a stable scroll-target id on each chip when messageId is given", () => {
+    const sources: Source[] = [
+      { id: "1", title: "Source A", url: "https://a.com", chunkId: "c1" },
+      { id: "2", title: "Source B", chunkId: "c2" },
+    ];
+    const { container } = render(<CitationChips sources={sources} messageId="m1" />);
+    expect(container.querySelector("#cite-m1-1")).not.toBeNull();
+    expect(container.querySelector("#cite-m1-2")).not.toBeNull();
+  });
+
+  it("omits ids when messageId is absent", () => {
+    const sources: Source[] = [{ id: "1", title: "Source A", url: "https://a.com", chunkId: "c1" }];
+    const { container } = render(<CitationChips sources={sources} />);
+    expect(container.querySelector("[id^='cite-']")).toBeNull();
+  });
 });

--- a/app/(app)/chat/citation-chips.tsx
+++ b/app/(app)/chat/citation-chips.tsx
@@ -8,21 +8,49 @@ type Props = {
   sources: Source[] | null | undefined;
   /** When set, each chip gets id `cite-${messageId}-${n}` as a scroll target. */
   messageId?: string;
+  /**
+   * Assistant message text. When provided and it contains inline `[n]`
+   * markers, the list is filtered to only the cited sources (numbering
+   * preserved). When it contains no markers — older messages, or a reply the
+   * model didn't cite — all sources are shown as a fallback.
+   */
+  content?: string;
 };
+
+const MARKER_RE = /\[(\d+)\]/g;
+
+/** Distinct 1-indexed citation numbers referenced in `content`. */
+export function parseCitedMarkers(content: string): Set<number> {
+  const out = new Set<number>();
+  MARKER_RE.lastIndex = 0;
+  let m: RegExpExecArray | null = MARKER_RE.exec(content);
+  while (m !== null) {
+    out.add(Number(m[1]));
+    m = MARKER_RE.exec(content);
+  }
+  return out;
+}
 
 /**
  * Renders 1-indexed numbered chips for each source under an assistant
  * message bubble. Sources with a URL render as `<a>` opening in a new tab;
- * those without render as a non-clickable `<span>`. Returns null when there
+ * those without render as a non-clickable `<span>`. When `content` cites a
+ * subset of sources inline, only those are shown. Returns null when there
  * are no sources to render.
  */
-export function CitationChips({ sources, messageId }: Props) {
+export function CitationChips({ sources, messageId, content }: Props) {
   if (!sources || sources.length === 0) return null;
+
+  // Filter to cited sources only when the content actually cites some;
+  // otherwise show everything (back-compat / uncited replies).
+  const cited = content ? parseCitedMarkers(content) : null;
+  const visible = cited && cited.size > 0 ? sources.filter((_s, i) => cited.has(i + 1)) : sources;
+  if (visible.length === 0) return null;
 
   return (
     <div className="mt-2 flex flex-wrap gap-1.5">
-      {sources.map((s, i) => {
-        const number = i + 1;
+      {visible.map((s) => {
+        const number = sources.indexOf(s) + 1;
         const label = `[${number}]`;
         const id = messageId ? `cite-${messageId}-${number}` : undefined;
         if (s.url) {

--- a/app/(app)/chat/citation-chips.tsx
+++ b/app/(app)/chat/citation-chips.tsx
@@ -6,6 +6,8 @@ export const CITATION_CHIP_CLASS =
 
 type Props = {
   sources: Source[] | null | undefined;
+  /** When set, each chip gets id `cite-${messageId}-${n}` as a scroll target. */
+  messageId?: string;
 };
 
 /**
@@ -14,7 +16,7 @@ type Props = {
  * those without render as a non-clickable `<span>`. Returns null when there
  * are no sources to render.
  */
-export function CitationChips({ sources }: Props) {
+export function CitationChips({ sources, messageId }: Props) {
   if (!sources || sources.length === 0) return null;
 
   return (
@@ -22,10 +24,12 @@ export function CitationChips({ sources }: Props) {
       {sources.map((s, i) => {
         const number = i + 1;
         const label = `[${number}]`;
+        const id = messageId ? `cite-${messageId}-${number}` : undefined;
         if (s.url) {
           return (
             <a
               key={s.id}
+              id={id}
               href={s.url}
               target="_blank"
               rel="noopener noreferrer"
@@ -39,6 +43,7 @@ export function CitationChips({ sources }: Props) {
         return (
           <span
             key={s.id}
+            id={id}
             title={s.title}
             className={`${CITATION_CHIP_CLASS} text-muted-gray cursor-default`}
           >

--- a/app/(app)/chat/citation-chips.tsx
+++ b/app/(app)/chat/citation-chips.tsx
@@ -1,5 +1,9 @@
 import type { Source } from "@/types/agents";
 
+// Shared base style for citation chips (inline markers + bottom list).
+export const CITATION_CHIP_CLASS =
+  "border-border text-charcoal hover:bg-white/40 inline-flex items-center rounded-full border bg-white/20 px-2 py-0.5 text-xs leading-tight transition-colors";
+
 type Props = {
   sources: Source[] | null | undefined;
 };
@@ -26,7 +30,7 @@ export function CitationChips({ sources }: Props) {
               target="_blank"
               rel="noopener noreferrer"
               title={s.title}
-              className="border-border text-charcoal hover:bg-white/40 inline-flex items-center rounded-full border bg-white/20 px-2 py-0.5 text-xs leading-tight transition-colors"
+              className={CITATION_CHIP_CLASS}
             >
               {label}
             </a>
@@ -36,7 +40,7 @@ export function CitationChips({ sources }: Props) {
           <span
             key={s.id}
             title={s.title}
-            className="border-border text-muted-gray inline-flex cursor-default items-center rounded-full border bg-white/10 px-2 py-0.5 text-xs leading-tight"
+            className={`${CITATION_CHIP_CLASS} text-muted-gray cursor-default`}
           >
             {label}
           </span>

--- a/app/(app)/chat/citation-marker.test.tsx
+++ b/app/(app)/chat/citation-marker.test.tsx
@@ -1,0 +1,64 @@
+import type { Source } from "@/types/agents";
+import { fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { CitationMarker } from "./citation-marker";
+
+const withUrl: Source[] = [
+  { id: "1", title: "Cancer Council", url: "https://example.com/a", chunkId: "c1" },
+];
+const noUrl: Source[] = [{ id: "1", title: "Internal note", chunkId: "c1" }];
+
+describe("CitationMarker", () => {
+  it("renders a new-tab link for a source with a URL", () => {
+    render(<CitationMarker n={1} sources={withUrl} messageId="m1" />);
+    const link = screen.getByRole("link", { name: "[1]" });
+    expect(link).toHaveAttribute("href", "https://example.com/a");
+    expect(link).toHaveAttribute("target", "_blank");
+    expect(link.getAttribute("rel")).toContain("noopener");
+    expect(link).toHaveAttribute("title", "Cancer Council");
+  });
+
+  it("renders plain text (no link/button) for an out-of-range number", () => {
+    render(<CitationMarker n={5} sources={withUrl} messageId="m1" />);
+    expect(screen.queryByRole("link")).toBeNull();
+    expect(screen.queryByRole("button")).toBeNull();
+    expect(screen.getByText("[5]")).toBeInTheDocument();
+  });
+
+  it("renders plain text when sources is undefined", () => {
+    render(<CitationMarker n={1} sources={undefined} messageId="m1" />);
+    expect(screen.queryByRole("link")).toBeNull();
+    expect(screen.getByText("[1]")).toBeInTheDocument();
+  });
+
+  describe("URL-less source", () => {
+    beforeEach(() => {
+      // jsdom has no scrollIntoView; provide a spy.
+      Element.prototype.scrollIntoView = vi.fn();
+      vi.useFakeTimers();
+    });
+    afterEach(() => {
+      vi.useRealTimers();
+    });
+
+    it("renders a button that scrolls to + highlights the bottom entry on click", () => {
+      // Target element the marker should scroll to.
+      const target = document.createElement("div");
+      target.id = "cite-m1-1";
+      document.body.appendChild(target);
+
+      render(<CitationMarker n={1} sources={noUrl} messageId="m1" />);
+      const button = screen.getByRole("button", { name: "[1]" });
+      fireEvent.click(button);
+
+      expect(target.scrollIntoView).toHaveBeenCalledTimes(1);
+      expect(target.classList.contains("cite-highlight")).toBe(true);
+
+      // Highlight clears after the timeout.
+      vi.advanceTimersByTime(1600);
+      expect(target.classList.contains("cite-highlight")).toBe(false);
+
+      document.body.removeChild(target);
+    });
+  });
+});

--- a/app/(app)/chat/citation-marker.tsx
+++ b/app/(app)/chat/citation-marker.tsx
@@ -1,0 +1,62 @@
+import type { Source } from "@/types/agents";
+import { CITATION_CHIP_CLASS } from "./citation-chips";
+
+type Props = {
+  /** 1-indexed marker the model emitted. Resolves against `sources[n-1]`. */
+  n: number;
+  sources: Source[] | null | undefined;
+  /** Owning message id — used to build the bottom-list scroll target id. */
+  messageId: string;
+};
+
+// Inline marker styling: shared chip base, nudged to sit nicely in prose.
+const INLINE_CHIP_CLASS = `${CITATION_CHIP_CLASS} mx-0.5 align-baseline no-underline`;
+
+/** Scroll to and briefly highlight a source's entry in the bottom list. */
+export function scrollToCitation(messageId: string, n: number): void {
+  const el = document.getElementById(`cite-${messageId}-${n}`);
+  if (!el) return;
+  el.scrollIntoView({ behavior: "smooth", block: "center" });
+  el.classList.add("cite-highlight");
+  setTimeout(() => el.classList.remove("cite-highlight"), 1500);
+}
+
+/**
+ * Inline citation chip. Resolves `n` against `sources`:
+ * - matched + url   → new-tab link to the source
+ * - matched, no url → button that scrolls to the bottom-list entry
+ * - unmatched       → plain, non-clickable text
+ */
+export function CitationMarker({ n, sources, messageId }: Props) {
+  const label = `[${n}]`;
+  const source = sources?.[n - 1];
+
+  if (!source) {
+    return <span className={`${INLINE_CHIP_CLASS} text-muted-gray cursor-default`}>{label}</span>;
+  }
+
+  if (source.url) {
+    return (
+      <a
+        href={source.url}
+        target="_blank"
+        rel="noopener noreferrer"
+        title={source.title}
+        className={INLINE_CHIP_CLASS}
+      >
+        {label}
+      </a>
+    );
+  }
+
+  return (
+    <button
+      type="button"
+      title={source.title}
+      className={INLINE_CHIP_CLASS}
+      onClick={() => scrollToCitation(messageId, n)}
+    >
+      {label}
+    </button>
+  );
+}

--- a/app/globals.css
+++ b/app/globals.css
@@ -346,3 +346,17 @@
 .fade-up {
   animation: fadeUp 400ms ease-out both;
 }
+
+/* Transient highlight when an inline citation scrolls to its bottom-list entry. */
+.cite-highlight {
+  animation: cite-pulse 1.5s ease-out;
+}
+
+@keyframes cite-pulse {
+  0% {
+    box-shadow: 0 0 0 3px rgba(28, 28, 28, 0.25);
+  }
+  100% {
+    box-shadow: 0 0 0 3px rgba(28, 28, 28, 0);
+  }
+}

--- a/components/markdown-message.test.tsx
+++ b/components/markdown-message.test.tsx
@@ -1,3 +1,4 @@
+import type { Source } from "@/types/agents";
 import { render, screen } from "@testing-library/react";
 import { describe, expect, it } from "vitest";
 import { MarkdownMessage } from "./markdown-message";
@@ -96,5 +97,34 @@ describe("MarkdownMessage", () => {
   it("tolerates partial/streaming markdown (unclosed bold)", () => {
     // Should not throw while a token is mid-stream
     expect(() => render(<MarkdownMessage content="hello **wor" />)).not.toThrow();
+  });
+});
+
+describe("MarkdownMessage inline citations", () => {
+  const sources: Source[] = [
+    { id: "1", title: "Cancer Council", url: "https://example.com/a", chunkId: "c1" },
+  ];
+
+  it("renders a [1] marker as a clickable chip linking to the source", () => {
+    render(
+      <MarkdownMessage content="Screening every 5 years [1]." sources={sources} messageId="m1" />
+    );
+    const link = screen.getByRole("link", { name: "[1]" });
+    expect(link).toHaveAttribute("href", "https://example.com/a");
+    expect(link).toHaveAttribute("target", "_blank");
+  });
+
+  it("renders an unmatched [2] as plain text", () => {
+    render(<MarkdownMessage content="A claim [2]." sources={sources} messageId="m1" />);
+    expect(screen.queryByRole("link")).toBeNull();
+    expect(screen.getByText(/\[2\]/)).toBeInTheDocument();
+  });
+
+  it("still renders normal markdown links untouched", () => {
+    render(
+      <MarkdownMessage content="see [docs](https://example.com)" sources={sources} messageId="m1" />
+    );
+    const link = screen.getByRole("link", { name: "docs" });
+    expect(link).toHaveAttribute("href", "https://example.com");
   });
 });

--- a/components/markdown-message.tsx
+++ b/components/markdown-message.tsx
@@ -1,3 +1,6 @@
+import { CitationMarker } from "@/app/(app)/chat/citation-marker";
+import { remarkCitations } from "@/lib/markdown/remark-citations";
+import type { Source } from "@/types/agents";
 import { type ComponentPropsWithoutRef, memo } from "react";
 import ReactMarkdown from "react-markdown";
 import rehypeSanitize from "rehype-sanitize";
@@ -5,23 +8,41 @@ import remarkGfm from "remark-gfm";
 
 type Props = {
   content: string;
+  /** Citations for resolving inline `[n]` markers. Absent for ungrounded turns. */
+  sources?: Source[] | null;
+  /** Owning message id — threaded to CitationMarker for scroll targets. */
+  messageId?: string;
 };
+
+const CITE_HREF_RE = /^#cite-(\d+)$/;
 
 // Memoized: during streaming, every token triggers a setMessages that re-renders
 // the whole message list. Without memo, each already-complete message re-parses
 // its full markdown on every token. memo skips messages whose content is unchanged.
-export const MarkdownMessage = memo(function MarkdownMessage({ content }: Props) {
+export const MarkdownMessage = memo(function MarkdownMessage({
+  content,
+  sources,
+  messageId,
+}: Props) {
   return (
     <div className="markdown-message space-y-2 text-sm leading-relaxed [&_a]:underline [&_blockquote]:border-charcoal/20 [&_blockquote]:border-l-2 [&_blockquote]:pl-3 [&_blockquote]:text-charcoal/80 [&_code]:bg-charcoal/5 [&_code]:rounded [&_code]:px-1 [&_code]:py-0.5 [&_code]:text-[0.85em] [&_h1]:text-base [&_h1]:font-semibold [&_h2]:text-base [&_h2]:font-semibold [&_h3]:text-sm [&_h3]:font-semibold [&_li]:my-0.5 [&_ol]:list-decimal [&_ol]:pl-5 [&_p]:whitespace-pre-wrap [&_pre]:bg-charcoal/5 [&_pre]:overflow-x-auto [&_pre]:rounded [&_pre]:p-2 [&_pre_code]:bg-transparent [&_pre_code]:p-0 [&_strong]:font-semibold [&_ul]:list-disc [&_ul]:pl-5">
       <ReactMarkdown
-        remarkPlugins={[remarkGfm]}
+        remarkPlugins={[remarkGfm, remarkCitations]}
         rehypePlugins={[rehypeSanitize]}
         components={{
-          a: ({ children, href, ...rest }: ComponentPropsWithoutRef<"a">) => (
-            <a href={href} target="_blank" rel="noopener noreferrer" {...rest}>
-              {children}
-            </a>
-          ),
+          a: ({ children, href, ...rest }: ComponentPropsWithoutRef<"a">) => {
+            const match = typeof href === "string" ? href.match(CITE_HREF_RE) : null;
+            if (match && messageId) {
+              return (
+                <CitationMarker n={Number(match[1])} sources={sources} messageId={messageId} />
+              );
+            }
+            return (
+              <a href={href} target="_blank" rel="noopener noreferrer" {...rest}>
+                {children}
+              </a>
+            );
+          },
         }}
       >
         {content}

--- a/lib/agents/response-agent.test.ts
+++ b/lib/agents/response-agent.test.ts
@@ -193,6 +193,35 @@ describe("runResponseAgent", () => {
     expect(args[0].system).not.toContain("Retrieved context:");
   });
 
+  test("appends the citation instruction when groundingContext is present", async () => {
+    const anthropic = mockAnthropic({
+      events: [{ type: "content_block_delta", delta: { type: "text_delta", text: "ok" } }],
+    });
+    vi.mocked(getAnthropicClient).mockReturnValue(anthropic as never);
+
+    await collect(
+      runResponseAgent({
+        userMessage: "Hi",
+        history: [],
+        groundingContext: "[1] HPV is a virus.",
+      })
+    );
+    const args = anthropic.messages.stream.mock.calls[0] as unknown as [{ system: string }];
+    expect(args[0].system).toContain("append the corresponding marker");
+  });
+
+  test("does NOT append the citation instruction for ungrounded turns", async () => {
+    const anthropic = mockAnthropic({
+      events: [{ type: "content_block_delta", delta: { type: "text_delta", text: "ok" } }],
+    });
+    vi.mocked(getAnthropicClient).mockReturnValue(anthropic as never);
+
+    await collect(runResponseAgent({ userMessage: "Hi", history: [] }));
+    const args = anthropic.messages.stream.mock.calls[0] as unknown as [{ system: string }];
+    expect(args[0].system).toBe(DEFAULT_SYSTEM_PROMPT);
+    expect(args[0].system).not.toContain("append the corresponding marker");
+  });
+
   test("propagates errors thrown during streaming", async () => {
     const anthropic = mockAnthropic({
       events: [{ type: "content_block_delta", delta: { type: "text_delta", text: "partial" } }],

--- a/lib/agents/response-agent.ts
+++ b/lib/agents/response-agent.ts
@@ -1,7 +1,7 @@
 import { CLAUDE_MODEL } from "@/lib/ai/anthropic";
 import type { ChatHistoryMessage } from "@/lib/ai/context-window";
 import { loggedMessagesStream } from "@/lib/ai/logged-anthropic";
-import { RESPONSE_DEFAULT_PROMPT } from "@/lib/ai/prompts";
+import { CITATION_INSTRUCTION, RESPONSE_DEFAULT_PROMPT } from "@/lib/ai/prompts";
 import type { Source } from "@/types/agents";
 
 const MAX_TOKENS = 4096;
@@ -43,7 +43,7 @@ export async function* runResponseAgent(ctx: ResponseAgentContext): AsyncIterabl
     : RESPONSE_DEFAULT_PROMPT;
 
   const system = ctx.groundingContext
-    ? `${promptDef.text}\n\nRetrieved context:\n${ctx.groundingContext}`
+    ? `${promptDef.text}\n\nRetrieved context:\n${ctx.groundingContext}\n\n${CITATION_INSTRUCTION}`
     : promptDef.text;
 
   const messages = [...ctx.history, { role: "user" as const, content: ctx.userMessage }];

--- a/lib/ai/prompts.ts
+++ b/lib/ai/prompts.ts
@@ -28,6 +28,13 @@ If unsure, choose general_chat.`
 
 export const RESPONSE_DEFAULT_PROMPT = defPrompt("response.default", "v1", DEFAULT_SYSTEM_PROMPT);
 
+/**
+ * Appended to the response system prompt ONLY when grounding context is
+ * present (RAG / news / events). Tells the model to cite the numbered chunks
+ * inline. Never added to ungrounded (general_chat) turns.
+ */
+export const CITATION_INSTRUCTION = `CITATIONS: The retrieved context above is numbered [1], [2], and so on. After any sentence or claim you draw from that context, append the corresponding marker inline, e.g. "screening is recommended every 5 years [1]." Use consecutive markers like [1][2] when a claim draws on more than one source. Only cite numbers that actually appear in the retrieved context. Do not add a separate "Sources" list at the end — inline markers only.`;
+
 export function promptHash(text: string): string {
   return createHash("sha256").update(text).digest("hex");
 }

--- a/lib/markdown/remark-citations.test.ts
+++ b/lib/markdown/remark-citations.test.ts
@@ -1,0 +1,77 @@
+import remarkParse from "remark-parse";
+import { unified } from "unified";
+import { describe, expect, it } from "vitest";
+import { remarkCitations } from "./remark-citations";
+
+// Parse markdown → mdast, run the plugin, return the root node for inspection.
+function parse(md: string) {
+  const tree = unified().use(remarkParse).parse(md);
+  remarkCitations()(tree as never);
+  return tree as unknown as {
+    type: string;
+    children?: unknown[];
+  };
+}
+
+// Collect every node of a given type, depth-first.
+function collect(
+  node: { type: string; url?: string; value?: string; children?: unknown[] },
+  type: string
+) {
+  const out: Array<{ type: string; url?: string; value?: string; children?: unknown[] }> = [];
+  const walk = (n: { type: string; url?: string; value?: string; children?: unknown[] }) => {
+    if (n.type === type) out.push(n);
+    if (Array.isArray(n.children)) {
+      for (const c of n.children) walk(c as typeof n);
+    }
+  };
+  walk(node as never);
+  return out;
+}
+
+describe("remarkCitations", () => {
+  it("rewrites a single [1] into a #cite-1 link", () => {
+    const tree = parse("Screening every 5 years [1].");
+    const links = collect(tree as never, "link");
+    expect(links).toHaveLength(1);
+    expect(links[0].url).toBe("#cite-1");
+  });
+
+  it("rewrites consecutive [1][2] into two links", () => {
+    const tree = parse("A claim [1][2] here.");
+    const links = collect(tree as never, "link");
+    expect(links.map((l) => l.url)).toEqual(["#cite-1", "#cite-2"]);
+  });
+
+  it("preserves the literal [n] text inside the link", () => {
+    const tree = parse("x [3] y");
+    const links = collect(tree as never, "link") as Array<{
+      children: Array<{ value: string }>;
+    }>;
+    expect(links[0].children[0].value).toBe("[3]");
+  });
+
+  it("does not rewrite [1] inside inline code", () => {
+    const tree = parse("use `arr[1]` please");
+    expect(collect(tree as never, "link")).toHaveLength(0);
+  });
+
+  it("does not rewrite [1] inside a fenced code block", () => {
+    const tree = parse("```\nconst x = arr[1];\n```");
+    expect(collect(tree as never, "link")).toHaveLength(0);
+  });
+
+  it("does not rewrite the label of a real markdown link", () => {
+    // The label text "see [1]" must stay literal text inside the existing link.
+    const tree = parse("[see [1]](https://example.com)");
+    const links = collect(tree as never, "link");
+    // Exactly one link — the real one — and its url is unchanged.
+    expect(links).toHaveLength(1);
+    expect(links[0].url).toBe("https://example.com");
+  });
+
+  it("ignores non-numeric brackets like [note]", () => {
+    const tree = parse("a footnote [note] here");
+    expect(collect(tree as never, "link")).toHaveLength(0);
+  });
+});

--- a/lib/markdown/remark-citations.ts
+++ b/lib/markdown/remark-citations.ts
@@ -1,0 +1,63 @@
+/**
+ * Minimal structural mdast node. We avoid `@types/mdast` / `unist-util-visit`
+ * (not resolvable under pnpm strict node_modules) and walk the tree by hand.
+ * `Node` from unified is structurally assignable to this, so the plugin still
+ * type-checks where react-markdown expects a remark plugin.
+ */
+interface MdNode {
+  type: string;
+  value?: string;
+  url?: string;
+  children?: MdNode[];
+}
+
+const CITATION_RE = /\[(\d+)\]/g;
+
+// Split a text value into alternating text / citation-link nodes.
+function splitCitations(value: string): MdNode[] {
+  const out: MdNode[] = [];
+  let last = 0;
+  CITATION_RE.lastIndex = 0;
+  let m: RegExpExecArray | null = CITATION_RE.exec(value);
+  while (m !== null) {
+    if (m.index > last) out.push({ type: "text", value: value.slice(last, m.index) });
+    out.push({
+      type: "link",
+      url: `#cite-${m[1]}`,
+      children: [{ type: "text", value: m[0] }],
+    });
+    last = m.index + m[0].length;
+    m = CITATION_RE.exec(value);
+  }
+  if (last < value.length) out.push({ type: "text", value: value.slice(last) });
+  return out.length > 0 ? out : [{ type: "text", value }];
+}
+
+// Rebuild a node's children, splitting text nodes and recursing into
+// containers. Never descends into `link` nodes (don't rewrite real link
+// labels). `inlineCode` / `code` carry their content in `value`, not in a
+// `text` child, so code is left untouched automatically.
+function transform(node: MdNode): void {
+  if (!node.children) return;
+  const next: MdNode[] = [];
+  for (const child of node.children) {
+    if (child.type === "text" && typeof child.value === "string") {
+      next.push(...splitCitations(child.value));
+    } else {
+      if (child.type !== "link") transform(child);
+      next.push(child);
+    }
+  }
+  node.children = next;
+}
+
+/**
+ * Remark plugin: rewrite `[n]` markers in prose into sentinel `#cite-n` link
+ * nodes. The fragment href survives rehype-sanitize and is resolved into a
+ * CitationMarker by the MarkdownMessage `a`-override.
+ */
+export function remarkCitations() {
+  return (tree: MdNode): void => {
+    transform(tree);
+  };
+}

--- a/package.json
+++ b/package.json
@@ -59,9 +59,11 @@
     "jsdom": "^29.0.2",
     "msw": "^2.13.2",
     "postcss": "^8.5.3",
+    "remark-parse": "^11.0.0",
     "tailwindcss": "^3.4.17",
     "tsx": "^4.21.0",
     "typescript": "^5",
+    "unified": "^11.0.5",
     "vitest": "^4.1.4"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -129,6 +129,9 @@ importers:
       postcss:
         specifier: ^8.5.3
         version: 8.5.9
+      remark-parse:
+        specifier: ^11.0.0
+        version: 11.0.0
       tailwindcss:
         specifier: ^3.4.17
         version: 3.4.19(tsx@4.21.0)
@@ -138,6 +141,9 @@ importers:
       typescript:
         specifier: ^5
         version: 5.9.3
+      unified:
+        specifier: ^11.0.5
+        version: 11.0.5
       vitest:
         specifier: ^4.1.4
         version: 4.1.4(@types/node@20.19.39)(jsdom@29.0.2(@noble/hashes@1.8.0))(msw@2.13.2(@types/node@20.19.39)(typescript@5.9.3))(vite@8.0.8(@types/node@20.19.39)(esbuild@0.27.7)(jiti@1.21.7)(tsx@4.21.0))


### PR DESCRIPTION
## What & why

Sources used to live entirely **at the end** of an assistant message (a chip row below the bubble). This adds **inline `[n]` citation chips** within the response text — Perplexity-style — so each claim points at the source it came from, while keeping the bottom list.

## How it works (end to end)

1. **Model** — on grounded turns (RAG / news / events), a `CITATION_INSTRUCTION` is appended to the system prompt telling the model to emit the numbered markers inline. Ungrounded `general_chat` turns are untouched.
2. **Parse** — a dependency-free remark plugin (`lib/markdown/remark-citations.ts`) rewrites `[n]` prose markers into sentinel `#cite-n` link nodes (survives `rehype-sanitize`; skips real link labels and code).
3. **Render** — `MarkdownMessage`'s `a`-override resolves `#cite-n` into a `CitationMarker` chip: URL source → opens in a new tab; URL-less source → scrolls to + briefly highlights its entry in the bottom list. Unmatched/hallucinated numbers degrade to plain text.
4. **Bottom list** — now filtered to only the sources actually cited inline (numbering preserved), falling back to all sources when a reply cites none. This resolves the mismatch where the text cited `[1][2]` but the list showed all retrieved candidates `[1]-[5]`.

## Notable decisions

- Reused the existing numbering: grounding chunks were already labelled `[1]`, `[2]` matching `Source.id`, so no retrieval/agent changes were needed.
- Chose prompt-driven markers over the native Anthropic Citations API — far less pipeline rework given the numbering already lines up. (Tradeoff: best-effort model compliance, handled by graceful degradation.)
- `unified` + `remark-parse` added as **dev-only** deps (used solely by the plugin's unit test).

## Testing

- TDD throughout: remark plugin, `CitationMarker`, `MarkdownMessage` inline rendering, bottom-list filtering, and the grounded/ungrounded prompt branch.
- Full suite green: **508 passed**, 0 failures. `tsc --noEmit` clean, Biome clean, `pnpm build` exit 0.
- Manual smoke (`pnpm dev` + real Claude call) not yet run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
