### PR TITLE
feat(admin): knowledge gaps view + manual seed, admin nav link

### DIFF
--- a/app/(app)/admin/knowledge/gaps/add-gap-form.test.tsx
+++ b/app/(app)/admin/knowledge/gaps/add-gap-form.test.tsx
@@ -1,0 +1,38 @@
+// @vitest-environment jsdom
+
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, test, vi } from "vitest";
+
+vi.mock("sonner", () => ({ toast: { success: vi.fn(), error: vi.fn() } }));
+vi.mock("@/lib/discovery/gap-actions", () => ({ addManualGap: vi.fn() }));
+
+import { addManualGap } from "@/lib/discovery/gap-actions";
+import { toast } from "sonner";
+import { AddGapForm } from "./add-gap-form";
+
+describe("AddGapForm", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  test("submits the question and toasts success", async () => {
+    vi.mocked(addManualGap).mockResolvedValue(undefined);
+    render(<AddGapForm />);
+
+    fireEvent.change(screen.getByLabelText(/gap question/i), {
+      target: { value: "When is the HPV booster due?" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: /add gap/i }));
+
+    await waitFor(() => expect(toast.success).toHaveBeenCalled());
+    expect(addManualGap).toHaveBeenCalledWith("When is the HPV booster due?");
+  });
+
+  test("toasts an error when the action rejects", async () => {
+    vi.mocked(addManualGap).mockRejectedValue(new Error("fail"));
+    render(<AddGapForm />);
+
+    fireEvent.change(screen.getByLabelText(/gap question/i), { target: { value: "x" } });
+    fireEvent.click(screen.getByRole("button", { name: /add gap/i }));
+
+    await waitFor(() => expect(toast.error).toHaveBeenCalled());
+  });
+});

--- a/app/(app)/admin/knowledge/gaps/add-gap-form.tsx
+++ b/app/(app)/admin/knowledge/gaps/add-gap-form.tsx
@@ -1,0 +1,50 @@
+"use client";
+
+import { Button } from "@/components/ui/button";
+import { addManualGap } from "@/lib/discovery/gap-actions";
+import { useState } from "react";
+import { toast } from "sonner";
+
+/** Admin-only form to seed a knowledge gap by hand (drives discovery). */
+export function AddGapForm() {
+  const [question, setQuestion] = useState("");
+  const [pending, setPending] = useState(false);
+
+  async function onSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    setPending(true);
+    try {
+      await addManualGap(question.trim());
+      toast.success("Gap added. Run discovery to find sources for it.");
+      setQuestion("");
+    } catch {
+      toast.error("Could not add the gap. Check the question and try again.");
+    } finally {
+      setPending(false);
+    }
+  }
+
+  return (
+    <form
+      onSubmit={onSubmit}
+      className="space-y-3 rounded-lg border border-[#eceae4] bg-[#fcfbf8] p-5"
+    >
+      <h2 className="text-lg font-medium text-charcoal">Add a gap</h2>
+      <p className="text-sm text-muted-gray">
+        Seed a question the knowledge base should cover. It enters the same queue as gaps from real
+        user questions.
+      </p>
+      <input
+        aria-label="Gap question"
+        placeholder="e.g. When is the HPV booster due?"
+        value={question}
+        onChange={(e) => setQuestion(e.target.value)}
+        maxLength={200}
+        className="w-full rounded border border-[#eceae4] bg-cream px-3 py-2 text-sm text-charcoal placeholder:text-muted-gray"
+      />
+      <Button type="submit" disabled={pending || !question.trim()}>
+        {pending ? "Adding…" : "Add gap"}
+      </Button>
+    </form>
+  );
+}

--- a/app/(app)/admin/knowledge/gaps/gap-row.test.tsx
+++ b/app/(app)/admin/knowledge/gaps/gap-row.test.tsx
@@ -1,0 +1,39 @@
+// @vitest-environment jsdom
+
+import { render, screen } from "@testing-library/react";
+import { describe, expect, test } from "vitest";
+import { GapRow } from "./gap-row";
+
+const base = {
+  id: "g1",
+  question: "When is the HPV booster due?",
+  topScore: 0.41,
+  source: "user" as const,
+  createdAt: "2026-06-20T00:00:00Z",
+  addressed: false,
+};
+
+describe("GapRow", () => {
+  test("renders the question and a User source badge", () => {
+    render(<GapRow gap={base} />);
+    expect(screen.getByText(/when is the hpv booster due\?/i)).toBeInTheDocument();
+    expect(screen.getByText(/^user$/i)).toBeInTheDocument();
+  });
+
+  test("shows a Manual badge for manual gaps", () => {
+    render(<GapRow gap={{ ...base, source: "manual" }} />);
+    expect(screen.getByText(/^manual$/i)).toBeInTheDocument();
+  });
+
+  test("shows an Addressed badge only when addressed", () => {
+    const { rerender } = render(<GapRow gap={base} />);
+    expect(screen.queryByText(/addressed/i)).not.toBeInTheDocument();
+    rerender(<GapRow gap={{ ...base, addressed: true }} />);
+    expect(screen.getByText(/addressed/i)).toBeInTheDocument();
+  });
+
+  test("renders an em dash when topScore is null", () => {
+    render(<GapRow gap={{ ...base, topScore: null }} />);
+    expect(screen.getByText("—")).toBeInTheDocument();
+  });
+});

--- a/app/(app)/admin/knowledge/gaps/gap-row.tsx
+++ b/app/(app)/admin/knowledge/gaps/gap-row.tsx
@@ -1,0 +1,29 @@
+import type { KnowledgeGap } from "@/lib/discovery/gaps";
+
+/** One row in the admin gaps list. Presentational; no data fetching. */
+export function GapRow({ gap }: { gap: KnowledgeGap }) {
+  const date = new Date(gap.createdAt).toLocaleDateString();
+  const badge = "inline-flex items-center rounded-full px-2 py-0.5 text-xs font-medium";
+
+  return (
+    <li className="rounded-lg border border-[#eceae4] bg-[#fcfbf8] p-4">
+      <div className="flex items-start justify-between gap-3">
+        <p className="text-sm text-charcoal">{gap.question}</p>
+        <div className="flex shrink-0 items-center gap-2">
+          <span className={`${badge} bg-[#eceae4] text-charcoal`}>
+            {gap.source === "manual" ? "Manual" : "User"}
+          </span>
+          {gap.addressed ? (
+            <span className={`${badge} bg-[#e3efe3] text-charcoal`}>Addressed</span>
+          ) : null}
+        </div>
+      </div>
+      <div className="mt-2 flex items-center gap-4 text-xs text-muted-gray">
+        <span>
+          score: <span>{gap.topScore === null ? "—" : gap.topScore.toFixed(2)}</span>
+        </span>
+        <span>{date}</span>
+      </div>
+    </li>
+  );
+}

--- a/app/(app)/admin/knowledge/gaps/gap-row.tsx
+++ b/app/(app)/admin/knowledge/gaps/gap-row.tsx
@@ -2,7 +2,7 @@ import type { KnowledgeGap } from "@/lib/discovery/gaps";
 
 /** One row in the admin gaps list. Presentational; no data fetching. */
 export function GapRow({ gap }: { gap: KnowledgeGap }) {
-  const date = new Date(gap.createdAt).toLocaleDateString();
+  const date = gap.createdAt ? new Date(gap.createdAt).toLocaleDateString() : "";
   const badge = "inline-flex items-center rounded-full px-2 py-0.5 text-xs font-medium";
 
   return (

--- a/app/(app)/admin/knowledge/gaps/page.tsx
+++ b/app/(app)/admin/knowledge/gaps/page.tsx
@@ -1,0 +1,51 @@
+import { requireAdmin } from "@/lib/auth/require-admin";
+import { GAP_LOOKBACK_DAYS } from "@/lib/discovery/constants";
+import { listRecentGaps } from "@/lib/discovery/gaps";
+import Link from "next/link";
+import { RunDiscoveryButton } from "../run-discovery-button";
+import { AddGapForm } from "./add-gap-form";
+import { GapRow } from "./gap-row";
+
+// Always render fresh — the list changes as gaps are added and addressed.
+export const dynamic = "force-dynamic";
+
+export default async function KnowledgeGapsPage() {
+  const { supabase } = await requireAdmin();
+  const gaps = await listRecentGaps(supabase);
+
+  return (
+    <main className="min-h-screen bg-cream px-6 py-10">
+      <div className="mx-auto max-w-3xl space-y-8">
+        <header className="flex items-center justify-between gap-4">
+          <div>
+            <h1 className="text-2xl font-medium text-charcoal">Knowledge gaps</h1>
+            <p className="mt-1 text-sm text-muted-gray">
+              {gaps.length} gap{gaps.length === 1 ? "" : "s"} from the last {GAP_LOOKBACK_DAYS} days
+            </p>
+          </div>
+          <div className="flex items-center gap-3">
+            <Link href="/admin/knowledge" className="text-sm text-charcoal underline">
+              ← Review queue
+            </Link>
+            <RunDiscoveryButton />
+          </div>
+        </header>
+
+        <AddGapForm />
+
+        {gaps.length === 0 ? (
+          <p className="rounded-lg border border-[#eceae4] bg-[#fcfbf8] p-8 text-center text-sm text-muted-gray">
+            No gaps in the last {GAP_LOOKBACK_DAYS} days. Add one above, or wait for user questions
+            the knowledge base answers poorly.
+          </p>
+        ) : (
+          <ul className="space-y-3">
+            {gaps.map((gap) => (
+              <GapRow key={gap.id} gap={gap} />
+            ))}
+          </ul>
+        )}
+      </div>
+    </main>
+  );
+}

--- a/app/(app)/admin/knowledge/page.tsx
+++ b/app/(app)/admin/knowledge/page.tsx
@@ -22,6 +22,9 @@ export default async function KnowledgeReviewPage() {
             </p>
           </div>
           <div className="flex items-center gap-3">
+            <Link href="/admin/knowledge/gaps" className="text-sm text-charcoal underline">
+              View gaps →
+            </Link>
             <Link href="/admin/knowledge/documents" className="text-sm text-charcoal underline">
               Manage documents →
             </Link>

--- a/app/(app)/layout.tsx
+++ b/app/(app)/layout.tsx
@@ -1,13 +1,16 @@
 import { AppNav } from "@/components/app/app-nav";
+import { isCurrentUserAdmin } from "@/lib/auth/require-admin";
 
-export default function AppLayout({
+export default async function AppLayout({
   children,
 }: {
   children: React.ReactNode;
 }) {
+  const isAdmin = await isCurrentUserAdmin();
+
   return (
     <div className="flex min-h-screen flex-col">
-      <AppNav />
+      <AppNav isAdmin={isAdmin} />
       {/* flex flex-col makes <main> a flex container so chat's nested flex-1 chain
           (sidebar/messages/input) gets a definite height to grow into. Routes that
           rely on natural sizing (clinics/profile use min-h-screen) still work as

--- a/components/app/app-nav.test.tsx
+++ b/components/app/app-nav.test.tsx
@@ -50,6 +50,26 @@ describe("AppNav", () => {
     expect(screen.getByRole("link", { name: /^learn$/i })).not.toHaveAttribute("aria-current");
   });
 
+  it("does not render an Admin link by default", () => {
+    mockPathname.mockReturnValue("/chat");
+    render(<AppNav />);
+    expect(screen.queryByRole("link", { name: /^admin$/i })).not.toBeInTheDocument();
+  });
+
+  it("renders an Admin link to /admin/knowledge when isAdmin", () => {
+    mockPathname.mockReturnValue("/chat");
+    render(<AppNav isAdmin />);
+    const adminLink = screen.getByRole("link", { name: /^admin$/i });
+    expect(adminLink).toBeInTheDocument();
+    expect(adminLink).toHaveAttribute("href", "/admin/knowledge");
+  });
+
+  it("marks the Admin link active on /admin routes", () => {
+    mockPathname.mockReturnValue("/admin/knowledge/gaps");
+    render(<AppNav isAdmin />);
+    expect(screen.getByRole("link", { name: /^admin$/i })).toHaveAttribute("aria-current", "page");
+  });
+
   it("hides the link list and sign out button on mobile via Tailwind classes", () => {
     mockPathname.mockReturnValue("/chat");
     const { container } = render(<AppNav />);

--- a/components/app/app-nav.tsx
+++ b/components/app/app-nav.tsx
@@ -11,7 +11,7 @@ const links = [
   { label: "Learn", href: "/learn" },
 ];
 
-export function AppNav() {
+export function AppNav({ isAdmin = false }: { isAdmin?: boolean }) {
   const pathname = usePathname();
   const [scrolled, setScrolled] = useState(false);
 
@@ -49,6 +49,19 @@ export function AppNav() {
               </li>
             );
           })}
+          {isAdmin ? (
+            <li>
+              <Link
+                href="/admin/knowledge"
+                className={`text-base underline-offset-4 hover:underline ${
+                  pathname.startsWith("/admin") ? "underline" : ""
+                }`}
+                aria-current={pathname.startsWith("/admin") ? "page" : undefined}
+              >
+                Admin
+              </Link>
+            </li>
+          ) : null}
         </ul>
         <div className="hidden md:inline-flex">
           <SignOutButton />

--- a/lib/auth/require-admin.ts
+++ b/lib/auth/require-admin.ts
@@ -29,3 +29,23 @@ export async function requireAdmin(): Promise<AdminContext> {
 
   return { supabase, user };
 }
+
+/**
+ * Non-redirecting admin check for shared surfaces (e.g. the (app) layout/nav).
+ * Returns false for guests and non-admins instead of redirecting, so it is safe
+ * to call on routes that all authenticated users can see.
+ */
+export async function isCurrentUserAdmin(): Promise<boolean> {
+  const supabase = createClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+  if (!user) return false;
+
+  const { data: profile } = await supabase
+    .from("profiles")
+    .select("role")
+    .eq("id", user.id)
+    .single();
+  return profile?.role === "admin";
+}

--- a/lib/discovery/gap-actions.test.ts
+++ b/lib/discovery/gap-actions.test.ts
@@ -1,0 +1,55 @@
+// @vitest-environment node
+
+import { beforeEach, describe, expect, test, vi } from "vitest";
+
+vi.mock("@/lib/auth/require-admin", () => ({ requireAdmin: vi.fn() }));
+vi.mock("next/cache", () => ({ revalidatePath: vi.fn() }));
+
+import { requireAdmin } from "@/lib/auth/require-admin";
+import { revalidatePath } from "next/cache";
+import { addManualGap } from "./gap-actions";
+
+function fakeAdmin(insertError: unknown = null) {
+  const insert = vi.fn().mockResolvedValue({ error: insertError });
+  const from = vi.fn().mockReturnValue({ insert });
+  return { supabase: { from }, user: { id: "admin-1" }, from, insert };
+}
+
+describe("addManualGap", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  test("inserts a manual rag_gap event attributed to the admin", async () => {
+    const ctx = fakeAdmin();
+    vi.mocked(requireAdmin).mockResolvedValue(ctx as never);
+
+    await addManualGap("  When is the HPV booster due?  ");
+
+    expect(ctx.from).toHaveBeenCalledWith("analytics_events");
+    expect(ctx.insert).toHaveBeenCalledWith({
+      user_id: "admin-1",
+      event_type: "rag_gap",
+      payload: { question: "When is the HPV booster due?", top_score: 0, source: "manual" },
+    });
+    expect(revalidatePath).toHaveBeenCalledWith("/admin/knowledge/gaps");
+  });
+
+  test("rejects an empty question without inserting", async () => {
+    const ctx = fakeAdmin();
+    vi.mocked(requireAdmin).mockResolvedValue(ctx as never);
+    await expect(addManualGap("   ")).rejects.toThrow();
+    expect(ctx.insert).not.toHaveBeenCalled();
+  });
+
+  test("rejects an over-length question (> 200 chars)", async () => {
+    const ctx = fakeAdmin();
+    vi.mocked(requireAdmin).mockResolvedValue(ctx as never);
+    await expect(addManualGap("x".repeat(201))).rejects.toThrow();
+    expect(ctx.insert).not.toHaveBeenCalled();
+  });
+
+  test("throws when the insert errors", async () => {
+    const ctx = fakeAdmin({ message: "rls denied" });
+    vi.mocked(requireAdmin).mockResolvedValue(ctx as never);
+    await expect(addManualGap("valid question")).rejects.toThrow("rls denied");
+  });
+});

--- a/lib/discovery/gap-actions.ts
+++ b/lib/discovery/gap-actions.ts
@@ -1,0 +1,29 @@
+"use server";
+
+import { requireAdmin } from "@/lib/auth/require-admin";
+import { revalidatePath } from "next/cache";
+import { z } from "zod";
+
+// Length cap matches QUESTION_MAX in lib/ai/rag-gap.ts so manual and
+// real gaps store comparable question text.
+const questionSchema = z.string().trim().min(1).max(200);
+
+/**
+ * Add a knowledge gap by hand. Stored as a `rag_gap` analytics event so it
+ * flows through the existing mineGaps pipeline unchanged; `source: "manual"`
+ * is display-only. Inserted via the admin's RLS-bound client (the
+ * "users can insert own" policy allows auth.uid() = user_id). Admin-only.
+ */
+export async function addManualGap(question: string): Promise<void> {
+  const validQuestion = questionSchema.parse(question);
+  const { supabase, user } = await requireAdmin();
+
+  const { error } = await supabase.from("analytics_events").insert({
+    user_id: user.id,
+    event_type: "rag_gap",
+    payload: { question: validQuestion, top_score: 0, source: "manual" },
+  });
+  if (error) throw new Error(error.message);
+
+  revalidatePath("/admin/knowledge/gaps");
+}

--- a/lib/discovery/gaps.test.ts
+++ b/lib/discovery/gaps.test.ts
@@ -1,0 +1,79 @@
+// @vitest-environment node
+
+import { beforeEach, describe, expect, test, vi } from "vitest";
+import { listRecentGaps } from "./gaps";
+
+// Two tables are read: analytics_events (the gap events) and
+// knowledge_candidates (to compute "addressed"). The fake branches on table.
+function fakeAdmin(gapRows: unknown[], candRows: unknown[], opts: { gapErr?: unknown } = {}) {
+  const analytics = {
+    select: vi.fn().mockReturnValue({
+      eq: vi.fn().mockReturnValue({
+        gte: vi.fn().mockReturnValue({
+          order: vi.fn().mockResolvedValue({ data: gapRows, error: opts.gapErr ?? null }),
+        }),
+      }),
+    }),
+  };
+  const candidates = {
+    select: vi.fn().mockResolvedValue({ data: candRows, error: null }),
+  };
+  const from = vi.fn((table: string) => (table === "analytics_events" ? analytics : candidates));
+  return { client: { from }, from };
+}
+
+describe("listRecentGaps", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  test("maps rows, defaults source to user, and flags addressed via gap_refs", async () => {
+    const gapRows = [
+      {
+        id: "g1",
+        payload: { question: "what is hpv?", top_score: 0.4 },
+        created_at: "2026-06-20T00:00:00Z",
+      },
+      {
+        id: "g2",
+        payload: { question: "booster timing?", top_score: 0, source: "manual" },
+        created_at: "2026-06-21T00:00:00Z",
+      },
+    ];
+    const candRows = [{ gap_refs: ["g1"] }];
+    const { client, from } = fakeAdmin(gapRows, candRows);
+
+    const out = await listRecentGaps(client as never);
+
+    expect(from).toHaveBeenCalledWith("analytics_events");
+    expect(from).toHaveBeenCalledWith("knowledge_candidates");
+    expect(out).toEqual([
+      {
+        id: "g1",
+        question: "what is hpv?",
+        topScore: 0.4,
+        source: "user",
+        createdAt: "2026-06-20T00:00:00Z",
+        addressed: true,
+      },
+      {
+        id: "g2",
+        question: "booster timing?",
+        topScore: 0,
+        source: "manual",
+        createdAt: "2026-06-21T00:00:00Z",
+        addressed: false,
+      },
+    ]);
+  });
+
+  test("drops events with no usable question text", async () => {
+    const gapRows = [{ id: "g3", payload: {}, created_at: "2026-06-22T00:00:00Z" }];
+    const { client } = fakeAdmin(gapRows, []);
+    const out = await listRecentGaps(client as never);
+    expect(out).toEqual([]);
+  });
+
+  test("throws on a gap query error", async () => {
+    const { client } = fakeAdmin([], [], { gapErr: { message: "boom" } });
+    await expect(listRecentGaps(client as never)).rejects.toThrow("boom");
+  });
+});

--- a/lib/discovery/gaps.ts
+++ b/lib/discovery/gaps.ts
@@ -1,0 +1,58 @@
+import type { Database } from "@/types/supabase";
+import type { SupabaseClient } from "@supabase/supabase-js";
+import { GAP_LOOKBACK_DAYS } from "./constants";
+
+export type KnowledgeGap = {
+  id: string;
+  question: string;
+  topScore: number | null;
+  source: "user" | "manual";
+  createdAt: string;
+  addressed: boolean;
+};
+
+type GapPayload = { question?: unknown; top_score?: unknown; source?: unknown };
+
+/**
+ * List rag_gap events from the last GAP_LOOKBACK_DAYS (newest first), each
+ * flagged `addressed` when its id appears in a knowledge_candidates.gap_refs
+ * array — the same "already handled" test mineGaps uses. Admin-only by RLS;
+ * call under an admin-bound client (e.g. from requireAdmin()).
+ */
+export async function listRecentGaps(supabase: SupabaseClient<Database>): Promise<KnowledgeGap[]> {
+  const since = new Date(Date.now() - GAP_LOOKBACK_DAYS * 86_400_000).toISOString();
+
+  const { data: gapRows, error: gapErr } = await supabase
+    .from("analytics_events")
+    .select("id, payload, created_at")
+    .eq("event_type", "rag_gap")
+    .gte("created_at", since)
+    .order("created_at", { ascending: false });
+  if (gapErr) throw new Error(gapErr.message);
+
+  const { data: candRows, error: candErr } = await supabase
+    .from("knowledge_candidates")
+    .select("gap_refs");
+  if (candErr) throw new Error(candErr.message);
+
+  const addressed = new Set<string>();
+  for (const row of candRows ?? []) {
+    const refs = (row as { gap_refs: unknown }).gap_refs;
+    if (Array.isArray(refs)) for (const r of refs) if (typeof r === "string") addressed.add(r);
+  }
+
+  return (gapRows ?? [])
+    .map((r) => {
+      const p = (r.payload ?? {}) as GapPayload;
+      const question = typeof p.question === "string" ? p.question : "";
+      return {
+        id: r.id,
+        question,
+        topScore: typeof p.top_score === "number" ? p.top_score : null,
+        source: p.source === "manual" ? ("manual" as const) : ("user" as const),
+        createdAt: r.created_at,
+        addressed: addressed.has(r.id),
+      };
+    })
+    .filter((g) => g.question.length > 0);
+}

--- a/lib/discovery/gaps.ts
+++ b/lib/discovery/gaps.ts
@@ -50,7 +50,7 @@ export async function listRecentGaps(supabase: SupabaseClient<Database>): Promis
         question,
         topScore: typeof p.top_score === "number" ? p.top_score : null,
         source: p.source === "manual" ? ("manual" as const) : ("user" as const),
-        createdAt: r.created_at,
+        createdAt: r.created_at ?? "",
         addressed: addressed.has(r.id),
       };
     })


### PR DESCRIPTION
## What

Adds an admin page to **view recent RAG coverage gaps** and **manually add one**, plus a role-gated **Admin** link in the app nav.

### Why
The discovery pipeline is purely reactive — it only acts on `rag_gap` events written when real users hit weak KB coverage. There was no way to *see* those gaps or to *seed* one proactively (e.g. on a fresh deploy with no traffic), and `/admin/*` had no nav entry point.

## How
- **Manual gap = a `rag_gap` analytics event** (`payload={question, top_score:0, source:'manual'}`, attributed to the admin). It flows through the existing `mineGaps` pipeline with **zero changes to discovery logic**; `source` is display-only. This is a minimal slice of the "Topic-driven mode" future work in `docs/discovery-pipeline.md`.
- Inserted via the admin's **RLS-bound client** — the existing `analytics_events` "users can insert own" policy (`auth.uid() = user_id`) covers it; no service role needed.
- New `/admin/knowledge/gaps` page: manual-add form + raw event list (question, score, date, source badge, "Addressed" flag computed from `knowledge_candidates.gap_refs` — the same test `mineGaps` uses). Reuses the existing `RunDiscoveryButton`. Cross-linked from the review queue header.
- Nav: server `(app)` layout reads role via a new non-redirecting `isCurrentUserAdmin()` and passes `isAdmin` into `AppNav`, which conditionally renders the **Admin** link. The real guard remains `requireAdmin()` server-side on every `/admin/*` request.

## Tests
- `listRecentGaps` (3), `addManualGap` (4), `AddGapForm` (2), `GapRow` (4), `AppNav` admin-link cases (3 new).
- Full suite: 545 pass / 30 skipped. Biome clean. Production build succeeds.

## Out of scope (YAGNI)
Editing/deleting gaps, theme-cluster view, background-job UX. `mineGaps`/thresholds untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)