### PR TITLE
fix(events): stop forcing a health-domain clause into SerpAPI queries

### DIFF
--- a/app/api/events/route.test.ts
+++ b/app/api/events/route.test.ts
@@ -53,13 +53,36 @@ describe("GET /api/events", () => {
     expect(res.status).toBe(400);
   });
 
-  it("returns empty events + error flag on upstream 500", async () => {
+  it("returns empty events + upstream_unavailable on upstream 500", async () => {
     server.use(http.get(SERPAPI_URL, () => new HttpResponse(null, { status: 500 })));
     const res = await GET(makeRequest("/api/events?location=Sydney"));
     expect(res.status).toBe(200);
     const body = (await res.json()) as { events: unknown[]; error?: string };
     expect(body.events).toEqual([]);
-    expect(body.error).toBe("unavailable");
+    expect(body.error).toBe("upstream_unavailable");
+  });
+
+  it("returns empty events + no_results when nothing relevant is found", async () => {
+    server.use(
+      http.get(SERPAPI_URL, () =>
+        HttpResponse.json({
+          events_results: [
+            {
+              title: "Saturday Night Concert",
+              date: { when: "May 10" },
+              address: ["Town Hall"],
+              link: "https://example.com/concert",
+              description: null,
+            },
+          ],
+        })
+      )
+    );
+    const res = await GET(makeRequest("/api/events?location=Sydney"));
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { events: unknown[]; error?: string };
+    expect(body.events).toEqual([]);
+    expect(body.error).toBe("no_results");
   });
 
   it("never echoes the SerpAPI key in the response", async () => {
@@ -68,7 +91,7 @@ describe("GET /api/events", () => {
         HttpResponse.json({
           events_results: [
             {
-              title: "T",
+              title: "Cervical Screening Session",
               date: { when: "May 10" },
               address: ["X"],
               link: "https://example.com/x",

--- a/app/api/events/route.ts
+++ b/app/api/events/route.ts
@@ -13,14 +13,17 @@ export async function GET(request: Request) {
     return Response.json({ error: "invalid_request" }, { status: 400 });
   }
 
-  const events = await searchEventsApi({
+  const result = await searchEventsApi({
     location: parsed.data.location,
     query: parsed.data.q,
     max_results: parsed.data.max,
   });
 
-  if (events.length === 0) {
-    return Response.json({ events: [], error: "unavailable" });
+  if (result.status === "no_results") {
+    return Response.json({ events: [], error: "no_results" });
   }
-  return Response.json({ events });
+  if (result.status === "upstream_unavailable") {
+    return Response.json({ events: [], error: "upstream_unavailable" });
+  }
+  return Response.json({ events: result.events });
 }

--- a/docs/api-routes.md
+++ b/docs/api-routes.md
@@ -108,9 +108,14 @@ asks the user to type a suburb instead of reporting an empty search.
 
 **Auth:** None  
 **Query params:** `location: string`, `q?: string`, `max?: number` (default 5)  
-**Proxied to:** SerpAPI Google Events (`SERPAPI_KEY` injected server-side)  
-**Default keywords appended:** `women's health cervical screening HPV`  
-**Response:** `HealthEvent[]` — `{ name, date, location, url, description }`
+**Proxied to:** SerpAPI Google Events (`SERPAPI_KEY` injected server-side), `gl=au&hl=en`. The
+upstream query is sent as-is (`q` or a plain `"events"` fallback) — no forced health-domain
+boolean clause, since Google Events returns nothing for those. Health relevance is filtered
+locally, against title/description/address, after the upstream call.  
+**Response:** `{ events: HealthEvent[] }` on a match, `{ events: [], error: "no_results" }` when
+the search completed but nothing relevant came back, `{ events: [], error: "upstream_unavailable" }`
+when the upstream call itself failed (network error, non-2xx, malformed JSON). `HealthEvent` is
+`{ name, date, location, url, description }`.
 
 ### `POST /api/mcp`
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -82,9 +82,11 @@ User message
 **Events Agent** (`lib/agents/events-agent.ts`)
 - Calls `findHealthEvents` tool → proxies SerpAPI Google Events
 - Requires user location; uses `profiles.locale` as a hint if set
-- Default keywords appended: `women's health OR cervical screening OR HPV`
+- Upstream query is sent naturally (no forced boolean clause); relevance against
+  `women's health` / `cervical` / `screening` / `hpv` / `pap` is filtered locally afterward
 - Returns up to 5 upcoming events (name, date, location, URL)
-- Falls back gracefully if no events found
+- Distinguishes a genuine no-results search from an upstream failure — the orchestrator shows
+  different fallback copy for each (`EVENTS_EMPTY_FALLBACK` vs `EVENTS_UNAVAILABLE_FALLBACK`)
 
 **Location resolution** (`lib/agents/location.ts`)
 - Runs *before* dispatch and decides whether the turn has a usable location:

--- a/lib/agents/events-agent.test.ts
+++ b/lib/agents/events-agent.test.ts
@@ -24,7 +24,7 @@ function ev(overrides: Partial<HealthEvent> = {}): HealthEvent {
 describe("runEventsAgent", () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    vi.mocked(findHealthEvents).mockResolvedValue([]);
+    vi.mocked(findHealthEvents).mockResolvedValue({ status: "no_results" });
   });
 
   test("calls findHealthEvents with caller-provided city as location", async () => {
@@ -74,24 +74,36 @@ describe("runEventsAgent", () => {
     });
   });
 
-  test("returns empty result when tool returns []", async () => {
-    vi.mocked(findHealthEvents).mockResolvedValue([]);
+  test("returns empty result when tool returns no_results", async () => {
+    vi.mocked(findHealthEvents).mockResolvedValue({ status: "no_results" });
 
     const result = await runEventsAgent({ userMessage: "x", city: "Sydney" });
 
     expect(result).toEqual({ eventsContext: "", eventsSources: [] });
     expect(result).not.toHaveProperty("needsLocation", true);
+    expect(result).not.toHaveProperty("unavailable", true);
+  });
+
+  test("returns unavailable=true when tool returns upstream_unavailable", async () => {
+    vi.mocked(findHealthEvents).mockResolvedValue({ status: "upstream_unavailable" });
+
+    const result = await runEventsAgent({ userMessage: "x", city: "Sydney" });
+
+    expect(result).toEqual({ eventsContext: "", eventsSources: [], unavailable: true });
   });
 
   test("formats a single event with [1] marker, name, date, location", async () => {
-    vi.mocked(findHealthEvents).mockResolvedValue([
-      ev({
-        name: "Women's Health Fair",
-        date: "Sat, May 10, 2026",
-        location: "Town Hall, Sydney NSW",
-        url: "https://example.com/1",
-      }),
-    ]);
+    vi.mocked(findHealthEvents).mockResolvedValue({
+      status: "ok",
+      events: [
+        ev({
+          name: "Women's Health Fair",
+          date: "Sat, May 10, 2026",
+          location: "Town Hall, Sydney NSW",
+          url: "https://example.com/1",
+        }),
+      ],
+    });
 
     const result = await runEventsAgent({ userMessage: "x", city: "Sydney" });
 
@@ -110,11 +122,14 @@ describe("runEventsAgent", () => {
   });
 
   test("formats multiple events with sequential markers and blank-line separators", async () => {
-    vi.mocked(findHealthEvents).mockResolvedValue([
-      ev({ name: "A", url: "https://a.com" }),
-      ev({ name: "B", url: "https://b.com" }),
-      ev({ name: "C", url: "https://c.com" }),
-    ]);
+    vi.mocked(findHealthEvents).mockResolvedValue({
+      status: "ok",
+      events: [
+        ev({ name: "A", url: "https://a.com" }),
+        ev({ name: "B", url: "https://b.com" }),
+        ev({ name: "C", url: "https://c.com" }),
+      ],
+    });
 
     const result = await runEventsAgent({ userMessage: "x", city: "Sydney" });
 
@@ -124,7 +139,10 @@ describe("runEventsAgent", () => {
   });
 
   test("includes description when present", async () => {
-    vi.mocked(findHealthEvents).mockResolvedValue([ev({ description: "Free screenings and Q&A" })]);
+    vi.mocked(findHealthEvents).mockResolvedValue({
+      status: "ok",
+      events: [ev({ description: "Free screenings and Q&A" })],
+    });
 
     const result = await runEventsAgent({ userMessage: "x", city: "Sydney" });
 
@@ -132,7 +150,10 @@ describe("runEventsAgent", () => {
   });
 
   test("omits description gracefully when null", async () => {
-    vi.mocked(findHealthEvents).mockResolvedValue([ev({ description: null, name: "T" })]);
+    vi.mocked(findHealthEvents).mockResolvedValue({
+      status: "ok",
+      events: [ev({ description: null, name: "T" })],
+    });
 
     const result = await runEventsAgent({ userMessage: "x", city: "Sydney" });
 
@@ -141,19 +162,23 @@ describe("runEventsAgent", () => {
   });
 
   test("uses url-keyed chunkId for citation deduplication", async () => {
-    vi.mocked(findHealthEvents).mockResolvedValue([ev({ url: "https://x.com/event-42" })]);
+    vi.mocked(findHealthEvents).mockResolvedValue({
+      status: "ok",
+      events: [ev({ url: "https://x.com/event-42" })],
+    });
 
     const result = await runEventsAgent({ userMessage: "x", city: "Sydney" });
 
     expect(result.eventsSources[0].chunkId).toBe("events:https://x.com/event-42");
   });
 
-  test("never throws — degrades to empty when tool unexpectedly throws", async () => {
+  test("never throws — degrades to unavailable when tool unexpectedly throws", async () => {
     vi.mocked(findHealthEvents).mockRejectedValueOnce(new Error("boom"));
 
     await expect(runEventsAgent({ userMessage: "x", city: "Sydney" })).resolves.toEqual({
       eventsContext: "",
       eventsSources: [],
+      unavailable: true,
     });
   });
 

--- a/lib/agents/events-agent.ts
+++ b/lib/agents/events-agent.ts
@@ -36,6 +36,12 @@ export type EventsAgentResult = {
    * generic "no events found" line.
    */
   needsLocation?: boolean;
+  /**
+   * Set when the search itself failed (network/upstream error) rather than
+   * genuinely returning nothing. The orchestrator uses this to avoid telling
+   * the user "no events found" when the truth is "couldn't search".
+   */
+  unavailable?: boolean;
 };
 
 /**
@@ -52,9 +58,9 @@ export async function runEventsAgent(ctx: EventsAgentContext): Promise<EventsAge
     return { eventsContext: "", eventsSources: [], needsLocation: true };
   }
 
-  let events: HealthEvent[] = [];
+  let result: Awaited<ReturnType<typeof findHealthEvents>>;
   try {
-    events = await findHealthEvents({
+    result = await findHealthEvents({
       location,
       query: ctx.userMessage,
       max_results: MAX_RESULTS,
@@ -64,13 +70,17 @@ export async function runEventsAgent(ctx: EventsAgentContext): Promise<EventsAge
       "[events-agent] findHealthEvents unexpectedly threw:",
       err instanceof Error ? err.message : err
     );
+    return { eventsContext: "", eventsSources: [], unavailable: true };
+  }
+
+  if (result.status === "upstream_unavailable") {
+    return { eventsContext: "", eventsSources: [], unavailable: true };
+  }
+  if (result.status === "no_results") {
     return { eventsContext: "", eventsSources: [] };
   }
 
-  if (events.length === 0) {
-    return { eventsContext: "", eventsSources: [] };
-  }
-
+  const events = result.events;
   const eventsSources: Source[] = events.map((e, i) => ({
     id: String(i + 1),
     title: e.name,

--- a/lib/agents/orchestrator.test.ts
+++ b/lib/agents/orchestrator.test.ts
@@ -220,6 +220,7 @@ import { recordRagGap } from "@/lib/ai/rag-gap";
 import {
   EVENTS_EMPTY_FALLBACK,
   EVENTS_NEEDS_LOCATION_FALLBACK,
+  EVENTS_UNAVAILABLE_FALLBACK,
   INJECTION_REFUSAL,
   type OrchestratorContext,
   runOrchestrator,
@@ -509,6 +510,24 @@ describe("runOrchestrator", () => {
 
     expect(runResponseAgent).not.toHaveBeenCalled();
     expect(chunks[0]).toEqual({ type: "text", text: EVENTS_EMPTY_FALLBACK });
+  });
+
+  test("events_request with upstream unavailable: yields the unavailable fallback, not the empty-results one", async () => {
+    vi.mocked(getAnthropicClient).mockReturnValue(mockAnthropicCreate("events_request") as never);
+    vi.mocked(runEventsAgent).mockResolvedValue({
+      eventsContext: "",
+      eventsSources: [],
+      unavailable: true,
+    });
+
+    const chunks = await collectOrchestrator({
+      ...baseCtx,
+      userMessage: "any events in glen waverley",
+    });
+
+    expect(runResponseAgent).not.toHaveBeenCalled();
+    expect(chunks[0]).toEqual({ type: "text", text: EVENTS_UNAVAILABLE_FALLBACK });
+    expect(chunks).not.toContainEqual(expect.objectContaining({ type: "pending_action" }));
   });
 
   test("events_request never calls runRagAgent", async () => {

--- a/lib/agents/orchestrator.ts
+++ b/lib/agents/orchestrator.ts
@@ -111,6 +111,14 @@ export const EVENTS_NEEDS_LOCATION_FALLBACK =
 export const EVENTS_EMPTY_FALLBACK =
   "I couldn't find any upcoming health events for that location right now. Try a nearby suburb, or check back later.";
 /**
+ * Distinct from EVENTS_EMPTY_FALLBACK: this fires when the general events
+ * search itself failed (network/upstream error), not when it genuinely found
+ * nothing. Saying "I couldn't find any events" for a search we never
+ * completed would misrepresent what happened.
+ */
+export const EVENTS_UNAVAILABLE_FALLBACK =
+  "I'm having trouble reaching the events search right now. Please try again in a bit.";
+/**
  * Spec §7, matching the services path: an out-of-Victoria request gets the scope
  * explained, not a bare empty result. Saying "I couldn't find any events" to a
  * Sydney user describes a search that was never run for them.
@@ -430,10 +438,14 @@ async function* dispatchEventsRequest(
   // Nothing verified. The general events search is a genuine second look for a
   // location we have confirmed, so an empty answer from it is a real "nothing
   // found" rather than a scope failure dressed up as one.
-  const { eventsContext, eventsSources } = await runEventsAgent({
+  const { eventsContext, eventsSources, unavailable } = await runEventsAgent({
     userMessage: ctx.userMessage,
     city: location ?? "Victoria",
   });
+  if (unavailable) {
+    yield { type: "text", text: EVENTS_UNAVAILABLE_FALLBACK };
+    return;
+  }
   if (eventsSources.length === 0) {
     yield { type: "text", text: EVENTS_EMPTY_FALLBACK };
     yield { type: "pending_action", action: pending() };

--- a/lib/events/search-events.test.ts
+++ b/lib/events/search-events.test.ts
@@ -30,16 +30,17 @@ describe("searchEventsApi", () => {
       )
     );
 
-    const events = await searchEventsApi({ location: "Sydney", max_results: 5 });
-    expect(events).toHaveLength(2);
-    expect(events[0]).toEqual({
+    const result = await searchEventsApi({ location: "Sydney", max_results: 5 });
+    if (result.status !== "ok") throw new Error(`expected ok, got ${result.status}`);
+    expect(result.events).toHaveLength(2);
+    expect(result.events[0]).toEqual({
       name: "Women's Health Fair",
       date: "Sat, May 10, 2026",
       location: "123 Main St, Sydney NSW",
       url: "https://example.com/event-1",
       description: "Free screenings and Q&A",
     });
-    expect(events[1].description).toBeNull();
+    expect(result.events[1].description).toBeNull();
   });
 
   it("respects max_results when upstream returns more", async () => {
@@ -47,7 +48,7 @@ describe("searchEventsApi", () => {
       http.get(SERPAPI_URL, () =>
         HttpResponse.json({
           events_results: Array.from({ length: 8 }, (_, i) => ({
-            title: `Event ${i}`,
+            title: `Cervical Screening Info Session ${i}`,
             date: { when: "May 10" },
             address: ["X"],
             link: `https://example.com/${i}`,
@@ -56,35 +57,42 @@ describe("searchEventsApi", () => {
         })
       )
     );
-    const events = await searchEventsApi({ location: "Sydney", max_results: 3 });
-    expect(events).toHaveLength(3);
+    const result = await searchEventsApi({ location: "Sydney", max_results: 3 });
+    if (result.status !== "ok") throw new Error(`expected ok, got ${result.status}`);
+    expect(result.events).toHaveLength(3);
   });
 
-  it("returns empty array on empty upstream", async () => {
+  it("returns no_results on a valid empty upstream response", async () => {
     server.use(http.get(SERPAPI_URL, () => HttpResponse.json({ events_results: [] })));
-    const events = await searchEventsApi({ location: "Sydney" });
-    expect(events).toEqual([]);
+    const result = await searchEventsApi({ location: "Sydney" });
+    expect(result).toEqual({ status: "no_results" });
   });
 
-  it("returns empty array when upstream omits events_results", async () => {
+  it("returns no_results when upstream omits events_results", async () => {
     server.use(http.get(SERPAPI_URL, () => HttpResponse.json({})));
-    const events = await searchEventsApi({ location: "Sydney" });
-    expect(events).toEqual([]);
+    const result = await searchEventsApi({ location: "Sydney" });
+    expect(result).toEqual({ status: "no_results" });
   });
 
-  it("returns empty array on upstream 500", async () => {
+  it("returns upstream_unavailable on upstream 500", async () => {
     server.use(http.get(SERPAPI_URL, () => new HttpResponse(null, { status: 500 })));
-    const events = await searchEventsApi({ location: "Sydney" });
-    expect(events).toEqual([]);
+    const result = await searchEventsApi({ location: "Sydney" });
+    expect(result).toEqual({ status: "upstream_unavailable" });
   });
 
-  it("returns empty array on network failure", async () => {
+  it("returns upstream_unavailable on network failure", async () => {
     server.use(http.get(SERPAPI_URL, () => HttpResponse.error()));
-    const events = await searchEventsApi({ location: "Sydney" });
-    expect(events).toEqual([]);
+    const result = await searchEventsApi({ location: "Sydney" });
+    expect(result).toEqual({ status: "upstream_unavailable" });
   });
 
-  it("returns empty array when location is missing", async () => {
+  it("returns upstream_unavailable on malformed JSON", async () => {
+    server.use(http.get(SERPAPI_URL, () => new HttpResponse("not json", { status: 200 })));
+    const result = await searchEventsApi({ location: "Sydney" });
+    expect(result).toEqual({ status: "upstream_unavailable" });
+  });
+
+  it("returns no_results when location is missing, without calling upstream", async () => {
     let called = false;
     server.use(
       http.get(SERPAPI_URL, () => {
@@ -92,12 +100,12 @@ describe("searchEventsApi", () => {
         return HttpResponse.json({ events_results: [] });
       })
     );
-    const events = await searchEventsApi({ location: "" });
-    expect(events).toEqual([]);
+    const result = await searchEventsApi({ location: "" });
+    expect(result).toEqual({ status: "no_results" });
     expect(called).toBe(false);
   });
 
-  it("forwards location and adds health-domain keywords to upstream q", async () => {
+  it("sends a natural query — no forced health-domain boolean clause", async () => {
     let captured = "";
     server.use(
       http.get(SERPAPI_URL, ({ request }) => {
@@ -109,9 +117,22 @@ describe("searchEventsApi", () => {
     const params = new URL(captured).searchParams;
     expect(params.get("location")).toBe("Sydney NSW");
     expect(params.get("engine")).toBe("google_events");
-    const q = params.get("q") ?? "";
-    expect(q.toLowerCase()).toContain("cancer");
-    expect(q.toLowerCase()).toContain("women's health");
+    expect(params.get("q")).toBe("cancer");
+    expect(params.get("gl")).toBe("au");
+    expect(params.get("hl")).toBe("en");
+  });
+
+  it("falls back to a plain 'events' query when no user query is given", async () => {
+    let captured = "";
+    server.use(
+      http.get(SERPAPI_URL, ({ request }) => {
+        captured = request.url;
+        return HttpResponse.json({ events_results: [] });
+      })
+    );
+    await searchEventsApi({ location: "Sydney" });
+    const params = new URL(captured).searchParams;
+    expect(params.get("q")).toBe("events");
   });
 
   it("never echoes the SerpAPI key in returned data", async () => {
@@ -120,7 +141,7 @@ describe("searchEventsApi", () => {
         HttpResponse.json({
           events_results: [
             {
-              title: "x",
+              title: "Cervical Screening Pop-Up",
               date: { when: "x" },
               address: ["x"],
               link: "https://example.com/x",
@@ -130,8 +151,8 @@ describe("searchEventsApi", () => {
         })
       )
     );
-    const events = await searchEventsApi({ location: "Sydney" });
-    expect(JSON.stringify(events)).not.toContain("test-serpapi-key");
+    const result = await searchEventsApi({ location: "Sydney" });
+    expect(JSON.stringify(result)).not.toContain("test-serpapi-key");
   });
 
   it("skips items missing required fields (title/link/date/address)", async () => {
@@ -140,21 +161,21 @@ describe("searchEventsApi", () => {
         HttpResponse.json({
           events_results: [
             {
-              title: "ok",
+              title: "Cervical Screening Info Day",
               date: { when: "May 10" },
               address: ["A"],
               link: "https://a.com",
               description: null,
             },
             {
-              title: "no-link",
+              title: "Cervical Screening no-link",
               date: { when: "May 10" },
               address: ["A"],
               link: null,
               description: null,
             },
             {
-              title: "no-date",
+              title: "Cervical Screening no-date",
               date: null,
               address: ["A"],
               link: "https://b.com",
@@ -171,9 +192,10 @@ describe("searchEventsApi", () => {
         })
       )
     );
-    const events = await searchEventsApi({ location: "Sydney" });
-    expect(events).toHaveLength(1);
-    expect(events[0].name).toBe("ok");
+    const result = await searchEventsApi({ location: "Sydney" });
+    if (result.status !== "ok") throw new Error(`expected ok, got ${result.status}`);
+    expect(result.events).toHaveLength(1);
+    expect(result.events[0].name).toBe("Cervical Screening Info Day");
   });
 
   it("falls back to empty location string when address array missing", async () => {
@@ -182,7 +204,7 @@ describe("searchEventsApi", () => {
         HttpResponse.json({
           events_results: [
             {
-              title: "T",
+              title: "Cervical Screening Session",
               date: { when: "May 10" },
               address: null,
               link: "https://a.com",
@@ -192,8 +214,86 @@ describe("searchEventsApi", () => {
         })
       )
     );
-    const events = await searchEventsApi({ location: "Sydney" });
-    expect(events).toHaveLength(1);
-    expect(events[0].location).toBe("");
+    const result = await searchEventsApi({ location: "Sydney" });
+    if (result.status !== "ok") throw new Error(`expected ok, got ${result.status}`);
+    expect(result.events).toHaveLength(1);
+    expect(result.events[0].location).toBe("");
+  });
+
+  it("returns no_results when candidates exist but none are health-relevant", async () => {
+    server.use(
+      http.get(SERPAPI_URL, () =>
+        HttpResponse.json({
+          events_results: [
+            {
+              title: "Saturday Night Concert",
+              date: { when: "May 10" },
+              address: ["Town Hall"],
+              link: "https://example.com/concert",
+              description: "Live music all night",
+            },
+            {
+              title: "Farmers Market",
+              date: { when: "May 11" },
+              address: ["Main St"],
+              link: "https://example.com/market",
+              description: "Fresh produce and crafts",
+            },
+          ],
+        })
+      )
+    );
+    const result = await searchEventsApi({ location: "Sydney" });
+    expect(result).toEqual({ status: "no_results" });
+  });
+
+  it("keeps only health-relevant candidates out of a mixed result set", async () => {
+    server.use(
+      http.get(SERPAPI_URL, () =>
+        HttpResponse.json({
+          events_results: [
+            {
+              title: "Saturday Night Concert",
+              date: { when: "May 10" },
+              address: ["Town Hall"],
+              link: "https://example.com/concert",
+              description: "Live music all night",
+            },
+            {
+              title: "HPV Vaccination Info Session",
+              date: { when: "May 11" },
+              address: ["Community Centre"],
+              link: "https://example.com/hpv-session",
+              description: null,
+            },
+          ],
+        })
+      )
+    );
+    const result = await searchEventsApi({ location: "Sydney" });
+    if (result.status !== "ok") throw new Error(`expected ok, got ${result.status}`);
+    expect(result.events).toHaveLength(1);
+    expect(result.events[0].name).toBe("HPV Vaccination Info Session");
+  });
+
+  it("treats health relevance found in the description as sufficient", async () => {
+    server.use(
+      http.get(SERPAPI_URL, () =>
+        HttpResponse.json({
+          events_results: [
+            {
+              title: "Community Wellness Day",
+              date: { when: "May 10" },
+              address: ["Town Hall"],
+              link: "https://example.com/wellness",
+              description: "Includes free cervical screening for eligible attendees",
+            },
+          ],
+        })
+      )
+    );
+    const result = await searchEventsApi({ location: "Sydney" });
+    if (result.status !== "ok") throw new Error(`expected ok, got ${result.status}`);
+    expect(result.events).toHaveLength(1);
   });
 });

--- a/lib/events/search-events.ts
+++ b/lib/events/search-events.ts
@@ -2,13 +2,20 @@ import { env } from "@/lib/env";
 import type { HealthEvent } from "@/lib/validations/events";
 
 const SERPAPI_ENDPOINT = "https://serpapi.com/search";
-const HEALTH_DOMAIN_BASE = "women's health OR cervical screening OR HPV";
+
+/** Local relevance vocabulary — matched against title/description/address, never sent upstream. */
+const HEALTH_KEYWORDS = ["women's health", "cervical", "screening", "hpv", "pap"];
 
 export type SearchEventsInput = {
   location: string;
   query?: string;
   max_results?: number;
 };
+
+export type EventsSearchResult =
+  | { status: "ok"; events: HealthEvent[] }
+  | { status: "no_results" }
+  | { status: "upstream_unavailable" };
 
 type UpstreamEvent = {
   title?: string | null;
@@ -25,29 +32,35 @@ type UpstreamResponse = {
 /**
  * Single source of truth for the SerpAPI Google Events call.
  * Used directly by the events agent's tool wrapper and by the `/api/events`
- * proxy. Never throws — always resolves to an array (empty on any failure)
- * so callers can degrade gracefully without try/catch boilerplate.
+ * proxy. Never throws — always resolves to a typed result so callers can
+ * distinguish "searched, nothing relevant" from "couldn't search at all".
  *
- * Returns `[]` immediately when `location` is empty: SerpAPI requires it,
- * and we'd rather skip the round-trip than burn quota on a guaranteed-empty
- * search.
+ * Sends a natural event query upstream (never a forced health-domain boolean
+ * clause — Google Events returns nothing for those) and filters/ranks
+ * candidates against `HEALTH_KEYWORDS` locally.
+ *
+ * Resolves to `no_results` immediately when `location` is empty: SerpAPI
+ * requires it, and we'd rather skip the round-trip than burn quota on a
+ * guaranteed-empty search.
  */
 export async function searchEventsApi({
   location,
   query = "",
   max_results = 5,
-}: SearchEventsInput): Promise<HealthEvent[]> {
+}: SearchEventsInput): Promise<EventsSearchResult> {
   const trimmedLocation = location.trim();
-  if (!trimmedLocation) return [];
+  if (!trimmedLocation) return { status: "no_results" };
 
   const max = Math.min(Math.max(max_results, 1), 10);
   const userQuery = query.trim();
-  const q = userQuery ? `(${userQuery}) AND (${HEALTH_DOMAIN_BASE})` : HEALTH_DOMAIN_BASE;
+  const q = userQuery || "events";
 
   const url = new URL(SERPAPI_ENDPOINT);
   url.searchParams.set("engine", "google_events");
   url.searchParams.set("q", q);
   url.searchParams.set("location", trimmedLocation);
+  url.searchParams.set("gl", "au");
+  url.searchParams.set("hl", "en");
   url.searchParams.set("num", String(max));
   url.searchParams.set("api_key", env.serpapiKey);
 
@@ -56,22 +69,22 @@ export async function searchEventsApi({
     upstream = await fetch(url, { headers: { Accept: "application/json" } });
   } catch (err) {
     console.error("[events] upstream fetch failed:", err instanceof Error ? err.message : err);
-    return [];
+    return { status: "upstream_unavailable" };
   }
 
   if (!upstream.ok) {
     console.error(`[events] upstream non-2xx: ${upstream.status}`);
-    return [];
+    return { status: "upstream_unavailable" };
   }
 
   let data: UpstreamResponse;
   try {
     data = (await upstream.json()) as UpstreamResponse;
   } catch {
-    return [];
+    return { status: "upstream_unavailable" };
   }
 
-  if (!Array.isArray(data.events_results)) return [];
+  if (!Array.isArray(data.events_results)) return { status: "no_results" };
 
   const normalized: HealthEvent[] = [];
   for (const e of data.events_results) {
@@ -80,14 +93,17 @@ export async function searchEventsApi({
     const date = e.date?.when?.trim();
     if (!name || !url || !date) continue;
     const address = Array.isArray(e.address) ? e.address.filter(Boolean).join(", ") : "";
-    normalized.push({
-      name,
-      date,
-      location: address,
-      url,
-      description: e.description ?? null,
-    });
+    const description = e.description ?? null;
+    if (!isHealthRelevant(name, description, address)) continue;
+    normalized.push({ name, date, location: address, url, description });
     if (normalized.length >= max) break;
   }
-  return normalized;
+
+  if (normalized.length === 0) return { status: "no_results" };
+  return { status: "ok", events: normalized };
+}
+
+function isHealthRelevant(name: string, description: string | null, address: string): boolean {
+  const haystack = `${name} ${description ?? ""} ${address}`.toLowerCase();
+  return HEALTH_KEYWORDS.some((kw) => haystack.includes(kw));
 }

--- a/lib/tools/events.test.ts
+++ b/lib/tools/events.test.ts
@@ -6,7 +6,7 @@ import { findHealthEvents } from "./events";
 const SERPAPI_URL = "https://serpapi.com/search";
 
 describe("findHealthEvents", () => {
-  it("returns parsed events on success", async () => {
+  it("returns ok with parsed events on success", async () => {
     server.use(
       http.get(SERPAPI_URL, () =>
         HttpResponse.json({
@@ -22,18 +22,21 @@ describe("findHealthEvents", () => {
         })
       )
     );
-    const events = await findHealthEvents({ location: "Sydney" });
-    expect(events).toHaveLength(1);
-    expect(events[0].name).toBe("Women's Health Fair");
+    const result = await findHealthEvents({ location: "Sydney" });
+    if (result.status !== "ok") throw new Error(`expected ok, got ${result.status}`);
+    expect(result.events).toHaveLength(1);
+    expect(result.events[0].name).toBe("Women's Health Fair");
   });
 
-  it("returns empty array on upstream failure (does not throw)", async () => {
+  it("returns upstream_unavailable on upstream failure (does not throw)", async () => {
     server.use(http.get(SERPAPI_URL, () => new HttpResponse(null, { status: 500 })));
-    await expect(findHealthEvents({ location: "Sydney" })).resolves.toEqual([]);
+    await expect(findHealthEvents({ location: "Sydney" })).resolves.toEqual({
+      status: "upstream_unavailable",
+    });
   });
 
-  it("returns empty array when location missing", async () => {
-    await expect(findHealthEvents({ location: "" })).resolves.toEqual([]);
+  it("returns no_results when location missing", async () => {
+    await expect(findHealthEvents({ location: "" })).resolves.toEqual({ status: "no_results" });
   });
 
   it("defaults max_results to 5", async () => {
@@ -41,7 +44,7 @@ describe("findHealthEvents", () => {
       http.get(SERPAPI_URL, () =>
         HttpResponse.json({
           events_results: Array.from({ length: 8 }, (_, i) => ({
-            title: `E${i}`,
+            title: `Cervical Screening Event ${i}`,
             date: { when: "May 10" },
             address: ["X"],
             link: `https://example.com/${i}`,
@@ -50,7 +53,8 @@ describe("findHealthEvents", () => {
         })
       )
     );
-    const events = await findHealthEvents({ location: "Sydney" });
-    expect(events).toHaveLength(5);
+    const result = await findHealthEvents({ location: "Sydney" });
+    if (result.status !== "ok") throw new Error(`expected ok, got ${result.status}`);
+    expect(result.events).toHaveLength(5);
   });
 });

--- a/lib/tools/events.ts
+++ b/lib/tools/events.ts
@@ -1,5 +1,5 @@
+import type { EventsSearchResult } from "@/lib/events/search-events";
 import { searchEventsApi } from "@/lib/events/search-events";
-import type { HealthEvent } from "@/lib/validations/events";
 
 export type FindHealthEventsInput = {
   location: string;
@@ -8,10 +8,10 @@ export type FindHealthEventsInput = {
 };
 
 /**
- * Events Agent's tool wrapper. Surfaces the same data the `/api/events` proxy
- * returns — both share `searchEventsApi`. Never throws; returns `[]` on any
- * failure (including missing location).
+ * Events Agent's tool wrapper. Surfaces the same typed result the `/api/events`
+ * proxy returns — both share `searchEventsApi`. Never throws; a missing
+ * location or any upstream failure resolves rather than rejects.
  */
-export async function findHealthEvents(input: FindHealthEventsInput): Promise<HealthEvent[]> {
+export async function findHealthEvents(input: FindHealthEventsInput): Promise<EventsSearchResult> {
   return searchEventsApi(input);
 }


### PR DESCRIPTION
## Summary
- The general events search built its upstream query as `(query) AND (women's health OR cervical screening OR HPV)`, which Google Events reliably returns zero results for — SerpAPI itself was reachable and had quota, this was a query-design bug, not an outage. Now sends a natural query and filters/ranks candidates for health relevance locally (title/description/address against a keyword list).
- `searchEventsApi` returns a typed result (`{ status: "ok", events }` / `{ status: "no_results" }` / `{ status: "upstream_unavailable" }`) instead of collapsing every outcome to a plain array, so a genuine "nothing relevant" search is no longer indistinguishable from a SerpAPI failure. Propagated through the tool wrapper, `/api/events` route, events agent, and orchestrator fallback copy (new `EVENTS_UNAVAILABLE_FALLBACK` distinct from the existing `EVENTS_EMPTY_FALLBACK`).
- Updated `docs/api-routes.md` and `docs/architecture.md` to match.

## Test plan
- [x] `pnpm exec vitest run` — 935 tests passing, full suite
- [x] `pnpm exec tsc --noEmit` — clean
- [x] `pnpm biome check --write .` — clean
- [x] Live verification against real SerpAPI (`pnpm dev -p 3100` with `MCP_BASE_URL` override, per port-3000-conflict note in project memory):
  - Real query for Melbourne returned a concert + a basketball game from SerpAPI; both correctly filtered out as non-health-relevant → `{"events":[],"error":"no_results"}`
  - Forced upstream failure (invalid `SERPAPI_KEY`) → server logged `[events] upstream non-2xx: 401` → `{"events":[],"error":"upstream_unavailable"}`
- [ ] Chat-UI wording split not driven through the browser manually — covered by exact-string assertions in `orchestrator.test.ts` (`EVENTS_UNAVAILABLE_FALLBACK` vs `EVENTS_EMPTY_FALLBACK`) using the same yield pipeline as every other chat fallback message

🤖 Generated with [Claude Code](https://claude.com/claude-code)