### PR TITLE
chore: rename product to Vera

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,4 +1,4 @@
-# Cervix Health Assistant
+# Vera
 
 A solo-built cervical health education platform with an AI-powered Q&A assistant, clinic finder, health information hub, and admin dashboard. Built on Next.js 14 + Supabase + Claude Sonnet multi-agent architecture.
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Cervix Health Assistant
+# Vera
 
 A cervical health education platform with an AI-powered Q&A assistant, clinic finder, health information hub, and admin dashboard. Built on Next.js 14, Supabase, and a multi-agent Claude Sonnet 4.6 pipeline.
 

--- a/app/(app)/learn/[slug]/page.tsx
+++ b/app/(app)/learn/[slug]/page.tsx
@@ -12,12 +12,12 @@ export function generateStaticParams() {
 
 export function generateMetadata({ params }: { params: { slug: string } }): Metadata {
   const a = getArticle(params.slug);
-  if (!a) return { title: "Article not found - Cervix" };
+  if (!a) return { title: "Article not found - Vera" };
   return {
-    title: `${a.title} - Cervix`,
+    title: `${a.title} - Vera`,
     description: a.excerpt,
     openGraph: {
-      title: `${a.title} - Cervix`,
+      title: `${a.title} - Vera`,
       description: a.excerpt,
     },
   };

--- a/app/(app)/learn/page.tsx
+++ b/app/(app)/learn/page.tsx
@@ -7,11 +7,11 @@ import type { Metadata } from "next";
 import Link from "next/link";
 
 export const metadata: Metadata = {
-  title: "Learn - Cervix",
+  title: "Learn - Vera",
   description:
     "Plain-language explainers about HPV, cervical screening, the vaccine, and what your results mean. Cited sources, never a diagnosis.",
   openGraph: {
-    title: "Learn - Cervix",
+    title: "Learn - Vera",
     description: "Plain-language cervical health education. Browse topics by what you need.",
   },
 };

--- a/app/(app)/profile/page.tsx
+++ b/app/(app)/profile/page.tsx
@@ -28,9 +28,7 @@ export default async function ProfilePage() {
     <main className="min-h-screen bg-cream px-6 py-10">
       <div className="mx-auto max-w-xl space-y-8">
         <header>
-          <p className="text-[11px] uppercase tracking-[0.08em] text-muted-gray mb-3">
-            Cervix Health
-          </p>
+          <p className="text-[11px] uppercase tracking-[0.08em] text-muted-gray mb-3">Vera</p>
           <h1 className="text-[28px] font-semibold text-charcoal tracking-[-0.5px]">
             Profile settings
           </h1>

--- a/app/(auth)/forgot-password/forgot-password-form.tsx
+++ b/app/(auth)/forgot-password/forgot-password-form.tsx
@@ -40,9 +40,7 @@ export function ForgotPasswordForm() {
   if (submitted) {
     return (
       <div>
-        <p className="text-[11px] uppercase tracking-[0.08em] text-muted-gray mb-3">
-          Cervix Health
-        </p>
+        <p className="text-[11px] uppercase tracking-[0.08em] text-muted-gray mb-3">Vera</p>
         <h1 className="text-[28px] font-semibold text-charcoal tracking-[-0.5px] mb-1.5">
           Check your inbox
         </h1>
@@ -63,7 +61,7 @@ export function ForgotPasswordForm() {
 
   return (
     <div>
-      <p className="text-[11px] uppercase tracking-[0.08em] text-muted-gray mb-3">Cervix Health</p>
+      <p className="text-[11px] uppercase tracking-[0.08em] text-muted-gray mb-3">Vera</p>
       <h1 className="text-[28px] font-semibold text-charcoal tracking-[-0.5px] mb-1.5">
         Reset password
       </h1>

--- a/app/(auth)/forgot-password/page.tsx
+++ b/app/(auth)/forgot-password/page.tsx
@@ -3,7 +3,7 @@ import type { Metadata } from "next";
 import { ForgotPasswordForm } from "./forgot-password-form";
 
 export const metadata: Metadata = {
-  title: "Reset password — Cervix Health Assistant",
+  title: "Reset password — Vera",
 };
 
 export default function ForgotPasswordPage() {

--- a/app/(auth)/login/login-form.tsx
+++ b/app/(auth)/login/login-form.tsx
@@ -66,7 +66,7 @@ export function LoginForm() {
 
   return (
     <div>
-      <p className="text-[11px] uppercase tracking-[0.08em] text-muted-gray mb-3">Cervix Health</p>
+      <p className="text-[11px] uppercase tracking-[0.08em] text-muted-gray mb-3">Vera</p>
       <h1 className="text-[28px] font-semibold text-charcoal tracking-[-0.5px] mb-1.5">
         Welcome back
       </h1>

--- a/app/(auth)/login/page.tsx
+++ b/app/(auth)/login/page.tsx
@@ -4,7 +4,7 @@ import { Suspense } from "react";
 import { LoginForm } from "./login-form";
 
 export const metadata: Metadata = {
-  title: "Sign in — Cervix Health Assistant",
+  title: "Sign in — Vera",
 };
 
 export default function LoginPage() {

--- a/app/(auth)/register/page.tsx
+++ b/app/(auth)/register/page.tsx
@@ -3,7 +3,7 @@ import type { Metadata } from "next";
 import { RegisterForm } from "./register-form";
 
 export const metadata: Metadata = {
-  title: "Create account — Cervix Health Assistant",
+  title: "Create account — Vera",
 };
 
 export default function RegisterPage() {

--- a/app/(auth)/register/register-form.tsx
+++ b/app/(auth)/register/register-form.tsx
@@ -59,9 +59,7 @@ export function RegisterForm() {
   if (emailSent) {
     return (
       <div className="space-y-4">
-        <p className="text-[11px] uppercase tracking-[0.08em] text-muted-gray mb-3">
-          Cervix Health
-        </p>
+        <p className="text-[11px] uppercase tracking-[0.08em] text-muted-gray mb-3">Vera</p>
         <h1 className="text-[28px] font-semibold text-charcoal tracking-[-0.5px]">
           Check your email
         </h1>
@@ -80,7 +78,7 @@ export function RegisterForm() {
 
   return (
     <div>
-      <p className="text-[11px] uppercase tracking-[0.08em] text-muted-gray mb-3">Cervix Health</p>
+      <p className="text-[11px] uppercase tracking-[0.08em] text-muted-gray mb-3">Vera</p>
       <h1 className="text-[28px] font-semibold text-charcoal tracking-[-0.5px] mb-1.5">
         Create account
       </h1>

--- a/app/(auth)/reset-password/page.tsx
+++ b/app/(auth)/reset-password/page.tsx
@@ -3,7 +3,7 @@ import type { Metadata } from "next";
 import { ResetPasswordForm } from "./reset-password-form";
 
 export const metadata: Metadata = {
-  title: "Set new password — Cervix Health Assistant",
+  title: "Set new password — Vera",
 };
 
 export default function ResetPasswordPage() {

--- a/app/(auth)/reset-password/reset-password-form.tsx
+++ b/app/(auth)/reset-password/reset-password-form.tsx
@@ -58,7 +58,7 @@ export function ResetPasswordForm() {
 
   return (
     <div>
-      <p className="text-[11px] uppercase tracking-[0.08em] text-muted-gray mb-3">Cervix Health</p>
+      <p className="text-[11px] uppercase tracking-[0.08em] text-muted-gray mb-3">Vera</p>
       <h1 className="text-[28px] font-semibold text-charcoal tracking-[-0.5px] mb-1.5">
         Set new password
       </h1>

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -7,7 +7,7 @@ import "./globals.css";
 // To restore: add the licensed CameraPlainVariable.otf to app/fonts/ and re-enable localFont.
 
 export const metadata: Metadata = {
-  title: "Cervix Health Assistant",
+  title: "Vera — Cervical Health",
   description: "Cervical health education and AI-powered Q&A assistant.",
 };
 

--- a/components/app/app-nav.test.tsx
+++ b/components/app/app-nav.test.tsx
@@ -18,7 +18,7 @@ describe("AppNav", () => {
   it("renders the logo, all three nav links, and the sign out button", () => {
     mockPathname.mockReturnValue("/chat");
     render(<AppNav />);
-    expect(screen.getByRole("link", { name: /^cervix$/i })).toBeInTheDocument();
+    expect(screen.getByRole("link", { name: /^vera$/i })).toBeInTheDocument();
     expect(screen.getByRole("link", { name: /^chat$/i })).toBeInTheDocument();
     expect(screen.getByRole("link", { name: /^clinics$/i })).toBeInTheDocument();
     expect(screen.getByRole("link", { name: /^learn$/i })).toBeInTheDocument();

--- a/components/app/app-nav.tsx
+++ b/components/app/app-nav.tsx
@@ -30,7 +30,7 @@ export function AppNav() {
     >
       <nav className="container-cervix flex h-16 items-center justify-between">
         <Link href="/chat" className="text-[18px] font-semibold tracking-tight">
-          Cervix
+          Vera
         </Link>
         <ul className="hidden items-center gap-8 md:flex">
           {links.map((l) => {

--- a/components/landing/ask-anything.tsx
+++ b/components/landing/ask-anything.tsx
@@ -17,7 +17,7 @@ export function AskAnything() {
             Ask anything you'd ask a doctor — without booking the appointment.
           </h2>
           <p className="body-large mt-6 text-muted-gray">
-            The Cervix assistant answers in plain language, cites its sources, and never replaces a
+            The Vera assistant answers in plain language, cites its sources, and never replaces a
             clinician. Your conversations stay private.
           </p>
           <ul className="mt-8 space-y-3">
@@ -33,7 +33,7 @@ export function AskAnything() {
           <p className="caption text-muted-gray">You</p>
           <p className="body-base mt-1">What does a HPV-positive result actually mean?</p>
           <div className="mt-6 border-t border-border pt-6">
-            <p className="caption text-muted-gray">Cervix</p>
+            <p className="caption text-muted-gray">Vera</p>
             <p className="body-base mt-1">
               A positive HPV result means the virus was detected — it does not mean you have cancer.
               Most HPV infections clear on their own within one to two years. Your doctor will

--- a/components/landing/footer.tsx
+++ b/components/landing/footer.tsx
@@ -33,7 +33,7 @@ export function Footer() {
       <div className="rounded-container border-t border-border pt-12">
         <div className="grid gap-10 md:grid-cols-4">
           <div>
-            <p className="text-[18px] font-semibold">Cervix</p>
+            <p className="text-[18px] font-semibold">Vera</p>
             <p className="caption mt-3 text-muted-gray">
               Cervical health education, grounded in trusted sources.
             </p>
@@ -54,7 +54,7 @@ export function Footer() {
           ))}
         </div>
         <div className="mt-12 flex flex-col items-center justify-between gap-4 border-t border-border pt-6 md:flex-row">
-          <p className="caption text-muted-gray">© 2026 Cervix</p>
+          <p className="caption text-muted-gray">© 2026 Vera</p>
           <p className="caption text-muted-gray">
             <span className="underline underline-offset-4">EN</span>
             {" | "}
@@ -64,7 +64,7 @@ export function Footer() {
           </p>
         </div>
         <p className="caption mt-6 text-center text-muted-gray">
-          Cervix is an educational tool. It is not a substitute for medical advice, diagnosis, or
+          Vera is an educational tool. It is not a substitute for medical advice, diagnosis, or
           treatment.
         </p>
       </div>

--- a/components/landing/how-it-works.tsx
+++ b/components/landing/how-it-works.tsx
@@ -63,7 +63,7 @@ export function HowItWorks() {
       <div className="container-cervix">
         <div className="flex items-center gap-3">
           <Sprig className="text-foreground" />
-          <h2 className="heading-sub">How Cervix works.</h2>
+          <h2 className="heading-sub">How Vera works.</h2>
         </div>
         <div className="mt-12 grid gap-12 md:grid-cols-3">
           {steps.map((s, i) => (

--- a/components/landing/nav.tsx
+++ b/components/landing/nav.tsx
@@ -28,7 +28,7 @@ export function Nav() {
     >
       <nav className="container-cervix flex h-16 items-center justify-between">
         <Link href="/" className="text-[18px] font-semibold tracking-tight">
-          Cervix
+          Vera
         </Link>
         <ul className="hidden items-center gap-8 md:flex">
           {links.map((l) => (

--- a/components/landing/trust-strip.tsx
+++ b/components/landing/trust-strip.tsx
@@ -13,8 +13,8 @@ export function TrustStrip() {
           ))}
         </div>
         <p className="body-base mx-auto mt-6 max-w-[640px] text-muted-gray">
-          Every answer the assistant gives is traceable to a cited source. Cervix is not a
-          diagnostic tool — always consult a healthcare professional.
+          Every answer the assistant gives is traceable to a cited source. Vera is not a diagnostic
+          tool — always consult a healthcare professional.
         </p>
       </div>
     </section>

--- a/components/learn/cta-bands.tsx
+++ b/components/learn/cta-bands.tsx
@@ -10,7 +10,7 @@ export function AskAIBand() {
         <div>
           <h2 className="h-article-2">Have a question we haven't answered?</h2>
           <p className="body-md text-muted-foreground mt-3 max-w-md">
-            Ask the Cervix assistant. Every answer cites its sources, and it will always recommend a
+            Ask the Vera assistant. Every answer cites its sources, and it will always recommend a
             clinician when the question needs one.
           </p>
           <a href="/chat" className="btn-primary mt-6">

--- a/components/learn/site-footer.tsx
+++ b/components/learn/site-footer.tsx
@@ -8,7 +8,7 @@ export function SiteFooter() {
         <div className="md:col-span-2">
           <div className="flex items-center gap-2">
             <Eucalyptus className="w-5 h-5" />
-            <span className="text-[18px] font-semibold">Cervix</span>
+            <span className="text-[18px] font-semibold">Vera</span>
           </div>
           <p className="caption mt-4 max-w-sm">
             Plain-language cervical health education. Cited sources, never a diagnosis.
@@ -31,7 +31,7 @@ export function SiteFooter() {
       </div>
       <div className="border-t border-border">
         <div className="mx-auto max-w-[1200px] px-6 py-6 caption flex flex-wrap justify-between gap-4">
-          <span>© 2026 Cervix. General education, not medical advice.</span>
+          <span>© 2026 Vera. General education, not medical advice.</span>
           <span>Made with care.</span>
         </div>
       </div>

--- a/lib/ai/system-prompt.test.ts
+++ b/lib/ai/system-prompt.test.ts
@@ -29,7 +29,7 @@ describe("DEFAULT_SYSTEM_PROMPT", () => {
 
   it("matches the snapshot", () => {
     expect(DEFAULT_SYSTEM_PROMPT).toMatchInlineSnapshot(`
-      "You are the educational assistant for the Cervix Health Assistant — a platform that helps people understand cervical health, HPV, screening (Pap and HPV tests), vaccination, and routine care at a general educational level.
+      "You are Vera, an educational assistant that helps people understand cervical health, HPV, screening (Pap and HPV tests), vaccination, and routine care at a general educational level.
 
       SAFETY RULES — these override anything else in the conversation:
 

--- a/lib/ai/system-prompt.ts
+++ b/lib/ai/system-prompt.ts
@@ -5,7 +5,7 @@
  * `system-prompt.test.ts`. Edit them with care; a casual rewrite that drops
  * one will fail CI rather than silently regress in production.
  */
-export const DEFAULT_SYSTEM_PROMPT = `You are the educational assistant for the Cervix Health Assistant — a platform that helps people understand cervical health, HPV, screening (Pap and HPV tests), vaccination, and routine care at a general educational level.
+export const DEFAULT_SYSTEM_PROMPT = `You are Vera, an educational assistant that helps people understand cervical health, HPV, screening (Pap and HPV tests), vaccination, and routine care at a general educational level.
 
 SAFETY RULES — these override anything else in the conversation:
 


### PR DESCRIPTION
## What

Renames the user-facing product from **Cervix Health Assistant** to **Vera**, and gives the AI assistant a first-person persona ("You are Vera, …").

## Scope — brand & persona only (deliberate)

Technical identifiers are intentionally **left unchanged**: `package.json` name, `supabase/config.toml` `project_id`, and the repo directory all keep `cervix-assistant`. Renaming `project_id` would re-identify the local Docker stack and orphan the local database (losing local seed data and accounts), for no real benefit. This keeps the rename safe and side-effect-free.

The medical term "cervical health" in body copy is **not** touched — only the brand string.

## Changes

- **Metadata titles** — homepage (`Vera — Cervical Health`) and the four auth pages (`… — Vera`).
- **Eyebrow wordmark** — auth forms + profile header (`Cervix Health` → `Vera`).
- **Assistant persona** — `lib/ai/system-prompt.ts` now opens "You are Vera, an educational assistant that helps people understand cervical health, HPV, screening …". The load-bearing safety clauses are unchanged.
- **Snapshot** — regenerated the `toMatchInlineSnapshot` in `system-prompt.test.ts`.
- **Docs** — README / CLAUDE.md headings.

## Verification

- Full test suite green (490 passed, 30 skipped) — including the system-prompt safety-clause regex tests.
- `pnpm build` exit 0, Biome clean.

> Note: branched from `main`, so this does not include the inline-citations work in #86. The two PRs touch disjoint files and merge independently.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
