### PR TITLE
docs: admin knowledge gaps view + manual seed

### DIFF
--- a/docs/api-routes.md
+++ b/docs/api-routes.md
@@ -85,6 +85,11 @@ All route handlers are in `app/api/` using Next.js App Router conventions (`rout
 **Auth:** `admin` role (server-side gate via `requireAdmin`, enforced in `app/(app)/admin/layout.tsx`).
 **Purpose:** Manage the documents in `knowledge_chunks` directly. **Lists** every document (one row per `source`, via the `list_knowledge_documents()` RPC). **Add** — server action `addDocument` chunks + embeds pasted text via `ingestDocument` (`source` = the typed name, `metadata.origin = "manual"`). **Delete** — server action `deleteDocument` hard-deletes all chunks for a `source`. Covers seed, discovery-approved, and manually-added documents alike.
 
+### `/admin/knowledge/gaps` (page, not an API route)
+
+**Auth:** `admin` role (server-side gate via `requireAdmin`, enforced in `app/(app)/admin/layout.tsx`).
+**Purpose:** View recent RAG coverage gaps and seed one by hand. **Lists** `rag_gap` events from the last `GAP_LOOKBACK_DAYS` (via `listRecentGaps`), each flagged `addressed` when its id appears in a `knowledge_candidates.gap_refs` array (the same test `mineGaps` uses), with a User/Manual source badge. **Add a gap** — server action `addManualGap` inserts a `rag_gap` event (`payload={ question, top_score: 0, source: "manual" }`, attributed to the admin) via the RLS-bound client, so it flows through `mineGaps` unchanged; `source` is display-only. **Run discovery now** — reuses the same `RunDiscoveryButton` as the review queue.
+
 ### `POST /api/analytics/event`
 
 **Auth:** `user` role  

--- a/docs/discovery-pipeline.md
+++ b/docs/discovery-pipeline.md
@@ -152,8 +152,11 @@ lib/discovery/
   run.ts                     runDiscovery coordinator (bounded batch)
 app/api/embeddings/discover/route.ts    cron + manual trigger
 app/(app)/admin/knowledge/              review queue UI
+app/(app)/admin/knowledge/gaps/         view gaps + manual-seed UI
 lib/discovery/review-actions.ts         approveCandidate / rejectCandidate
-lib/auth/require-admin.ts               server-side admin gate
+lib/discovery/gaps.ts                    listRecentGaps (gaps view query)
+lib/discovery/gap-actions.ts             addManualGap (manual gap seed)
+lib/auth/require-admin.ts               requireAdmin + isCurrentUserAdmin (nav gate)
 ```
 
 Tables: `knowledge_candidates` (staging), `discovery_runs` (run log), and
@@ -164,9 +167,13 @@ Tables: `knowledge_candidates` (staging), `discovery_runs` (run log), and
 
 ## Operating it
 
-- **Exercise it manually:** ask the prod chat a few health questions the KB can't
-  answer well (creates `rag_gap` events), then click **"Run discovery now"** on
-  `/admin/knowledge`. Without gaps, a run stages nothing — that's expected.
+- **Exercise it manually:** either ask the prod chat a few health questions the KB
+  can't answer well (creates `rag_gap` events), or add a gap by hand on
+  `/admin/knowledge/gaps` (the "Add a gap" form inserts a `source:'manual'`
+  `rag_gap` event), then click **"Run discovery now"**. Without gaps, a run stages
+  nothing — that's expected.
+- **View gaps:** `/admin/knowledge/gaps` lists `rag_gap` events from the last
+  `GAP_LOOKBACK_DAYS`, each marked addressed/unaddressed and tagged User/Manual.
 - **Seeding the initial KB** is separate from discovery: `pnpm seed:kb` (or the
   same script pointed at prod via an env file) re-ingests the curated source
   docs in `supabase/seeds/knowledge/` straight into `knowledge_chunks`.
@@ -181,7 +188,9 @@ Tables: `knowledge_candidates` (staging), `discovery_runs` (run log), and
 ## Not built (possible future work)
 
 - **Topic-driven mode:** proactively cover a curated topic list even with no user
-  gaps. Today the pipeline is purely reactive to `rag_gap` events.
+  gaps. The manual "Add a gap" form on `/admin/knowledge/gaps` is a minimal slice
+  of this (seed one question at a time); a full curated-topic-list mode is still
+  unbuilt.
 - **Background-job UX:** "Run discovery now" currently blocks until the run
   finishes (up to `RUN_BUDGET_MS`).
 - **`discovery_runs` history view** in the admin section.


### PR DESCRIPTION
## What

Documentation for the admin knowledge-gaps feature (code in #90).

- **`docs/api-routes.md`** — new `/admin/knowledge/gaps` page section: lists `rag_gap` events from the last `GAP_LOOKBACK_DAYS` (`listRecentGaps`, with addressed/User-Manual flags), and the `addManualGap` server action (inserts a `source:'manual'` `rag_gap` event via the admin's RLS-bound client; `mineGaps` untouched, `source` display-only).
- **`docs/discovery-pipeline.md`** — file map adds the gaps page + `gaps.ts` / `gap-actions.ts` / `isCurrentUserAdmin`; "Operating it" gains view-gaps / manual-seed steps; "Not built" Topic-driven mode reframed as having a minimal slice (the manual form).

## Note

Docs-only. The implementation lives in #90 (`feat/admin-knowledge-gaps`); merge order between the two doesn't matter since these files don't overlap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)