### PR TITLE
fix(mcp): stop rejecting our own agent-layer calls as browser traffic

### DIFF
--- a/app/api/mcp/route.test.ts
+++ b/app/api/mcp/route.test.ts
@@ -68,7 +68,9 @@ describe("POST /api/mcp", () => {
   });
 
   test("rejects a browser request even when it carries a valid token", async () => {
-    const res = await POST(req({ ...AUTH, "sec-fetch-mode": "cors" }));
+    // `sec-fetch-site` rather than `sec-fetch-mode`: Node's own HTTP stack
+    // sends the latter, so it never marked a browser. See lib/mcp/auth.ts.
+    const res = await POST(req({ ...AUTH, "sec-fetch-site": "cross-site" }));
 
     expect(res.status).toBe(401);
     expect(createVeraMcpServer).not.toHaveBeenCalled();

--- a/docs/api-routes.md
+++ b/docs/api-routes.md
@@ -75,8 +75,12 @@ timeout; any failure resolves to `null` so the chat route degrades rather than e
 **Not browser-callable, by two independent guards** (`lib/mcp/auth.ts`):
 
 1. `MCP_AUTH_TOKEN` is a non-public env var, so it is never bundled into client JS.
-2. Any request carrying `Sec-Fetch-Mode` / `Sec-Fetch-Site` — headers a browser cannot suppress —
-   is rejected regardless of its token.
+2. Any request carrying `Sec-Fetch-Site`, `Sec-Fetch-Dest`, or `Origin` — headers a browser
+   attaches to every request and cannot suppress — is rejected regardless of its token.
+
+   Deliberately **not** `Sec-Fetch-Mode`: Node's own undici HTTP stack sends `Sec-Fetch-Mode: cors`,
+   so gating on it rejected 100% of our own agent-layer calls. `lib/mcp/auth.transport.test.ts`
+   pins these header facts against the real MCP transport.
 
 There is deliberately **no** session-cookie path: being signed in, even as an admin, grants nothing here.
 Every rejection returns the same opaque `401 {"error":"unauthorized"}`.

--- a/docs/trusted-health-mcp.md
+++ b/docs/trusted-health-mcp.md
@@ -146,7 +146,7 @@ when one lapses — that is a follow-on.
 
 | Property | How it holds |
 |---|---|
-| Not browser-callable | `MCP_AUTH_TOKEN` is non-public so it never reaches client JS; requests with `Sec-Fetch-*` headers are rejected regardless of token; no cookie path exists |
+| Not browser-callable | `MCP_AUTH_TOKEN` is non-public so it never reaches client JS; requests with `Sec-Fetch-Site` / `Sec-Fetch-Dest` / `Origin` are rejected regardless of token (**not** `Sec-Fetch-Mode` — Node's undici sends that itself); no cookie path exists |
 | Read-only | No handler has a write path; `lib/mcp/no-write.test.ts` fails the build if a mutation appears in the read path |
 | No prompt injection via tool output | Safety rule 4 in `lib/ai/system-prompt.ts`: retrieved context is DATA, never instructions |
 | No arbitrary URLs | Inputs are closed Zod objects; `location` is a suburb/postcode pattern that rejects URLs and hosts |

--- a/lib/mcp/auth.test.ts
+++ b/lib/mcp/auth.test.ts
@@ -47,16 +47,26 @@ describe("authenticateMcpRequest", () => {
     );
   });
 
-  test.each(["sec-fetch-mode", "sec-fetch-site"])(
-    "rejects a request carrying %s, even with a valid token",
-    (header) => {
-      const request = req({ authorization: `Bearer ${TOKEN}`, [header]: "cors" });
-      expect(authenticateMcpRequest(request, TOKEN)).toBe("browser_origin");
-    }
-  );
+  test.each([
+    ["sec-fetch-site", "cross-site"],
+    ["sec-fetch-dest", "empty"],
+    ["origin", "https://vera.test"],
+  ])("rejects a request carrying %s, even with a valid token", (header, value) => {
+    const request = req({ authorization: `Bearer ${TOKEN}`, [header]: value });
+    expect(authenticateMcpRequest(request, TOKEN)).toBe("browser_origin");
+  });
+
+  test("does not treat sec-fetch-mode as a browser signal — Node's own fetch sends it", () => {
+    // The bug this suite used to assert as correct: undici puts
+    // `Sec-Fetch-Mode: cors` on every request, so rejecting it rejected every
+    // agent-layer call. lib/mcp/auth.transport.test.ts pins that against the
+    // real transport; here we just pin the guard's half of the contract.
+    const request = req({ authorization: `Bearer ${TOKEN}`, "sec-fetch-mode": "cors" });
+    expect(authenticateMcpRequest(request, TOKEN)).toBeNull();
+  });
 
   test("the browser guard is checked before the token, so a browser never probes the token", () => {
-    const request = req({ authorization: "Bearer wrong", "sec-fetch-mode": "cors" });
+    const request = req({ authorization: "Bearer wrong", "sec-fetch-site": "cross-site" });
     expect(authenticateMcpRequest(request, TOKEN)).toBe("browser_origin");
   });
 });

--- a/lib/mcp/auth.transport.test.ts
+++ b/lib/mcp/auth.transport.test.ts
@@ -1,0 +1,82 @@
+// @vitest-environment node
+
+import { createServer } from "node:http";
+import type { AddressInfo } from "node:net";
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { StreamableHTTPClientTransport } from "@modelcontextprotocol/sdk/client/streamableHttp.js";
+import { afterAll, beforeAll, expect, test } from "vitest";
+import { authenticateMcpRequest } from "./auth";
+
+/**
+ * The seam lib/mcp/auth.test.ts cannot cover: it builds `Request` objects by
+ * hand, so it can only assert what we *believe* a real caller sends.
+ *
+ * This ran in production for a day rejecting every single agent-layer call with
+ * `browser_origin`, because the guard assumed "only browsers send Sec-Fetch-*"
+ * — and Node's built-in fetch (undici), which the MCP SDK transport uses,
+ * always sends `Sec-Fetch-Mode: cors`. Both unit suites passed throughout.
+ *
+ * So: drive the real StreamableHTTPClientTransport at a real socket, capture
+ * the headers it actually put on the wire, and run them through the real guard.
+ * If a future undici starts sending another Sec-Fetch-* header, this fails here
+ * instead of silently degrading every Victorian turn to the non-MCP path.
+ */
+
+const TOKEN = "s3cret-token-value";
+
+let captured: Request | null = null;
+let server: ReturnType<typeof createServer>;
+let port: number;
+
+beforeAll(async () => {
+  server = createServer((req, res) => {
+    captured = new Request("https://vera.test/api/mcp", {
+      method: "POST",
+      headers: Object.entries(req.headers).flatMap(([k, v]) =>
+        typeof v === "string" ? [[k, v] as [string, string]] : []
+      ),
+    });
+    // Close the turn immediately; we only care about the request headers.
+    res.writeHead(401, { "content-type": "application/json" });
+    res.end(JSON.stringify({ error: "unauthorized" }));
+  });
+  await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));
+  port = (server.address() as AddressInfo).port;
+
+  const transport = new StreamableHTTPClientTransport(new URL(`http://127.0.0.1:${port}/api/mcp`), {
+    requestInit: { headers: { authorization: `Bearer ${TOKEN}` } },
+  });
+  const client = new Client({ name: "vera-agent-layer", version: "0.1.0" });
+  // The 401 above makes connect reject; the headers are already captured.
+  await client.connect(transport).catch(() => {});
+  await client.close().catch(() => {});
+});
+
+afterAll(() => {
+  server.close();
+});
+
+test("the MCP SDK transport reaches the wire at all", () => {
+  expect(captured).not.toBeNull();
+});
+
+test("Node's fetch sends Sec-Fetch-Mode, so it cannot be a browser signal", () => {
+  // Documents the fact that broke production. If this ever stops being true the
+  // guard is merely stricter than it needs to be, which is safe.
+  expect(captured?.headers.get("sec-fetch-mode")).toBe("cors");
+});
+
+test("sends none of the headers the guard treats as browser-only", () => {
+  for (const header of ["sec-fetch-site", "sec-fetch-dest", "origin"]) {
+    expect(`${header}=${captured?.headers.get(header)}`).toBe(`${header}=null`);
+  }
+});
+
+test("the guard accepts a real agent-layer call carrying a valid token", () => {
+  expect(captured).not.toBeNull();
+  expect(authenticateMcpRequest(captured as Request, TOKEN)).toBeNull();
+});
+
+test("the guard still rejects that same call when the token is wrong", () => {
+  expect(authenticateMcpRequest(captured as Request, "a-different-token")).toBe("invalid_token");
+});

--- a/lib/mcp/auth.ts
+++ b/lib/mcp/auth.ts
@@ -9,14 +9,29 @@ import { timingSafeEqual } from "node:crypto";
  * 1. A bearer token that only the server has. `MCP_AUTH_TOKEN` is a non-public
  *    env var, so it is never bundled into client JavaScript — a browser has no
  *    way to obtain it. This is the real gate.
- * 2. A rejection of any request carrying browser fetch-metadata headers. A
- *    browser always sends `Sec-Fetch-Mode`; server-side `fetch` does not. This
- *    is defence in depth against a future mistake that leaks the token into the
+ * 2. A rejection of any request carrying browser-only fetch metadata. This is
+ *    defence in depth against a future mistake that leaks the token into the
  *    client bundle, and it makes the "never callable from the browser" property
  *    observable rather than merely intended.
+ *
+ * On (2), the discriminating headers matter and an earlier version got them
+ * wrong: it also rejected `Sec-Fetch-Mode`, on the assumption that only
+ * browsers send Sec-Fetch-* at all. Node's built-in undici HTTP stack — which
+ * the MCP SDK transport uses — sends `Sec-Fetch-Mode: cors` on every request, so
+ * that guard rejected 100% of our own agent-layer calls with `browser_origin`
+ * while both unit suites stayed green. See lib/mcp/auth.transport.test.ts,
+ * which pins these header facts against the real transport.
+ *
+ * `Sec-Fetch-Site` and `Sec-Fetch-Dest` are the browser-only pair: every
+ * modern browser attaches both to every request, and undici sends neither.
+ * `Origin` is the same kind of signal for the cross-origin POST a leaked-token
+ * browser call would have to make.
  */
 
 export type McpAuthFailure = "missing_token" | "invalid_token" | "browser_origin";
+
+/** Sent by every browser on every request; not sent by Node's fetch. */
+const BROWSER_ONLY_HEADERS = ["sec-fetch-site", "sec-fetch-dest", "origin"] as const;
 
 /** Constant-time comparison that tolerates length mismatch without leaking it. */
 function tokensMatch(provided: string, expected: string): boolean {
@@ -40,8 +55,9 @@ export function authenticateMcpRequest(
   expectedToken: string
 ): McpAuthFailure | null {
   // A browser cannot suppress fetch metadata, so its presence is conclusive.
-  if (request.headers.has("sec-fetch-mode") || request.headers.has("sec-fetch-site")) {
-    return "browser_origin";
+  // Deliberately NOT `sec-fetch-mode`: Node's own fetch sends that too.
+  for (const header of BROWSER_ONLY_HEADERS) {
+    if (request.headers.has(header)) return "browser_origin";
   }
 
   const header = request.headers.get("authorization");

--- a/lib/mcp/client.test.ts
+++ b/lib/mcp/client.test.ts
@@ -1,6 +1,6 @@
 // @vitest-environment node
 
-import { beforeEach, describe, expect, test, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
 
 const connect = vi.fn();
 const callTool = vi.fn();
@@ -140,5 +140,58 @@ describe("MCP client", () => {
     await expect(findVictoriaScreeningServicesViaMcp({ location: "Carlton" })).resolves.toEqual(
       VALID_DIRECTORY
     );
+  });
+
+  // Regression: production had NEXT_PUBLIC_APP_URL set to "". `??` treated the
+  // empty string as configured, so the base became "" and `new URL("/api/mcp")`
+  // threw out of the client, past the orchestrator, and killed the chat stream
+  // with "Invalid URL" instead of degrading to RAG.
+  describe("base URL resolution", () => {
+    const saved = {
+      mcp: process.env.MCP_BASE_URL,
+      app: process.env.NEXT_PUBLIC_APP_URL,
+    };
+
+    afterEach(() => {
+      process.env.MCP_BASE_URL = saved.mcp;
+      process.env.NEXT_PUBLIC_APP_URL = saved.app;
+    });
+
+    test("falls back to localhost when both vars are blank rather than throwing", async () => {
+      process.env.MCP_BASE_URL = "";
+      process.env.NEXT_PUBLIC_APP_URL = "";
+      callTool.mockResolvedValue({ structuredContent: VALID_DIRECTORY });
+
+      await expect(findVictoriaScreeningServicesViaMcp({ location: "Carlton" })).resolves.toEqual(
+        VALID_DIRECTORY
+      );
+      expect(StreamableHTTPClientTransport).toHaveBeenCalledWith(
+        new URL("http://localhost:3000/api/mcp"),
+        expect.anything()
+      );
+    });
+
+    test("prefers MCP_BASE_URL over NEXT_PUBLIC_APP_URL", async () => {
+      process.env.MCP_BASE_URL = "https://internal.example.com/";
+      process.env.NEXT_PUBLIC_APP_URL = "https://public.example.com";
+      callTool.mockResolvedValue({ structuredContent: VALID_DIRECTORY });
+
+      await findVictoriaScreeningServicesViaMcp({ location: "Carlton" });
+
+      expect(StreamableHTTPClientTransport).toHaveBeenCalledWith(
+        new URL("https://internal.example.com/api/mcp"),
+        expect.anything()
+      );
+    });
+
+    test("returns null instead of throwing when the base is not an absolute URL", async () => {
+      process.env.MCP_BASE_URL = "cervix-assistant.vercel.app";
+      process.env.NEXT_PUBLIC_APP_URL = "";
+
+      await expect(
+        findVictoriaScreeningServicesViaMcp({ location: "Carlton" })
+      ).resolves.toBeNull();
+      expect(StreamableHTTPClientTransport).not.toHaveBeenCalled();
+    });
   });
 });

--- a/lib/mcp/client.ts
+++ b/lib/mcp/client.ts
@@ -30,8 +30,12 @@ import { StreamableHTTPClientTransport } from "@modelcontextprotocol/sdk/client/
 const CALL_TIMEOUT_MS = 5_000;
 
 function baseUrl(): string {
-  const configured = process.env.MCP_BASE_URL ?? process.env.NEXT_PUBLIC_APP_URL;
-  return (configured ?? "http://localhost:3000").replace(/\/$/, "");
+  // `??` is not enough here: a var that exists but holds an empty string — the
+  // shape a blank value in the Vercel dashboard takes — would pass the nullish
+  // check and leave us building `new URL("/api/mcp")`, which throws. Treat
+  // blank as unset so the default still applies.
+  const configured = process.env.MCP_BASE_URL?.trim() || process.env.NEXT_PUBLIC_APP_URL?.trim();
+  return (configured || "http://localhost:3000").replace(/\/$/, "");
 }
 
 /**
@@ -40,7 +44,21 @@ function baseUrl(): string {
  * long-lived client would add reconnect handling for no measurable gain.
  */
 async function callTool(name: string, args: Record<string, unknown>): Promise<unknown | null> {
-  const transport = new StreamableHTTPClientTransport(new URL(`${baseUrl()}/api/mcp`), {
+  // Built inside its own guard, not as an argument further down: `new URL` on a
+  // misconfigured base throws synchronously, and a throw here would escape the
+  // "never throws" contract below and abort the whole chat turn rather than
+  // degrading to RAG.
+  let endpoint: URL;
+  try {
+    endpoint = new URL(`${baseUrl()}/api/mcp`);
+  } catch {
+    console.warn(
+      `[mcp/client] ${name} skipped: MCP_BASE_URL / NEXT_PUBLIC_APP_URL is not a valid absolute URL`
+    );
+    return null;
+  }
+
+  const transport = new StreamableHTTPClientTransport(endpoint, {
     requestInit: {
       headers: { authorization: `Bearer ${env.mcpAuthToken}` },
     },


### PR DESCRIPTION
## The bug

The Victoria Trusted Health MCP was being called in production on every Victorian turn — and **every single call was answered `401 unauthorized` by our own auth guard**.

Production logs, both halves of the same failed call:

```
[/api/mcp]   rejected: browser_origin
[mcp/client] list_victoria_verified_events unavailable:
             Streamable HTTP error: Error POSTing to endpoint: {"error":"unauthorized"}
```

## Root cause

`lib/mcp/auth.ts` rejected any request carrying a `Sec-Fetch-*` header, on this premise:

> A browser always sends `Sec-Fetch-Mode`; server-side `fetch` does not.

The second half is false. Node's built-in undici HTTP stack — which the MCP SDK's `StreamableHTTPClientTransport` uses — sends `Sec-Fetch-Mode: cors` on **every** request. Headers captured from the real transport:

```
authorization: Bearer …
sec-fetch-mode: cors        ← added by Node itself
user-agent: node
```

So 100% of agent-layer calls tripped the browser guard.

## Why it stayed invisible

Three well-behaved things stacked up to hide it:

1. **The client degraded exactly as designed.** `callTool` caught the transport error → returned `null` → agent returned EMPTY → orchestrator fell through to the non-MCP path. Per spec §8. No crash, no user-visible error.
2. **`mcp_call_logs` could not discriminate.** Auth rejects *before* the handler and the audit insert, so zero rows is equally consistent with "never called" and "rejected every time" — precisely the two cases we were trying to tell apart.
3. **Both unit suites were green.** `auth.test.ts` and `route.test.ts` build their `Request` by hand, so they can only assert what we *believe* a caller sends. The `sec-fetch-mode: cors` → `browser_origin` case had the bug baked in as an expected outcome.

Compounding it, the path being tested was **events**, and `verified_events` is empty by design — so MCP failure and a genuine no-results answer are indistinguishable in the UI.

## The fix

Gate on `Sec-Fetch-Site` / `Sec-Fetch-Dest` / `Origin` instead. Every modern browser attaches all three to every request; undici sends none of them. The bearer token remains the real gate — this layer stays defence in depth, and its coverage is now wider, not narrower.

`lib/mcp/auth.transport.test.ts` closes the missing seam: it drives the real `StreamableHTTPClientTransport` at a real socket and runs the captured headers through the real guard. If a future undici starts sending another `Sec-Fetch-*` header, it fails loudly here instead of silently degrading every Victorian turn.

Also included: the previously unshipped `baseUrl()` fix — Vercel held `NEXT_PUBLIC_APP_URL` as an empty string, which passed the `??` nullish check and made `new URL("/api/mcp")` throw from *outside* the try, breaking the module's "never throws" contract and turning whole turns into `[reply was interrupted: Invalid URL]`.

## Verification

End-to-end, not just unit tests — real client → real route on a live dev server:

- all three tools returned real data
- local `mcp_call_logs` went **0 → 6 rows**, so the audit path works too

`785 passed / 30 skipped` · `tsc --noEmit` clean · `biome check` clean

## Testing after deploy

Use a **services** question ("where can I get screening in Melbourne?"), not events. `directory_links` has 2 rows, so success shows real directory links while failure shows the distinct `SERVICES_EMPTY_FALLBACK`. `verified_events` is still empty by design and will tell you nothing either way.

## Found but deliberately not changed here

1. `MCP_AUTH_TOKEN` is set for **Production only**. Since `lib/env.ts` uses `requireEnv`, any Preview deployment throws at module load on every server route — not just the MCP ones.
2. `CALL_TIMEOUT_MS` does not cover `client.connect()`, despite the comment claiming "including connect". Only `callTool` gets the 5s budget; a hung connect blocks the turn instead of degrading.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
